### PR TITLE
feat(bot): 支持审核群封禁与解封用户

### DIFF
--- a/apps/server/src/runtime/onebot-command.test.ts
+++ b/apps/server/src/runtime/onebot-command.test.ts
@@ -62,6 +62,10 @@ describe("review group ban command parsing", () => {
     expect(parseReviewGroupCommand("ban 123456789 刷屏广告")).toEqual({ name: "ban", args: "123456789 刷屏广告" });
     expect(parseReviewGroupCommand("unban 123456789")).toEqual({ name: "unban", args: "123456789" });
   });
+
+  test("审核群裸命令复用 CQ at 规范化", () => {
+    expect(parseReviewGroupCommand("[CQ:at,qq=10000] ban 123456789 刷屏广告")).toEqual({ name: "ban", args: "123456789 刷屏广告" });
+  });
 });
 
 describe("private post semantic mode selection", () => {

--- a/apps/server/src/runtime/onebot-command.test.ts
+++ b/apps/server/src/runtime/onebot-command.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseCommand, resolvePrivatePostModeSelectionFromSemantic, shouldSubmitPrivatePostAfterModeSelection } from "./onebot";
+import { parseBanCommandArgs, parseCommand, parseUnbanCommandArgs, resolvePrivatePostModeSelectionFromSemantic, shouldSubmitPrivatePostAfterModeSelection } from "./onebot";
 
 describe("parseCommand prefix handling", () => {
   test("解析半角 # 命令", () => {
@@ -29,6 +29,33 @@ describe("parseCommand prefix handling", () => {
 
   test("命令前有非 @ 文本时不识别", () => {
     expect(parseCommand("随便说点什么 ＃通过 1")).toBeNull();
+  });
+});
+
+describe("review group ban command parsing", () => {
+  test("解析封禁参数中的 QQ 与理由", () => {
+    expect(parseBanCommandArgs("123456789 刷屏广告")).toEqual({ qqUin: "123456789", reason: "刷屏广告" });
+  });
+
+  test("封禁理由可以包含空格", () => {
+    expect(parseBanCommandArgs("123456789 多次 发布 广告")).toEqual({ qqUin: "123456789", reason: "多次 发布 广告" });
+  });
+
+  test("封禁参数缺少理由时返回 null", () => {
+    expect(parseBanCommandArgs("123456789")).toBeNull();
+  });
+
+  test("解析解封参数中的 QQ", () => {
+    expect(parseUnbanCommandArgs("123456789")).toEqual({ qqUin: "123456789" });
+  });
+
+  test("解封参数包含额外内容时返回 null", () => {
+    expect(parseUnbanCommandArgs("123456789 其他内容")).toBeNull();
+  });
+
+  test("裸 ban/unban 命令可被识别", () => {
+    expect(parseCommand("ban 123456789 刷屏广告")).toEqual({ name: "ban", args: "123456789 刷屏广告" });
+    expect(parseCommand("unban 123456789")).toEqual({ name: "unban", args: "123456789" });
   });
 });
 

--- a/apps/server/src/runtime/onebot-command.test.ts
+++ b/apps/server/src/runtime/onebot-command.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseBanCommandArgs, parseCommand, parseUnbanCommandArgs, resolvePrivatePostModeSelectionFromSemantic, shouldSubmitPrivatePostAfterModeSelection } from "./onebot";
+import { parseBanCommandArgs, parseCommand, parseReviewGroupCommand, parseUnbanCommandArgs, resolvePrivatePostModeSelectionFromSemantic, shouldSubmitPrivatePostAfterModeSelection } from "./onebot";
 
 describe("parseCommand prefix handling", () => {
   test("解析半角 # 命令", () => {
@@ -53,9 +53,14 @@ describe("review group ban command parsing", () => {
     expect(parseUnbanCommandArgs("123456789 其他内容")).toBeNull();
   });
 
-  test("裸 ban/unban 命令可被识别", () => {
-    expect(parseCommand("ban 123456789 刷屏广告")).toEqual({ name: "ban", args: "123456789 刷屏广告" });
-    expect(parseCommand("unban 123456789")).toEqual({ name: "unban", args: "123456789" });
+  test("裸 ban/unban 不在通用解析中识别", () => {
+    expect(parseCommand("ban 123456789 刷屏广告")).toBeNull();
+    expect(parseCommand("unban 123456789")).toBeNull();
+  });
+
+  test("审核群解析支持裸 ban/unban 命令", () => {
+    expect(parseReviewGroupCommand("ban 123456789 刷屏广告")).toEqual({ name: "ban", args: "123456789 刷屏广告" });
+    expect(parseReviewGroupCommand("unban 123456789")).toEqual({ name: "unban", args: "123456789" });
   });
 });
 

--- a/apps/server/src/runtime/onebot.ts
+++ b/apps/server/src/runtime/onebot.ts
@@ -204,6 +204,8 @@ type OneBotMessageEvent = {
   // but we treat them as part of `message` / `raw_message` as fallback.
 };
 
+const PERMANENT_BAN_ENDS_AT = new Date("9999-12-31T23:59:59.999Z");
+
 const reviewHelp = [
   "审核命令：",
   "#通过 <稿件id>",
@@ -2256,7 +2258,7 @@ export class OneBotRuntime {
         const { operator } = await requireBotTenantRole(bot.tenantId, operatorQqUin, "reviewer");
         const parsed = parseBanCommandArgs(command.args);
         if (!parsed) {
-          await this.sendGroupMessage(botQqUin, groupId, "请提供要封禁的 QQ 号和理由，例如：#封禁 123456789 刷屏广告");
+          await this.sendGroupMessage(botQqUin, groupId, "请提供要封禁的 QQ 号和理由，例如：#封禁 123456789 刷屏广告 或 ban 123456789 刷屏广告");
           return;
         }
         const targetUser = await prisma.user.findUnique({
@@ -2282,7 +2284,7 @@ export class OneBotRuntime {
           await this.sendGroupMessage(botQqUin, groupId, "不能封禁管理员");
           return;
         }
-        const endsAt = new Date("9999-12-31T23:59:59.999Z");
+        const endsAt = new Date(PERMANENT_BAN_ENDS_AT);
         await prisma.banRecord.create({
           data: {
             tenantId: bot.tenantId,
@@ -3223,8 +3225,12 @@ function escapeRegex(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function normalizeCommandInput(input: string) {
+  return input.replace(/\[CQ:at,qq=\d+\]/g, "").trim();
+}
+
 export function parseCommand(input: string) {
-  const normalized = input.replace(/\[CQ:at,qq=\d+\]/g, "").trim();
+  const normalized = normalizeCommandInput(input);
 
   // 同时支持半角 # / 与全角 ＃ 作为命令前缀（全角 # 在中文输入法下很常见，否则会出现指令无法识别）
   const commandStart = normalized.search(/[#＃/]/);
@@ -3253,7 +3259,7 @@ export function parseReviewGroupCommand(input: string) {
     return command;
   }
 
-  const normalized = input.replace(/\[CQ:at,qq=\d+\]/g, "").trim();
+  const normalized = normalizeCommandInput(input);
   const bareCommand = normalized.match(/^(ban|unban)\b(?:\s+(.*))?$/i);
   if (!bareCommand?.[1]) {
     return null;

--- a/apps/server/src/runtime/onebot.ts
+++ b/apps/server/src/runtime/onebot.ts
@@ -2029,7 +2029,7 @@ export class OneBotRuntime {
       return;
     }
 
-    let command = parseCommand(extractPlainText(event));
+    let command = parseReviewGroupCommand(extractPlainText(event));
 
     // 如果没有以 # 或 / 明确给出命令，但消息是 @ 机器人的短命令（比如 过/拒），支持基于 mention 的快捷命令。
     if (!command && isMentioningBot(event, botQqUin)) {
@@ -3225,13 +3225,6 @@ function escapeRegex(value: string) {
 
 export function parseCommand(input: string) {
   const normalized = input.replace(/\[CQ:at,qq=\d+\]/g, "").trim();
-  const bareCommand = normalized.match(/^(ban|unban)\b(?:\s+(.*))?$/i);
-  if (bareCommand?.[1]) {
-    return {
-      name: bareCommand[1].toLowerCase(),
-      args: bareCommand[2]?.trim() ?? "",
-    };
-  }
 
   // 同时支持半角 # / 与全角 ＃ 作为命令前缀（全角 # 在中文输入法下很常见，否则会出现指令无法识别）
   const commandStart = normalized.search(/[#＃/]/);
@@ -3251,6 +3244,23 @@ export function parseCommand(input: string) {
   return {
     name,
     args: match[2]?.trim() ?? "",
+  };
+}
+
+export function parseReviewGroupCommand(input: string) {
+  const command = parseCommand(input);
+  if (command) {
+    return command;
+  }
+
+  const normalized = input.replace(/\[CQ:at,qq=\d+\]/g, "").trim();
+  const bareCommand = normalized.match(/^(ban|unban)\b(?:\s+(.*))?$/i);
+  if (!bareCommand?.[1]) {
+    return null;
+  }
+  return {
+    name: bareCommand[1].toLowerCase(),
+    args: bareCommand[2]?.trim() ?? "",
   };
 }
 

--- a/apps/server/src/runtime/onebot.ts
+++ b/apps/server/src/runtime/onebot.ts
@@ -212,7 +212,8 @@ const reviewHelp = [
   "#回复 <内容> （引用转发私信后使用）",
   "#发布 <内容> （可附带图片，文字+图片一起发布到空间）",
   "#撤回 [tid] （回复 #发布 成功消息可撤回刚发布的说说）",
-  "#解封 <QQ号>",
+  "#封禁 <QQ号> <理由> 或 ban <QQ号> <理由>",
+  "#解封 <QQ号> 或 unban <QQ号>",
   "#好友数",
   "#登录 或 #刷新qzone cookies",
   "#扫码登录",
@@ -2251,13 +2252,75 @@ export class OneBotRuntime {
         return;
       }
 
-      if (command.name === "解封") {
+      if (["封禁", "ban"].includes(command.name)) {
         const { operator } = await requireBotTenantRole(bot.tenantId, operatorQqUin, "reviewer");
-        const qqUin = command.args.trim();
-        if (!qqUin || !/^\d+$/.test(qqUin)) {
+        const parsed = parseBanCommandArgs(command.args);
+        if (!parsed) {
+          await this.sendGroupMessage(botQqUin, groupId, "请提供要封禁的 QQ 号和理由，例如：#封禁 123456789 刷屏广告");
+          return;
+        }
+        const targetUser = await prisma.user.findUnique({
+          where: { qqUin: BigInt(parsed.qqUin) },
+        });
+        if (!targetUser) {
+          await this.sendGroupMessage(botQqUin, groupId, `未找到 QQ ${parsed.qqUin} 对应的账号，请先让该账号通过 Bot 注册或由运维创建`);
+          return;
+        }
+        const membership = await prisma.tenantMembership.findUnique({
+          where: {
+            tenantId_userId: {
+              tenantId: bot.tenantId,
+              userId: targetUser.id,
+            },
+          },
+        });
+        if (!membership) {
+          await this.sendGroupMessage(botQqUin, groupId, "该用户不属于当前校园墙");
+          return;
+        }
+        if (membership.role === "admin") {
+          await this.sendGroupMessage(botQqUin, groupId, "不能封禁管理员");
+          return;
+        }
+        const endsAt = new Date("9999-12-31T23:59:59.999Z");
+        await prisma.banRecord.create({
+          data: {
+            tenantId: bot.tenantId,
+            userId: targetUser.id,
+            operatorId: operator.id,
+            comment: parsed.reason,
+            endsAt,
+          },
+        });
+        await writeAuditLog({
+          tenantId: bot.tenantId,
+          actorId: operator.id,
+          action: "ban.create",
+          targetType: "user",
+          targetId: targetUser.id,
+          detail: {
+            comment: parsed.reason,
+            endsAt: endsAt.toISOString(),
+            source: "review_group",
+          },
+        });
+        await this.sendGroupMessage(botQqUin, groupId, `已封禁 QQ ${parsed.qqUin}，理由：${parsed.reason}`);
+        const tenant = await prisma.tenant.findUnique({ where: { id: bot.tenantId } });
+        const tenantName = tenant?.name ?? "校园墙";
+        await this.sendPrivateMessageViaTenantBots(bot.tenantId, parsed.qqUin, formatBanNotify(tenantName, parsed.reason, endsAt)).catch((error) => {
+          this.logger.warn({ error, qqUin: parsed.qqUin }, "failed to send ban notification");
+        });
+        return;
+      }
+
+      if (["解封", "unban"].includes(command.name)) {
+        const { operator } = await requireBotTenantRole(bot.tenantId, operatorQqUin, "reviewer");
+        const parsed = parseUnbanCommandArgs(command.args);
+        if (!parsed) {
           await this.sendGroupMessage(botQqUin, groupId, "请提供要解封的 QQ 号，例如：#解封 123456789");
           return;
         }
+        const qqUin = parsed.qqUin;
         const targetUser = await prisma.user.findUnique({
           where: { qqUin: BigInt(qqUin) },
         });
@@ -3162,6 +3225,14 @@ function escapeRegex(value: string) {
 
 export function parseCommand(input: string) {
   const normalized = input.replace(/\[CQ:at,qq=\d+\]/g, "").trim();
+  const bareCommand = normalized.match(/^(ban|unban)\b(?:\s+(.*))?$/i);
+  if (bareCommand?.[1]) {
+    return {
+      name: bareCommand[1].toLowerCase(),
+      args: bareCommand[2]?.trim() ?? "",
+    };
+  }
+
   // 同时支持半角 # / 与全角 ＃ 作为命令前缀（全角 # 在中文输入法下很常见，否则会出现指令无法识别）
   const commandStart = normalized.search(/[#＃/]/);
   if (commandStart < 0) {
@@ -3233,6 +3304,27 @@ function parseRejectArgs(args: string) {
   return {
     comment: comment.trim(),
     displayId,
+  };
+}
+
+export function parseBanCommandArgs(args: string) {
+  const match = args.trim().match(/^(\d+)\s+(.+\S)$/);
+  if (!match?.[1] || !match[2]) {
+    return null;
+  }
+  return {
+    qqUin: match[1],
+    reason: match[2].trim(),
+  };
+}
+
+export function parseUnbanCommandArgs(args: string) {
+  const match = args.trim().match(/^(\d+)$/);
+  if (!match?.[1]) {
+    return null;
+  }
+  return {
+    qqUin: match[1],
   };
 }
 


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

为审核组添加支持，允许在封禁和解封用户时附带原因，包括不带前缀的基础 ban/unban 命令。

新特性：
- 引入审核组命令，用于带理由永久封禁用户以及解封用户，同时支持带前缀和不带前缀的 ban/unban 语法。

增强内容：
- 扩展审核帮助文本，记录新的 ban/unban 审核命令。
- 为审核组命令添加专门的解析逻辑，以识别不带前缀的 ban/unban 消息，并提取 QQ 和原因参数。

测试：
- 添加单元测试，覆盖 ban/unban 参数解析，以及审核组解析器对不带前缀的 ban/unban 命令的识别。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为评审小组版主添加在小组中永久封禁和解禁用户的支持，包括带理由的裸封禁/解禁指令，并将其接入 OneBot 运行时。

新特性：
- 引入评审小组的封禁和解禁指令，接受 QQ 号和理由，支持带前缀和裸封禁/解禁语法。

增强：
- 扩展评审帮助文本，记录新的封禁/解禁管理指令。
- 添加专门的解析工具和评审小组封禁/解禁指令处理逻辑，包括对无指令前缀消息的支持。

测试：
- 添加封禁/解禁参数解析的单元测试，以及评审小组对裸封禁/解禁消息的指令解析测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for review group moderators to permanently ban and unban users in groups, including bare ban/unban commands with reasons, and wire this into the OneBot runtime.

New Features:
- Introduce review-group ban and unban commands that accept a QQ number and reason, supporting both prefixed and bare ban/unban syntax.

Enhancements:
- Extend review help text to document the new ban/unban moderation commands.
- Add dedicated parsing utilities and review-group command handling for ban/unban, including support for messages without a command prefix.

Tests:
- Add unit tests for ban/unban argument parsing and for review-group command parsing of bare ban/unban messages.

</details>

</details>

新功能：
- 引入群组指令，以附带原因的方式永久封禁用户，以及解封用户；同时支持带 `#` 前缀和不带前缀的 `ban`/`unban` 语法。

改进：
- 添加用于 `ban` 和 `unban` 指令的参数解析辅助方法，并将其集成到指令调度器中。
- 扩展帮助文本以记录新的封禁/解封评审指令。

测试：
- 添加单元测试，覆盖封禁/解封参数解析，以及在指令解析器中识别不带前缀的 `ban`/`unban` 指令。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

为审核组添加支持，允许在封禁和解封用户时附带原因，包括不带前缀的基础 ban/unban 命令。

新特性：
- 引入审核组命令，用于带理由永久封禁用户以及解封用户，同时支持带前缀和不带前缀的 ban/unban 语法。

增强内容：
- 扩展审核帮助文本，记录新的 ban/unban 审核命令。
- 为审核组命令添加专门的解析逻辑，以识别不带前缀的 ban/unban 消息，并提取 QQ 和原因参数。

测试：
- 添加单元测试，覆盖 ban/unban 参数解析，以及审核组解析器对不带前缀的 ban/unban 命令的识别。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为评审小组版主添加在小组中永久封禁和解禁用户的支持，包括带理由的裸封禁/解禁指令，并将其接入 OneBot 运行时。

新特性：
- 引入评审小组的封禁和解禁指令，接受 QQ 号和理由，支持带前缀和裸封禁/解禁语法。

增强：
- 扩展评审帮助文本，记录新的封禁/解禁管理指令。
- 添加专门的解析工具和评审小组封禁/解禁指令处理逻辑，包括对无指令前缀消息的支持。

测试：
- 添加封禁/解禁参数解析的单元测试，以及评审小组对裸封禁/解禁消息的指令解析测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for review group moderators to permanently ban and unban users in groups, including bare ban/unban commands with reasons, and wire this into the OneBot runtime.

New Features:
- Introduce review-group ban and unban commands that accept a QQ number and reason, supporting both prefixed and bare ban/unban syntax.

Enhancements:
- Extend review help text to document the new ban/unban moderation commands.
- Add dedicated parsing utilities and review-group command handling for ban/unban, including support for messages without a command prefix.

Tests:
- Add unit tests for ban/unban argument parsing and for review-group command parsing of bare ban/unban messages.

</details>

</details>

</details>