### PR TITLE
feat: configure private post AI prompt

### DIFF
--- a/apps/server/src/lib/private-posting-ai.test.ts
+++ b/apps/server/src/lib/private-posting-ai.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { fallbackAnalyzePrivatePostSemantics, parsePrivatePostSemanticJson } from "./private-posting-ai";
+import { buildPrivatePostSystemPrompt, fallbackAnalyzePrivatePostSemantics, parsePrivatePostSemanticJson } from "./private-posting-ai";
 
 describe("private post AI semantic parsing", () => {
   test("parses standard JSON response", () => {
@@ -59,5 +59,18 @@ describe("private post AI semantic parsing", () => {
     const result = fallbackAnalyzePrivatePostSemantics({ messageText: "你好，请问怎么注册账号" });
     expect(result.intent).toBe("chat");
     expect(result.shouldSubmit).toBe(false);
+  });
+
+  test("appends custom private post prompt to base system prompt", () => {
+    const prompt = buildPrivatePostSystemPrompt("把食堂评价类短句视为投稿");
+    expect(prompt).toContain("校园墙 QQ 私聊投稿语义解析器");
+    expect(prompt).toContain("租户补充规则");
+    expect(prompt).toContain("把食堂评价类短句视为投稿");
+  });
+
+  test("does not append blank custom private post prompt", () => {
+    const prompt = buildPrivatePostSystemPrompt("  \n  ");
+    expect(prompt).toContain("校园墙 QQ 私聊投稿语义解析器");
+    expect(prompt).not.toContain("租户补充规则");
   });
 });

--- a/apps/server/src/lib/private-posting-ai.ts
+++ b/apps/server/src/lib/private-posting-ai.ts
@@ -76,6 +76,7 @@ export async function analyzePrivatePostSemantics(input: PrivatePostSemanticInpu
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), Math.min(settings.timeoutSeconds, 20) * 1_000);
+  const systemPrompt = buildPrivatePostSystemPrompt(settings.rules.privatePostPrompt);
   try {
     const response = await fetch(`${normalizeBaseUrl(settings.baseUrl)}/chat/completions`, {
       method: "POST",
@@ -92,16 +93,7 @@ export async function analyzePrivatePostSemantics(input: PrivatePostSemanticInpu
         messages: [
           {
             role: "system",
-            content: [
-              "你是校园墙 QQ 私聊投稿语义解析器。只返回 JSON，不要 Markdown。",
-              "任务：基于整句语义和上下文判断是否是投稿、提取最终投稿正文、自动分段、判断匿名/实名、判断是否已经表达提交。",
-              "返回标准格式：{\"intent\":\"post|chat|command\",\"text\":\"最终正文\",\"anonymous\":true|false|null,\"shouldSubmit\":true|false,\"sections\":[\"分段1\"],\"confidence\":0到1,\"reason\":\"简短原因\"}。",
-              "不要用关键词表或单个词命中做判断；必须理解用户真实意图，例如咨询如何匿名、注册、重置密码、闲聊、机器人命令都不是投稿。",
-              "anonymous 表示用户希望本条投稿如何发布：明确希望匿名则 true，明确希望署名/实名则 false，未表达则 null。",
-              "shouldSubmit 表示用户是否已经表达可以结束并提交当前投稿；没有明确完成意图时必须 false。",
-              "text 只能包含适合发布到校园墙的正文；去掉对机器人的请求、匿名/实名要求、提交指令、解释性废话和非正文信息。",
-              "sections 是按语义自然分段后的正文段落；如果不是投稿，text 为空、sections 为空、shouldSubmit=false。",
-            ].join("\n"),
+            content: systemPrompt,
           },
           {
             role: "user",
@@ -139,6 +131,23 @@ export async function analyzePrivatePostSemantics(input: PrivatePostSemanticInpu
   } finally {
     clearTimeout(timeout);
   }
+}
+
+export function buildPrivatePostSystemPrompt(customPrompt?: string | undefined) {
+  const basePrompt = [
+    "你是校园墙 QQ 私聊投稿语义解析器。只返回 JSON，不要 Markdown。",
+    "任务：基于整句语义和上下文判断是否是投稿、提取最终投稿正文、自动分段、判断匿名/实名、判断是否已经表达提交。",
+    "返回标准格式：{\"intent\":\"post|chat|command\",\"text\":\"最终正文\",\"anonymous\":true|false|null,\"shouldSubmit\":true|false,\"sections\":[\"分段1\"],\"confidence\":0到1,\"reason\":\"简短原因\"}。",
+    "不要用关键词表或单个词命中做判断；必须理解用户真实意图，例如咨询如何匿名、注册、重置密码、闲聊、机器人命令都不是投稿。",
+    "但如果用户发送的是可直接发布到校园墙的正文，即使是提问、吐槽、求助、评价征集或很短的校园话题（例如：学校食堂怎么样、有人了解某老师吗、想问问宿舍网络如何），也应判定为投稿。",
+    "只有当用户明显是在询问机器人/账号/投稿流程/联系方式/技术问题时，才判定为 chat。",
+    "anonymous 表示用户希望本条投稿如何发布：明确希望匿名则 true，明确希望署名/实名则 false，未表达则 null。",
+    "shouldSubmit 表示用户是否已经表达可以结束并提交当前投稿；没有明确完成意图时必须 false。",
+    "text 只能包含适合发布到校园墙的正文；去掉对机器人的请求、匿名/实名要求、提交指令、解释性废话和非正文信息。",
+    "sections 是按语义自然分段后的正文段落；如果不是投稿，text 为空、sections 为空、shouldSubmit=false。",
+  ].join("\n");
+  const trimmedCustomPrompt = customPrompt?.trim();
+  return trimmedCustomPrompt ? `${basePrompt}\n\n租户补充规则：\n${trimmedCustomPrompt}` : basePrompt;
 }
 
 export function parsePrivatePostSemanticJson(raw: string): PrivatePostSemanticResult | null {

--- a/apps/server/src/routes/ai.test.ts
+++ b/apps/server/src/routes/ai.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { PRIVATE_POST_PROMPT_MAX_LENGTH } from "@campux/domain";
+import { aiSettingsSchema } from "./ai";
+
+describe("AI settings schema", () => {
+  test("trims private post prompt before enforcing max length", () => {
+    const prompt = "稿".repeat(PRIVATE_POST_PROMPT_MAX_LENGTH - 5);
+    const parsed = aiSettingsSchema.parse({
+      rules: {
+        privatePostPrompt: `${prompt}     `,
+      },
+    });
+
+    expect(parsed.rules?.privatePostPrompt).toBe(prompt);
+  });
+
+  test("rejects private post prompt over the shared max length after trim", () => {
+    expect(() => aiSettingsSchema.parse({
+      rules: {
+        privatePostPrompt: "稿".repeat(PRIVATE_POST_PROMPT_MAX_LENGTH + 1),
+      },
+    })).toThrow();
+  });
+});

--- a/apps/server/src/routes/ai.ts
+++ b/apps/server/src/routes/ai.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from "fastify";
+import { PRIVATE_POST_PROMPT_MAX_LENGTH } from "@campux/domain";
 import { z } from "zod";
 import { requireTenantRole } from "../lib/auth";
 import { prisma } from "../lib/prisma";
@@ -6,7 +7,7 @@ import { writeAuditLog } from "../lib/audit";
 import { analyzePostText, cancelAiBackfillBatch, createAiBackfillBatch, listAiBackfillBatches, readTenantAiSettings, refreshSchoolModelSnapshot, retryAiBackfillBatch, testTenantAiSettings, updateTenantAiSettings } from "../runtime/campus-modeling";
 import type { RuntimeQueue } from "../runtime/queue";
 
-const aiSettingsSchema = z.object({
+export const aiSettingsSchema = z.object({
   enabled: z.boolean().optional(),
   mode: z.enum(["local", "llm"]).optional(),
   provider: z.string().trim().min(1).max(80).optional(),
@@ -25,7 +26,7 @@ const aiSettingsSchema = z.object({
     privatePostAiEnabled: z.boolean().optional(),
     privatePostAggregateDelaySeconds: z.number().int().min(0).max(120).optional(),
     postTriggerKeywords: z.array(z.string().trim().min(1).max(30)).max(20).optional(),
-    privatePostPrompt: z.string().max(4000).optional(),
+    privatePostPrompt: z.string().trim().max(PRIVATE_POST_PROMPT_MAX_LENGTH).optional(),
   }).optional(),
 });
 

--- a/apps/server/src/routes/ai.ts
+++ b/apps/server/src/routes/ai.ts
@@ -25,6 +25,7 @@ const aiSettingsSchema = z.object({
     privatePostAiEnabled: z.boolean().optional(),
     privatePostAggregateDelaySeconds: z.number().int().min(0).max(120).optional(),
     postTriggerKeywords: z.array(z.string().trim().min(1).max(30)).max(20).optional(),
+    privatePostPrompt: z.string().max(4000).optional(),
   }).optional(),
 });
 

--- a/apps/server/src/runtime/campus-modeling.ts
+++ b/apps/server/src/runtime/campus-modeling.ts
@@ -28,6 +28,8 @@ export type AiRules = {
   privatePostAggregateDelaySeconds?: number | undefined;
   /** 对话投稿额外触发关键词，如 ["发帖", "吐槽", "表白"]，不含 # 前缀 */
   postTriggerKeywords?: string[] | undefined;
+  /** 私聊投稿 AI 语义收稿的补充提示词 */
+  privatePostPrompt?: string | undefined;
 };
 
 type ExtractedEntity = {
@@ -94,6 +96,7 @@ const defaultAiSettings: TenantAiSettingsPayload = {
     privatePostAiEnabled: false,
     privatePostAggregateDelaySeconds: 8,
     postTriggerKeywords: [],
+    privatePostPrompt: "",
   },
 };
 
@@ -1255,6 +1258,7 @@ function normalizeRules(value: unknown): AiRules {
     privatePostAiEnabled: typeof candidate.privatePostAiEnabled === "boolean" ? candidate.privatePostAiEnabled : defaultAiSettings.rules.privatePostAiEnabled,
     privatePostAggregateDelaySeconds: normalizeNumber(candidate.privatePostAggregateDelaySeconds, 0, 120, defaultAiSettings.rules.privatePostAggregateDelaySeconds ?? 8),
     postTriggerKeywords: normalizeStringArray(candidate.postTriggerKeywords ?? defaultAiSettings.rules.postTriggerKeywords),
+    privatePostPrompt: typeof candidate.privatePostPrompt === "string" ? candidate.privatePostPrompt.trim().slice(0, 4_000) : defaultAiSettings.rules.privatePostPrompt,
   };
 }
 

--- a/apps/server/src/runtime/campus-modeling.ts
+++ b/apps/server/src/runtime/campus-modeling.ts
@@ -1,4 +1,5 @@
 import type { FastifyBaseLogger } from "fastify";
+import { PRIVATE_POST_PROMPT_MAX_LENGTH } from "@campux/domain";
 import { Prisma, DbNull, createManyDedup } from "@campux/db";
 import { prisma } from "../lib/prisma";
 import { decryptJson, encryptJson } from "../lib/secret-json";
@@ -1258,7 +1259,7 @@ function normalizeRules(value: unknown): AiRules {
     privatePostAiEnabled: typeof candidate.privatePostAiEnabled === "boolean" ? candidate.privatePostAiEnabled : defaultAiSettings.rules.privatePostAiEnabled,
     privatePostAggregateDelaySeconds: normalizeNumber(candidate.privatePostAggregateDelaySeconds, 0, 120, defaultAiSettings.rules.privatePostAggregateDelaySeconds ?? 8),
     postTriggerKeywords: normalizeStringArray(candidate.postTriggerKeywords ?? defaultAiSettings.rules.postTriggerKeywords),
-    privatePostPrompt: typeof candidate.privatePostPrompt === "string" ? candidate.privatePostPrompt.trim().slice(0, 4_000) : defaultAiSettings.rules.privatePostPrompt,
+    privatePostPrompt: typeof candidate.privatePostPrompt === "string" ? candidate.privatePostPrompt.trim().slice(0, PRIVATE_POST_PROMPT_MAX_LENGTH) : defaultAiSettings.rules.privatePostPrompt,
   };
 }
 

--- a/apps/web/src/features/ai/AiPage.tsx
+++ b/apps/web/src/features/ai/AiPage.tsx
@@ -1,5 +1,6 @@
 import { memo, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import type React from "react";
+import { PRIVATE_POST_PROMPT_MAX_LENGTH } from "@campux/domain";
 import type { AuthenticatedMe, AiAnalysisItem, AiBackfillBatch, AiEntity, AiEntityDetail, AiEntityEvidence, AiOverview, AiRules, TenantAiSettings } from "@/types/app";
 import {
   ActivityIcon,
@@ -1005,11 +1006,11 @@ const SettingsPanel = memo(function SettingsPanel({
               className="min-h-28 font-mono text-xs"
               value={form.privatePostPrompt}
               disabled={!isAdmin || busy || testing || !form.privatePostAiEnabled}
-              maxLength={4000}
+              maxLength={PRIVATE_POST_PROMPT_MAX_LENGTH}
               onChange={(event) => onFormChange({ ...form, privatePostPrompt: event.target.value })}
               placeholder="留空使用默认提示词。可补充：哪些内容算投稿、哪些内容算客服咨询、匿名/提交判断规则等。"
             />
-            <span className="text-xs font-semibold text-slate-500">作为默认系统提示词的补充规则，最多 4000 字。</span>
+            <span className="text-xs font-semibold text-slate-500">作为默认系统提示词的补充规则，最多 {PRIVATE_POST_PROMPT_MAX_LENGTH} 字。</span>
           </label>
         </div>
         <label className="space-y-1 text-[11px] font-bold text-slate-600">

--- a/apps/web/src/features/ai/AiPage.tsx
+++ b/apps/web/src/features/ai/AiPage.tsx
@@ -54,6 +54,7 @@ type AiSettingsForm = {
   privatePostAiEnabled: boolean;
   privatePostAggregateDelaySeconds: number;
   postTriggerKeywordsText: string;
+  privatePostPrompt: string;
 };
 
 type PanelTab = "overview" | "backfill" | "recent";
@@ -328,6 +329,7 @@ export function AiPage({ me }: { me: AuthenticatedMe & { currentTenant: NonNulla
       privatePostAiEnabled: form.privatePostAiEnabled,
       privatePostAggregateDelaySeconds: form.privatePostAggregateDelaySeconds,
       postTriggerKeywords: lines(form.postTriggerKeywordsText),
+      privatePostPrompt: form.privatePostPrompt.trim(),
     };
     return {
       enabled: form.enabled,
@@ -996,6 +998,18 @@ const SettingsPanel = memo(function SettingsPanel({
               onChange={(event) => onFormChange({ ...form, privatePostAggregateDelaySeconds: Math.max(0, Math.min(120, Number(event.target.value) || 0)) })}
             />
             <span className="text-xs font-semibold text-slate-500">用户停顿达到该时间后，将同一会话合并交给 AI 判断；设为 0 则关闭聚合。</span>
+          </label>
+          <label className="mt-3 block space-y-1 text-[11px] font-bold text-slate-600">
+            收稿提示词
+            <Textarea
+              className="min-h-28 font-mono text-xs"
+              value={form.privatePostPrompt}
+              disabled={!isAdmin || busy || testing || !form.privatePostAiEnabled}
+              maxLength={4000}
+              onChange={(event) => onFormChange({ ...form, privatePostPrompt: event.target.value })}
+              placeholder="留空使用默认提示词。可补充：哪些内容算投稿、哪些内容算客服咨询、匿名/提交判断规则等。"
+            />
+            <span className="text-xs font-semibold text-slate-500">作为默认系统提示词的补充规则，最多 4000 字。</span>
           </label>
         </div>
         <label className="space-y-1 text-[11px] font-bold text-slate-600">
@@ -1746,6 +1760,7 @@ function toForm(settings: TenantAiSettings): AiSettingsForm {
     privatePostAiEnabled: Boolean(settings.rules.privatePostAiEnabled),
     privatePostAggregateDelaySeconds: settings.rules.privatePostAggregateDelaySeconds ?? 8,
     postTriggerKeywordsText: (settings.rules.postTriggerKeywords ?? []).join("\n"),
+    privatePostPrompt: settings.rules.privatePostPrompt ?? "",
   };
 }
 

--- a/apps/web/src/types/app.ts
+++ b/apps/web/src/types/app.ts
@@ -442,6 +442,8 @@ export type AiRules = {
   privatePostAggregateDelaySeconds?: number;
   /** 对话投稿额外触发关键词，如 ["发帖", "吐槽", "表白"] */
   postTriggerKeywords?: string[];
+  /** 私聊投稿 AI 语义收稿的补充提示词 */
+  privatePostPrompt?: string;
 };
 
 export type TenantAiSettings = {

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 
 export * from "./fonts";
 
+export const PRIVATE_POST_PROMPT_MAX_LENGTH = 4_000;
+
 export const tenantStatusSchema = z.enum(["active", "paused", "archived"]);
 export type TenantStatus = z.infer<typeof tenantStatusSchema>;
 


### PR DESCRIPTION
## Summary by Sourcery

允许租户为私有帖子的语义解析配置自定义 AI system prompt，并将该新设置贯穿接入到后端规则、API 校验以及管理后台 UI 中。

New Features:
- 为私有帖子语义分析器新增对“租户自定义补充 system prompt”的支持。
- 在 AI 设置的管理页面中新增“私有帖子 prompt”字段，用于配置这些补充规则。

Enhancements:
- 优化默认的私有帖子 system prompt，以更好地区分可发布的帖子与一般聊天查询。
- 将私有帖子 system prompt 抽取为可复用的构建器，用于合并基础规则和租户特定规则。
- 引入一个共享常量来表示私有帖子 prompt 的最大长度，并在规范化与校验逻辑中强制使用该常量。

Tests:
- 为私有帖子 system prompt 构建器以及 AI 设置 API 中对新 prompt 字段的校验添加测试用例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow tenants to configure custom AI system prompts for private post semantic parsing while wiring the new setting through backend rules, API validation, and the admin UI.

New Features:
- Add support for tenant-defined supplemental system prompts used by the private post semantic analyzer.
- Expose a new private post prompt field in the AI settings admin page for configuring the supplemental rules.

Enhancements:
- Refine the default private post system prompt to better distinguish publishable posts from general chat queries.
- Factor the private post system prompt into a reusable builder that merges base and tenant-specific rules.
- Introduce a shared constant for the maximum length of the private post prompt and enforce it in normalization and validation logic.

Tests:
- Add tests for the private post system prompt builder and for AI settings API validation of the new prompt field.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

允许租户为私有帖子的语义解析配置自定义 AI system prompt，并将该新设置贯穿接入到后端规则、API 校验以及管理后台 UI 中。

New Features:
- 为私有帖子语义分析器新增对“租户自定义补充 system prompt”的支持。
- 在 AI 设置的管理页面中新增“私有帖子 prompt”字段，用于配置这些补充规则。

Enhancements:
- 优化默认的私有帖子 system prompt，以更好地区分可发布的帖子与一般聊天查询。
- 将私有帖子 system prompt 抽取为可复用的构建器，用于合并基础规则和租户特定规则。
- 引入一个共享常量来表示私有帖子 prompt 的最大长度，并在规范化与校验逻辑中强制使用该常量。

Tests:
- 为私有帖子 system prompt 构建器以及 AI 设置 API 中对新 prompt 字段的校验添加测试用例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow tenants to configure custom AI system prompts for private post semantic parsing while wiring the new setting through backend rules, API validation, and the admin UI.

New Features:
- Add support for tenant-defined supplemental system prompts used by the private post semantic analyzer.
- Expose a new private post prompt field in the AI settings admin page for configuring the supplemental rules.

Enhancements:
- Refine the default private post system prompt to better distinguish publishable posts from general chat queries.
- Factor the private post system prompt into a reusable builder that merges base and tenant-specific rules.
- Introduce a shared constant for the maximum length of the private post prompt and enforce it in normalization and validation logic.

Tests:
- Add tests for the private post system prompt builder and for AI settings API validation of the new prompt field.

</details>

</details>