### PR TITLE
ci: fix commitlint install

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -59,11 +59,17 @@ jobs:
           node-version: 22
 
       - name: Install commitlint
-        run: npm install --no-save @commitlint/cli @commitlint/config-conventional
+        run: |
+          npm install \
+            --prefix "$RUNNER_TEMP/commitlint" \
+            @commitlint/cli \
+            @commitlint/config-conventional
 
       - name: Lint commits in this PR
+        env:
+          NODE_PATH: ${{ runner.temp }}/commitlint/node_modules
         run: |
-          npx commitlint \
+          "$RUNNER_TEMP/commitlint/node_modules/.bin/commitlint" \
             --config commitlint.config.cjs \
             --from "${{ github.event.pull_request.base.sha }}" \
             --to "${{ github.event.pull_request.head.sha }}" \


### PR DESCRIPTION
## Summary
- Install commitlint into the runner temp directory instead of the repo root.
- Run commitlint from that temp install and expose its node_modules through NODE_PATH for the shared config.

## Why
The previous `npm install --no-save` ran at the workspace root, where npm tries to resolve `workspace:*` dependencies and fails before commitlint can run.

## Validation
- Locally installed commitlint into a temp prefix and verified `commitlint.config.cjs` accepts `ci: fix commitlint install`.
- `git diff --check`

## Summary by Sourcery

CI:
- 在 PR lint 工作流中，将 commitlint 安装到 runner 的临时目录中，并通过其本地二进制文件执行；同时通过设置 NODE_PATH 暴露其 `node_modules` 以共享配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Install commitlint into the runner temporary directory and execute it via its local binary in the PR lint workflow, exposing its node_modules through NODE_PATH for shared configuration.

</details>