### PR TITLE
fix(render): keep corner avatar round

### DIFF
--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -495,6 +495,8 @@ async function renderPostHtml(input: RenderPostCardInput) {
       right: -170px;
       width: 500px;
       height: 500px;
+      border-radius: 50%;
+      object-fit: cover;
       opacity: 0.25;
     }
   </style>


### PR DESCRIPTION
## Summary
- Restore the rendered card corner avatar to a circular crop.
- Keep the corner image covered inside the round shape.

## Validation
- `bun --cwd apps/server typecheck`

## Summary by Sourcery

改进内容：
- 调整头像样式，采用圆形边框半径并使用 `object-fit: cover`，以确保头像图像的圆角效果一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust avatar styling to use a circular border radius and cover object-fit for consistent rounded corner imagery.

</details>