### PR TITLE
feat(posts): add tag support

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -31,6 +31,7 @@ import { registerMetadataRoutes } from "./routes/metadata";
 import { registerOAuthRoutes } from "./routes/oauth";
 import { registerOneBotRoutes } from "./routes/onebot";
 import { registerPostRoutes } from "./routes/posts";
+import { registerPostTagRoutes } from "./routes/post-tags";
 import { registerReviewRoutes } from "./routes/review";
 import { registerSetupRoutes } from "./routes/setup";
 import { registerStatsRoutes } from "./routes/stats";
@@ -40,6 +41,7 @@ import { registerTenantRoutes } from "./routes/tenants";
 import { runDatabaseMigrations } from "./lib/migrations";
 import { registerQZoneCookieHeartbeat } from "./lib/qzone-cookies";
 import { registerTenantLifecycleScheduler } from "./runtime/tenant-lifecycle";
+import { registerPostTagMaintenanceScheduler } from "./runtime/post-tagging";
 import { ensureBotSessionSecretConfigured } from "./lib/secret-json";
 
 const config = loadConfig();
@@ -78,6 +80,7 @@ registerOAuthRoutes(app);
 registerAdminRoutes(app, queue, oneBot);
 registerBotRoutes(app, queue);
 registerPostRoutes(app, config, queue, oneBot);
+registerPostTagRoutes(app);
 registerReviewRoutes(app, queue, oneBot);
 registerSvgRoutes(app);
 registerStatsRoutes(app);
@@ -120,6 +123,7 @@ const stopTenantLifecycleScheduler = registerTenantLifecycleScheduler({ logger: 
 const stopQZonePostMetricScheduler = registerQZonePostMetricScheduler({ queue, logger: app.log });
 const stopBotFriendSnapshotScheduler = registerBotFriendSnapshotScheduler({ caller: oneBot, logger: app.log });
 const stopFollowedPostCommentScheduler = registerFollowedPostCommentScheduler({ caller: oneBot, logger: app.log });
+const stopPostTagMaintenanceScheduler = registerPostTagMaintenanceScheduler({ logger: app.log });
 const stopTelemetryReporter = registerTelemetryReporter({ logger: app.log, config });
 registerBatchFlushSweeper(queue, app.log);
 
@@ -129,6 +133,7 @@ app.addHook("onClose", async () => {
   stopQZonePostMetricScheduler();
   stopBotFriendSnapshotScheduler();
   stopFollowedPostCommentScheduler();
+  stopPostTagMaintenanceScheduler();
   stopTelemetryReporter();
   stopBatchFlushSweeper();
 });

--- a/apps/server/src/lib/post-tags.test.ts
+++ b/apps/server/src/lib/post-tags.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeTagIds, normalizeTagName, normalizeTagNames } from "./post-tags";
+
+describe("post tag normalization", () => {
+  test("normalizes tag names", () => {
+    expect(normalizeTagName("  ##高考   志愿  ")).toBe("高考 志愿");
+    expect(normalizeTagName("")).toBe("");
+  });
+
+  test("deduplicates names and ids", () => {
+    expect(normalizeTagNames(["高考志愿", "#高考志愿", "失物"])).toEqual(["高考志愿", "失物"]);
+    expect(normalizeTagIds(["a", "a", "b", 3])).toEqual(["a", "b"]);
+  });
+});

--- a/apps/server/src/lib/post-tags.ts
+++ b/apps/server/src/lib/post-tags.ts
@@ -1,0 +1,262 @@
+import { Prisma } from "@campux/db";
+import { prisma } from "./prisma";
+
+type TagClient = typeof prisma | Prisma.TransactionClient;
+
+export const maxTagsPerPost = 5;
+export const maxTagNameLength = 16;
+
+const tagColorPalette = [
+  "#dbeafe",
+  "#dcfce7",
+  "#fef3c7",
+  "#fee2e2",
+  "#ede9fe",
+  "#cffafe",
+  "#fce7f3",
+  "#e2e8f0",
+];
+
+export type SerializedPostTag = {
+  id: string;
+  name: string;
+  description: string | null;
+  color: string;
+  status: string;
+  source: string;
+  lastUsedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  postCount?: number;
+};
+
+export type SerializedAssignedPostTag = SerializedPostTag & {
+  assignmentSource: string;
+  confidence: number | null;
+};
+
+export function normalizeTagName(value: unknown): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value
+    .trim()
+    .replace(/^#+/, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxTagNameLength);
+}
+
+export function normalizeTagNames(values: unknown): string[] {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  const names: string[] = [];
+  for (const value of values) {
+    const name = normalizeTagName(value);
+    if (name && !names.includes(name)) {
+      names.push(name);
+    }
+  }
+  return names.slice(0, maxTagsPerPost);
+}
+
+export function normalizeTagIds(values: unknown): string[] {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  const ids: string[] = [];
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const trimmed = value.trim();
+    if (trimmed && !ids.includes(trimmed)) {
+      ids.push(trimmed);
+    }
+  }
+  return ids.slice(0, maxTagsPerPost);
+}
+
+export function tagColorForName(name: string): string {
+  let hash = 0;
+  for (const char of name) {
+    hash = (hash * 31 + char.codePointAt(0)!) >>> 0;
+  }
+  return tagColorPalette[hash % tagColorPalette.length] ?? tagColorPalette[0]!;
+}
+
+export function serializePostTag(tag: {
+  id: string;
+  name: string;
+  description: string | null;
+  color: string;
+  status: string;
+  source: string;
+  lastUsedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  _count?: { assignments?: number };
+}): SerializedPostTag {
+  return {
+    id: tag.id,
+    name: tag.name,
+    description: tag.description,
+    color: tag.color,
+    status: tag.status,
+    source: tag.source,
+    lastUsedAt: tag.lastUsedAt?.toISOString() ?? null,
+    createdAt: tag.createdAt.toISOString(),
+    updatedAt: tag.updatedAt.toISOString(),
+    ...(typeof tag._count?.assignments === "number" ? { postCount: tag._count.assignments } : {}),
+  };
+}
+
+export function serializeAssignedPostTags(
+  assignments: Array<{
+    source: string;
+    confidence: number | null;
+    tag: {
+      id: string;
+      name: string;
+      description: string | null;
+      color: string;
+      status: string;
+      source: string;
+      lastUsedAt: Date | null;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+  }> | undefined,
+): SerializedAssignedPostTag[] {
+  return (assignments ?? [])
+    .filter((assignment) => assignment.tag.status === "active")
+    .map((assignment) => ({
+      ...serializePostTag(assignment.tag),
+      assignmentSource: assignment.source,
+      confidence: assignment.confidence,
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name, "zh-Hans-CN"));
+}
+
+export async function resolveManualPostTags(
+  client: TagClient,
+  tenantId: string,
+  input: {
+    tagIds?: string[] | undefined;
+    tagNames?: string[] | undefined;
+  },
+) {
+  const tagIds = normalizeTagIds(input.tagIds ?? []);
+  const tagNames = normalizeTagNames(input.tagNames ?? []);
+  if (tagIds.length === 0 && tagNames.length === 0) {
+    return [];
+  }
+
+  const existingById = tagIds.length > 0
+    ? await client.postTag.findMany({
+        where: {
+          tenantId,
+          status: "active",
+          id: { in: tagIds },
+        },
+      })
+    : [];
+
+  const tags = [...existingById];
+  for (const name of tagNames) {
+    const alreadySelected = tags.some((tag) => tag.name === name);
+    if (alreadySelected) {
+      continue;
+    }
+    const tag = await client.postTag.upsert({
+      where: {
+        tenantId_name: {
+          tenantId,
+          name,
+        },
+      },
+      update: {
+        status: "active",
+      },
+      create: {
+        tenantId,
+        name,
+        color: tagColorForName(name),
+        source: "manual",
+      },
+    });
+    tags.push(tag);
+    if (tags.length >= maxTagsPerPost) {
+      break;
+    }
+  }
+
+  return tags.slice(0, maxTagsPerPost);
+}
+
+export async function assignPostTags(
+  client: TagClient,
+  input: {
+    tenantId: string;
+    postId: string;
+    tags: Array<{ tagId: string; source: "manual" | "llm"; confidence?: number | null | undefined }>;
+  },
+) {
+  const seen = new Set<string>();
+  const now = new Date();
+  for (const tag of input.tags) {
+    if (seen.has(tag.tagId)) {
+      continue;
+    }
+    seen.add(tag.tagId);
+    await client.postTagAssignment.upsert({
+      where: {
+        postId_tagId: {
+          postId: input.postId,
+          tagId: tag.tagId,
+        },
+      },
+      create: {
+        tenantId: input.tenantId,
+        postId: input.postId,
+        tagId: tag.tagId,
+        source: tag.source,
+        confidence: tag.confidence ?? null,
+      },
+      update: tag.source === "manual"
+        ? {
+            source: "manual",
+            confidence: tag.confidence ?? null,
+          }
+        : {},
+    });
+    await client.postTag.update({
+      where: { id: tag.tagId },
+      data: { lastUsedAt: now },
+    });
+  }
+}
+
+export async function listTenantPostTags(tenantId: string, options: { includeArchived?: boolean } = {}) {
+  const tags = await prisma.postTag.findMany({
+    where: {
+      tenantId,
+      ...(options.includeArchived ? {} : { status: "active" }),
+    },
+    include: {
+      _count: {
+        select: {
+          assignments: true,
+        },
+      },
+    },
+    orderBy: [
+      { status: "asc" },
+      { lastUsedAt: "desc" },
+      { updatedAt: "desc" },
+      { name: "asc" },
+    ],
+  });
+  return tags.map(serializePostTag);
+}

--- a/apps/server/src/lib/posts.ts
+++ b/apps/server/src/lib/posts.ts
@@ -7,6 +7,22 @@ type PostQZoneComment = {
   replies?: Array<{ uin: string; name: string; content: string; images: string[]; createdAt: string | null }>;
 };
 
+type PostTagAssignmentInput = {
+  source: string;
+  confidence: number | null;
+  tag: {
+    id: string;
+    name: string;
+    description: string | null;
+    color: string;
+    status: string;
+    source: string;
+    lastUsedAt: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+};
+
 export type PostQZoneMetric = {
   visitorCount: number | null;
   likeCount: number | null;
@@ -68,6 +84,7 @@ export function toPostListItem(post: {
       items: Array<{ post: { displayId: number } }>;
     };
   } | null;
+  tagAssignments?: PostTagAssignmentInput[];
 }) {
   const recallLog = post.logs
     ?.filter((log) => log.oldStatus === "published" && log.newStatus === "pending_recall")
@@ -95,7 +112,27 @@ export function toPostListItem(post: {
     submissionChannel: inferSubmissionChannel(post.logs),
     qzoneStats: toQZonePostStats(post.qzonePostMetrics ?? []),
     batch: toBatchSummary(post.batchItem, post.displayId),
+    tags: toPostTags(post.tagAssignments),
   };
+}
+
+function toPostTags(assignments: PostTagAssignmentInput[] | undefined) {
+  return (assignments ?? [])
+    .filter((assignment) => assignment.tag.status === "active")
+    .map((assignment) => ({
+      id: assignment.tag.id,
+      name: assignment.tag.name,
+      description: assignment.tag.description,
+      color: assignment.tag.color,
+      status: assignment.tag.status,
+      source: assignment.tag.source,
+      lastUsedAt: assignment.tag.lastUsedAt?.toISOString() ?? null,
+      createdAt: assignment.tag.createdAt.toISOString(),
+      updatedAt: assignment.tag.updatedAt.toISOString(),
+      assignmentSource: assignment.source,
+      confidence: assignment.confidence,
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name, "zh-Hans-CN"));
 }
 
 /**

--- a/apps/server/src/lib/published-feed.test.ts
+++ b/apps/server/src/lib/published-feed.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildPublishedFeed, type BatchFeedInput, type RawFeedPost, type SingleFeedInput } from "./published-feed";
+import { buildPublishedFeed, filterPublishedFeedByTag, type BatchFeedInput, type RawFeedPost, type SingleFeedInput } from "./published-feed";
 import type { PostQZoneMetric } from "./posts";
 
 function makePost(overrides: Partial<RawFeedPost> & { id: string; displayId: number }): RawFeedPost {
@@ -10,6 +10,7 @@ function makePost(overrides: Partial<RawFeedPost> & { id: string; displayId: num
     bgColor: null,
     textColor: null,
     font: null,
+    tags: [],
     author: { displayName: `用户${overrides.displayId}`, qqUin: BigInt(10000 + overrides.displayId) },
     createdAt: new Date("2026-06-08T00:00:00Z"),
     ...overrides,
@@ -144,5 +145,46 @@ describe("buildPublishedFeed", () => {
     expect(items[0]!.qzoneStats?.likeCount).toBe(5);
     expect(items[0]!.qzoneStats?.commentCount).toBe(5);
     expect(items[0]!.qzoneStats?.targets).toHaveLength(2);
+  });
+
+  test("按标签过滤 single 和 batch feed", () => {
+    const tag = {
+      id: "tag-gaokao",
+      name: "高考志愿",
+      description: null,
+      color: "#dbeafe",
+      status: "active",
+      source: "llm",
+      lastUsedAt: null,
+      createdAt: "2026-06-08T00:00:00.000Z",
+      updatedAt: "2026-06-08T00:00:00.000Z",
+      assignmentSource: "llm",
+      confidence: 0.9,
+    };
+    const items = buildPublishedFeed({
+      singles: [
+        {
+          post: makePost({ id: "p1", displayId: 1, tags: [tag] }),
+          publishedAt: new Date("2026-06-08T04:00:00Z"),
+          metrics: [],
+        },
+        {
+          post: makePost({ id: "p2", displayId: 2 }),
+          publishedAt: new Date("2026-06-08T03:00:00Z"),
+          metrics: [],
+        },
+      ],
+      batches: [
+        {
+          batchId: "b1",
+          publishedAt: new Date("2026-06-08T02:00:00Z"),
+          posts: [makePost({ id: "p3", displayId: 3 }), makePost({ id: "p4", displayId: 4, tags: [tag] })],
+          metrics: [],
+        },
+      ],
+      viewerIsReviewer: false,
+    });
+    expect(filterPublishedFeedByTag(items, "tag-gaokao").map((item) => item.key)).toEqual(["p1", "b1"]);
+    expect(filterPublishedFeedByTag(items, "高考志愿").map((item) => item.key)).toEqual(["p1", "b1"]);
   });
 });

--- a/apps/server/src/lib/published-feed.ts
+++ b/apps/server/src/lib/published-feed.ts
@@ -1,4 +1,5 @@
 import { toQZonePostStats, type PostQZoneMetric } from "./posts";
+import type { SerializedAssignedPostTag } from "./post-tags";
 
 /**
  * 「已发布」聚合 feed 的整形逻辑（纯函数，无 DB 访问，便于单测）。
@@ -30,6 +31,7 @@ export type RawFeedPost = {
   textColor: string | null;
   font: string | null;
   createdAt: Date;
+  tags?: SerializedAssignedPostTag[];
 };
 
 export type PublishedFeedAuthor = {
@@ -48,6 +50,7 @@ export type PublishedFeedPost = {
   textColor: string | null;
   font: string | null;
   createdAt: string;
+  tags: SerializedAssignedPostTag[];
 };
 
 export type PublishedFeedItem = {
@@ -89,6 +92,7 @@ function toFeedPost(post: RawFeedPost, viewerIsReviewer: boolean): PublishedFeed
     textColor: post.textColor,
     font: post.font,
     createdAt: post.createdAt.toISOString(),
+    tags: post.tags ?? [],
   };
 }
 
@@ -138,5 +142,17 @@ export function buildPublishedFeed(input: {
 
   return [...singleItems, ...batchItems].sort(
     (left, right) => new Date(right.publishedAt).getTime() - new Date(left.publishedAt).getTime(),
+  );
+}
+
+export function filterPublishedFeedByTag(items: PublishedFeedItem[], tag: string | null | undefined): PublishedFeedItem[] {
+  const normalized = tag?.trim();
+  if (!normalized || normalized === "all") {
+    return items;
+  }
+  return items.filter((item) =>
+    item.posts.some((post) =>
+      post.tags.some((postTag) => postTag.id === normalized || postTag.name === normalized),
+    ),
   );
 }

--- a/apps/server/src/routes/ai.ts
+++ b/apps/server/src/routes/ai.ts
@@ -17,6 +17,8 @@ export const aiSettingsSchema = z.object({
   timeoutSeconds: z.number().int().min(5).max(120).optional(),
   rules: z.object({
     privatePostAiEnabled: z.boolean().optional(),
+    postTaggingEnabled: z.boolean().optional(),
+    postTagMaintenanceEnabled: z.boolean().optional(),
     privatePostAggregateDelaySeconds: z.number().int().min(0).max(120).optional(),
     postTriggerKeywords: z.array(z.string().trim().min(1).max(30)).max(20).optional(),
     privatePostPrompt: z.string().trim().max(PRIVATE_POST_PROMPT_MAX_LENGTH).optional(),

--- a/apps/server/src/routes/post-tags.ts
+++ b/apps/server/src/routes/post-tags.ts
@@ -1,0 +1,32 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { requireReadyTenant } from "../lib/auth";
+import { listTenantPostTags } from "../lib/post-tags";
+import { maintainTenantPostTags } from "../runtime/post-tagging";
+
+const listTagsQuerySchema = z.object({
+  includeArchived: z.coerce.boolean().default(false),
+});
+
+export function registerPostTagRoutes(app: FastifyInstance) {
+  app.get("/api/post-tags", async (request, reply) => {
+    const context = await requireReadyTenant(request, reply, "submitter");
+    const query = listTagsQuerySchema.parse(request.query);
+    const includeArchived = query.includeArchived && context.selectedMembership.role === "admin";
+    return {
+      tags: await listTenantPostTags(context.selectedTenant.id, { includeArchived }),
+    };
+  });
+
+  app.post("/api/post-tags/maintain", async (request, reply) => {
+    const context = await requireReadyTenant(request, reply, "admin");
+    const result = await maintainTenantPostTags({
+      tenantId: context.selectedTenant.id,
+      logger: request.log,
+    });
+    return {
+      ok: true,
+      result,
+    };
+  });
+}

--- a/apps/server/src/routes/posts.ts
+++ b/apps/server/src/routes/posts.ts
@@ -9,7 +9,8 @@ import { getStorageDriver } from "@campux/integrations";
 import { renderPostCard } from "@campux/render";
 import { hasTenantRole, requireReadyTenant, requireTenantContext } from "../lib/auth";
 import { toPostListItem } from "../lib/posts";
-import { buildPublishedFeed, type BatchFeedInput, type RawFeedPost, type SingleFeedInput } from "../lib/published-feed";
+import { buildPublishedFeed, filterPublishedFeedByTag, type BatchFeedInput, type RawFeedPost, type SingleFeedInput } from "../lib/published-feed";
+import { assignPostTags, normalizeTagIds, normalizeTagNames, resolveManualPostTags, serializeAssignedPostTags } from "../lib/post-tags";
 import { prisma } from "../lib/prisma";
 import { readTenantPendingPostLimit, readTenantImageCompression } from "../lib/tenant-metadata";
 import { writeAuditLog } from "../lib/audit";
@@ -19,6 +20,7 @@ import { readSvgAvatarDataUrl } from "../lib/svg-avatars";
 import { formatBanNotify } from "../lib/bot-messages";
 import type { RuntimeQueue } from "../runtime/queue";
 import type { OneBotRuntime } from "../runtime/onebot";
+import { autoTagPost } from "../runtime/post-tagging";
 
 const fileQuerySchema = z.object({
   key: z.string().min(1),
@@ -31,6 +33,10 @@ const postParamsSchema = z.object({
 const listQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(50).default(10),
+});
+
+const publishedListQuerySchema = listQuerySchema.extend({
+  tag: z.string().trim().max(80).optional(),
 });
 
 const recallRequestSchema = z.object({
@@ -180,6 +186,15 @@ function isTransactionSerializationFailure(value: unknown) {
   return isPrismaKnownRequestError(value) && value.code === "P2034";
 }
 
+function parseJsonArrayField(value: unknown): unknown[] {
+  try {
+    const parsed = JSON.parse(String(value ?? "[]"));
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
 export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _queue: RuntimeQueue, oneBot?: OneBotRuntime) {
   app.get("/api/uploads/post-image", async (request, reply) => {
     const context = await requireTenantContext(request, reply);
@@ -233,6 +248,8 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
     let bgColor: string | null = null;
     let textColor: string | null = null;
     let font: string | null = null;
+    let manualTagIds: string[] = [];
+    let manualTagNames: string[] = [];
     const staged: PostAttachment[] = [];
     const remoteGifUrls: string[] = [];
 
@@ -252,6 +269,10 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
             textColor = String(part.value ?? "") || null;
           } else if (part.fieldname === "font") {
             font = String(part.value ?? "") || null;
+          } else if (part.fieldname === "tagIds") {
+            manualTagIds = normalizeTagIds(parseJsonArrayField(part.value));
+          } else if (part.fieldname === "tagNames") {
+            manualTagNames = normalizeTagNames(parseJsonArrayField(part.value));
           } else if (part.fieldname === "remoteGifUrls") {
             // Accept JSON array of GIF URLs from 失控图床 API conversion
             try {
@@ -457,8 +478,12 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
                 },
               });
               const displayId = tenant.nextPostDisplayId - 1;
+              const manualTags = await resolveManualPostTags(tx, context.selectedTenant.id, {
+                tagIds: manualTagIds,
+                tagNames: manualTagNames,
+              });
 
-              return tx.post.create({
+              const created = await tx.post.create({
                 data: {
                   tenantId: context.selectedTenant.id,
                   authorId: context.user.id,
@@ -478,6 +503,25 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
                       newStatus: initialStatus,
                       comment: logComment,
                     },
+                  },
+                },
+              });
+              if (manualTags.length > 0) {
+                await assignPostTags(tx, {
+                  tenantId: context.selectedTenant.id,
+                  postId: created.id,
+                  tags: manualTags.map((tag) => ({
+                    tagId: tag.id,
+                    source: "manual",
+                  })),
+                });
+              }
+              return tx.post.findUniqueOrThrow({
+                where: { id: created.id },
+                include: {
+                  tagAssignments: {
+                    include: { tag: true },
+                    orderBy: { createdAt: "asc" },
                   },
                 },
               });
@@ -505,6 +549,13 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
 
       oneBot?.notifyNewPost(post.id).catch((error) => {
         app.log.warn({ error, postId: post.id }, "failed to notify review group");
+      });
+      autoTagPost({
+        tenantId: context.selectedTenant.id,
+        postId: post.id,
+        logger: request.log,
+      }).catch((error) => {
+        app.log.warn({ error, postId: post.id }, "failed to auto-tag post");
       });
 
       return {
@@ -603,6 +654,14 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
             },
             take: 1,
           },
+          tagAssignments: {
+            include: {
+              tag: true,
+            },
+            orderBy: {
+              createdAt: "asc",
+            },
+          },
           qzonePostMetrics: {
             include: {
               publishAttempt: {
@@ -663,7 +722,7 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
   // 面向本墙任意登录成员公开。
   app.get("/api/posts/published", async (request, reply) => {
     const context = await requireReadyTenant(request, reply, "submitter");
-    const query = listQuerySchema.parse(request.query);
+    const query = publishedListQuerySchema.parse(request.query);
     const tenantId = context.selectedTenant.id;
     const viewerIsReviewer = hasTenantRole(context.selectedMembership.role, "reviewer");
 
@@ -699,6 +758,10 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
         },
         include: {
           author: authorSelect,
+          tagAssignments: {
+            include: { tag: true },
+            orderBy: { createdAt: "asc" },
+          },
           qzonePostMetrics: metricInclude,
         },
         orderBy: { updatedAt: "desc" },
@@ -709,7 +772,17 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
         include: {
           items: {
             orderBy: { position: "asc" },
-            include: { post: { include: { author: authorSelect } } },
+            include: {
+              post: {
+                include: {
+                  author: authorSelect,
+                  tagAssignments: {
+                    include: { tag: true },
+                    orderBy: { createdAt: "asc" },
+                  },
+                },
+              },
+            },
           },
           attempts: {
             include: { qzonePostMetrics: metricInclude },
@@ -730,6 +803,7 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
       font: string | null;
       createdAt: Date;
       author: { displayName: string | null; qqUin: bigint } | null;
+      tagAssignments?: Parameters<typeof serializeAssignedPostTags>[0];
     }): RawFeedPost => ({
       id: post.id,
       displayId: post.displayId,
@@ -741,6 +815,7 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
       font: post.font,
       author: post.author ? { displayName: post.author.displayName ?? "", qqUin: post.author.qqUin } : null,
       createdAt: post.createdAt,
+      tags: serializeAssignedPostTags(post.tagAssignments),
     });
 
     const singles: SingleFeedInput[] = singlePosts.map((post) => ({
@@ -759,7 +834,10 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
       };
     });
 
-    const allItems = buildPublishedFeed({ singles, batches: batchInputs, viewerIsReviewer });
+    const allItems = filterPublishedFeedByTag(
+      buildPublishedFeed({ singles, batches: batchInputs, viewerIsReviewer }),
+      query.tag,
+    );
     const total = allItems.length;
     const start = (query.page - 1) * query.limit;
     const items = allItems.slice(start, start + query.limit);
@@ -781,6 +859,10 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
       include: {
         author: true,
         tenant: true,
+        tagAssignments: {
+          include: { tag: true },
+          orderBy: { createdAt: "asc" },
+        },
       },
     });
 
@@ -819,6 +901,7 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
       bgColor: post.bgColor ?? null,
       textColor: post.textColor ?? null,
       font: post.font ?? null,
+      tags: serializeAssignedPostTags(post.tagAssignments).map((tag) => ({ name: tag.name, color: tag.color })),
     });
 
     reply.header("Cache-Control", "private, max-age=60");

--- a/apps/server/src/routes/review.ts
+++ b/apps/server/src/routes/review.ts
@@ -74,6 +74,14 @@ export function registerReviewRoutes(app: FastifyInstance, queue: RuntimeQueue, 
               createdAt: "asc",
             },
           },
+          tagAssignments: {
+            include: {
+              tag: true,
+            },
+            orderBy: {
+              createdAt: "asc",
+            },
+          },
           qzonePostMetrics: {
             include: {
               publishAttempt: {

--- a/apps/server/src/runtime/ai-settings.ts
+++ b/apps/server/src/runtime/ai-settings.ts
@@ -18,6 +18,10 @@ export type TenantAiSettingsPayload = {
 export type AiRules = {
   /** 是否启用私聊投稿 AI 语义收稿 */
   privatePostAiEnabled?: boolean | undefined;
+  /** 是否启用投稿后的 LLM 自动打标 */
+  postTaggingEnabled?: boolean | undefined;
+  /** 是否启用 LLM 定期维护标签库 */
+  postTagMaintenanceEnabled?: boolean | undefined;
   /** 私聊 AI 聚合收稿等待秒数，0 表示不聚合 */
   privatePostAggregateDelaySeconds?: number | undefined;
   /** 对话投稿额外触发关键词，如 ["发帖", "吐槽", "表白"]，不含 # 前缀 */
@@ -60,6 +64,8 @@ const defaultAiSettings: TenantAiSettingsPayload = {
   timeoutSeconds: 30,
   rules: {
     privatePostAiEnabled: false,
+    postTaggingEnabled: true,
+    postTagMaintenanceEnabled: true,
     privatePostAggregateDelaySeconds: 8,
     postTriggerKeywords: [],
     privatePostPrompt: DEFAULT_PRIVATE_POST_PROMPT,
@@ -261,6 +267,8 @@ export function normalizeAiRules(value: unknown): AiRules {
   const candidate = value as Record<string, unknown>;
   return {
     privatePostAiEnabled: typeof candidate.privatePostAiEnabled === "boolean" ? candidate.privatePostAiEnabled : defaultAiSettings.rules.privatePostAiEnabled,
+    postTaggingEnabled: typeof candidate.postTaggingEnabled === "boolean" ? candidate.postTaggingEnabled : defaultAiSettings.rules.postTaggingEnabled,
+    postTagMaintenanceEnabled: typeof candidate.postTagMaintenanceEnabled === "boolean" ? candidate.postTagMaintenanceEnabled : defaultAiSettings.rules.postTagMaintenanceEnabled,
     privatePostAggregateDelaySeconds: normalizeNumber(candidate.privatePostAggregateDelaySeconds, 0, 120, defaultAiSettings.rules.privatePostAggregateDelaySeconds ?? 8),
     postTriggerKeywords: normalizeStringArray(candidate.postTriggerKeywords ?? defaultAiSettings.rules.postTriggerKeywords),
     privatePostPrompt: normalizePrivatePostPrompt(candidate.privatePostPrompt),

--- a/apps/server/src/runtime/post-tagging.test.ts
+++ b/apps/server/src/runtime/post-tagging.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { parsePostTagMaintenanceJson, parsePostTagSuggestionJson } from "./post-tagging";
+
+describe("post tag LLM JSON parsing", () => {
+  test("parses tag suggestions and normalizes names", () => {
+    const parsed = parsePostTagSuggestionJson(`
+      {"selected":["#高考志愿"," 失物 招领 "],"create":[{"name":"#宿舍维修","description":"维修咨询","color":"#DBEAFE"}],"confidence":0.82}
+    `);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.selected).toEqual(["高考志愿", "失物 招领"]);
+    expect(parsed?.create[0]).toEqual({ name: "宿舍维修", description: "维修咨询", color: "#dbeafe" });
+    expect(parsed?.confidence).toBe(0.82);
+  });
+
+  test("parses maintenance actions and drops invalid create rows", () => {
+    const parsed = parsePostTagMaintenanceJson(`
+      {"create":[{"name":"高考志愿","description":"志愿填报","color":"bad"},{"name":"","description":"x"}],"archive":["旧活动"],"delete":["空标签"]}
+    `);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.create[0]?.name).toBe("高考志愿");
+    expect(parsed?.create[0]?.description).toBe("志愿填报");
+    expect(parsed?.create[0]?.color).toMatch(/^#[0-9a-f]{6}$/);
+    expect(parsed?.archive).toEqual(["旧活动"]);
+    expect(parsed?.delete).toEqual(["空标签"]);
+  });
+});

--- a/apps/server/src/runtime/post-tagging.ts
+++ b/apps/server/src/runtime/post-tagging.ts
@@ -1,0 +1,562 @@
+import type { FastifyBaseLogger } from "fastify";
+import { normalizeBaseUrl, readTenantAiSettings, resolveTenantAiApiKey } from "./ai-settings";
+import { assignPostTags, maxTagsPerPost, normalizeTagName, tagColorForName } from "../lib/post-tags";
+import { prisma } from "../lib/prisma";
+
+type ExistingTag = {
+  id: string;
+  name: string;
+  description: string | null;
+  color: string;
+};
+
+export type PostTagSuggestion = {
+  selected: string[];
+  create: Array<{
+    name: string;
+    description: string | null;
+    color: string | null;
+  }>;
+  confidence: number;
+};
+
+export type PostTagMaintenanceResult = {
+  created: string[];
+  archived: string[];
+  deleted: string[];
+};
+
+const tagPromptMaxTextChars = 800;
+
+export async function autoTagPost(options: {
+  tenantId: string;
+  postId: string;
+  logger: FastifyBaseLogger;
+}) {
+  const post = await prisma.post.findFirst({
+    where: {
+      id: options.postId,
+      tenantId: options.tenantId,
+    },
+    select: {
+      id: true,
+      text: true,
+      tagAssignments: {
+        select: {
+          tagId: true,
+        },
+      },
+    },
+  });
+  if (!post || !post.text.trim()) {
+    return;
+  }
+
+  const existingTags = await prisma.postTag.findMany({
+    where: {
+      tenantId: options.tenantId,
+      status: "active",
+    },
+    orderBy: [
+      { lastUsedAt: "desc" },
+      { updatedAt: "desc" },
+      { name: "asc" },
+    ],
+    take: 80,
+  });
+
+  const suggestion = await generatePostTagSuggestion({
+    tenantId: options.tenantId,
+    text: post.text,
+    existingTags,
+    logger: options.logger,
+  });
+  if (!suggestion) {
+    return;
+  }
+
+  const selectedNames = normalizeSuggestedNames(suggestion.selected);
+  const createItems = suggestion.create
+    .map((item) => {
+      const name = normalizeTagName(item.name);
+      return {
+        name,
+        description: item.description?.trim().slice(0, 80) || null,
+        color: normalizeHexColor(item.color) ?? tagColorForName(name),
+      };
+    })
+    .filter((item) => item.name)
+    .slice(0, Math.max(0, maxTagsPerPost - selectedNames.length));
+
+  const tagsByName = new Map(existingTags.map((tag) => [tag.name, tag]));
+  const tagsToAssign: Array<{ tagId: string; source: "llm"; confidence: number }> = [];
+
+  for (const name of selectedNames) {
+    const tag = tagsByName.get(name);
+    if (tag) {
+      tagsToAssign.push({ tagId: tag.id, source: "llm", confidence: suggestion.confidence });
+    }
+  }
+
+  for (const item of createItems) {
+    if (tagsByName.has(item.name)) {
+      const existing = tagsByName.get(item.name)!;
+      tagsToAssign.push({ tagId: existing.id, source: "llm", confidence: suggestion.confidence });
+      continue;
+    }
+    const tag = await prisma.postTag.upsert({
+      where: {
+        tenantId_name: {
+          tenantId: options.tenantId,
+          name: item.name,
+        },
+      },
+      update: {
+        status: "active",
+        ...(item.description ? { description: item.description } : {}),
+      },
+      create: {
+        tenantId: options.tenantId,
+        name: item.name,
+        description: item.description,
+        color: item.color,
+        source: "llm",
+      },
+    });
+    tagsByName.set(tag.name, tag);
+    tagsToAssign.push({ tagId: tag.id, source: "llm", confidence: suggestion.confidence });
+  }
+
+  const alreadyAssigned = new Set(post.tagAssignments.map((assignment) => assignment.tagId));
+  const remainingSlots = Math.max(0, maxTagsPerPost - alreadyAssigned.size);
+  if (remainingSlots === 0) {
+    return;
+  }
+  await assignPostTags(prisma, {
+    tenantId: options.tenantId,
+    postId: post.id,
+    tags: tagsToAssign
+      .filter((tag) => !alreadyAssigned.has(tag.tagId))
+      .slice(0, remainingSlots),
+  });
+}
+
+export async function generatePostTagSuggestion(options: {
+  tenantId: string;
+  text: string;
+  existingTags: ExistingTag[];
+  logger: FastifyBaseLogger;
+}): Promise<PostTagSuggestion | null> {
+  const settings = await readTenantAiSettings(options.tenantId).catch((error) => {
+    options.logger.warn({ error, tenantId: options.tenantId }, "post tags: failed to read AI settings");
+    return null;
+  });
+  if (!settings || !settings.enabled || !settings.rules.postTaggingEnabled || settings.mode !== "llm" || !settings.apiKeyConfigured) {
+    return null;
+  }
+
+  const apiKey = await resolveTenantAiApiKey(options.tenantId, {});
+  if (!apiKey) {
+    return null;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), Math.min(settings.timeoutSeconds, 20) * 1_000);
+  try {
+    const response = await fetch(`${normalizeBaseUrl(settings.baseUrl)}/chat/completions`, {
+      method: "POST",
+      signal: controller.signal,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: settings.model,
+        temperature: 0,
+        max_tokens: 500,
+        response_format: { type: "json_object" },
+        messages: [
+          {
+            role: "system",
+            content: [
+              "你是校园墙稿件标签助手。只返回 JSON，不要 Markdown。",
+              `目标：为一条校园墙稿件选择最多 ${maxTagsPerPost} 个主题标签。`,
+              "优先复用 existingTags 里的 name，selected 必须是已有标签名。",
+              "如果正文明显属于一个近期事件、办事主题或高频咨询方向，可以在 create 中新增 1-2 个短中文标签。",
+              "标签名 2-8 个汉字最佳，不能包含 #、表情、个人隐私、姓名、QQ、联系方式。",
+              "不要为了单条闲聊创建过细标签；不确定时少打标。",
+              "返回格式：{\"selected\":[\"已有标签名\"],\"create\":[{\"name\":\"新标签\",\"description\":\"一句话说明\",\"color\":\"#dbeafe\"}],\"confidence\":0到1}",
+            ].join("\n"),
+          },
+          {
+            role: "user",
+            content: JSON.stringify({
+              existingTags: options.existingTags.map((tag) => ({
+                name: tag.name,
+                description: tag.description,
+              })),
+              text: options.text.trim().slice(0, tagPromptMaxTextChars),
+            }),
+          },
+        ],
+      }),
+    });
+
+    const data = (await response.json().catch(() => null)) as
+      | { choices?: Array<{ message?: { content?: string } }>; error?: { message?: string } }
+      | null;
+    if (!response.ok) {
+      options.logger.warn({ tenantId: options.tenantId, status: response.status, error: data?.error?.message }, "post tags: LLM request failed");
+      return null;
+    }
+    const parsed = parsePostTagSuggestionJson(data?.choices?.[0]?.message?.content ?? "");
+    return parsed;
+  } catch (error) {
+    const aborted = error instanceof Error && error.name === "AbortError";
+    options.logger.warn({ error, tenantId: options.tenantId, aborted }, "post tags: LLM call errored");
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function parsePostTagSuggestionJson(raw: string): PostTagSuggestion | null {
+  const parsed = parseJsonObject(raw);
+  if (!parsed) {
+    return null;
+  }
+  const selected = normalizeSuggestedNames(parsed.selected);
+  const create = Array.isArray(parsed.create)
+    ? parsed.create.flatMap((item) => {
+        if (!item || typeof item !== "object") {
+          return [];
+        }
+        const record = item as Record<string, unknown>;
+        const name = normalizeTagName(record.name);
+        if (!name) {
+          return [];
+        }
+        return [{
+          name,
+          description: typeof record.description === "string" ? record.description.trim().slice(0, 80) || null : null,
+          color: normalizeHexColor(record.color),
+        }];
+      })
+    : [];
+  const confidence = clampNumber(typeof parsed.confidence === "number" ? parsed.confidence : Number(parsed.confidence), 0, 1, 0.5);
+  return {
+    selected: selected.slice(0, maxTagsPerPost),
+    create: create.slice(0, maxTagsPerPost),
+    confidence,
+  };
+}
+
+export async function maintainTenantPostTags(options: {
+  tenantId: string;
+  logger: FastifyBaseLogger;
+}): Promise<PostTagMaintenanceResult> {
+  const settings = await readTenantAiSettings(options.tenantId).catch((error) => {
+    options.logger.warn({ error, tenantId: options.tenantId }, "post tag maintenance: failed to read AI settings");
+    return null;
+  });
+  if (!settings || !settings.enabled || !settings.rules.postTagMaintenanceEnabled || settings.mode !== "llm" || !settings.apiKeyConfigured) {
+    return { created: [], archived: [], deleted: [] };
+  }
+
+  const apiKey = await resolveTenantAiApiKey(options.tenantId, {});
+  if (!apiKey) {
+    return { created: [], archived: [], deleted: [] };
+  }
+
+  const [tags, posts] = await Promise.all([
+    prisma.postTag.findMany({
+      where: { tenantId: options.tenantId },
+      include: { _count: { select: { assignments: true } } },
+      orderBy: [{ status: "asc" }, { lastUsedAt: "desc" }, { updatedAt: "desc" }],
+      take: 100,
+    }),
+    prisma.post.findMany({
+      where: {
+        tenantId: options.tenantId,
+        createdAt: { gte: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000) },
+      },
+      select: {
+        displayId: true,
+        text: true,
+        createdAt: true,
+        tagAssignments: {
+          select: {
+            tag: { select: { name: true } },
+          },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      take: 80,
+    }),
+  ]);
+
+  if (posts.length === 0 && tags.length === 0) {
+    return { created: [], archived: [], deleted: [] };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), Math.min(settings.timeoutSeconds, 30) * 1_000);
+  try {
+    const response = await fetch(`${normalizeBaseUrl(settings.baseUrl)}/chat/completions`, {
+      method: "POST",
+      signal: controller.signal,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: settings.model,
+        temperature: 0,
+        max_tokens: 900,
+        response_format: { type: "json_object" },
+        messages: [
+          {
+            role: "system",
+            content: [
+              "你是校园墙标签维护助手。只返回 JSON。",
+              "根据最近 14 天稿件和现有标签，维护一个简洁、可筛选的标签库。",
+              "create：近期事件或高频主题缺少标签时新增，最多 5 个。",
+              "archive：明显过期、近期不用但历史仍有价值的标签，最多 10 个。",
+              "delete：没有任何使用记录且冗余/质量差的标签，最多 10 个。不要删除有使用记录的标签。",
+              "标签名要短中文，不含 #、表情、个人隐私、姓名、QQ、联系方式。",
+              "返回格式：{\"create\":[{\"name\":\"高考志愿\",\"description\":\"志愿填报相关咨询\",\"color\":\"#dbeafe\"}],\"archive\":[\"旧标签\"],\"delete\":[\"空标签\"]}",
+            ].join("\n"),
+          },
+          {
+            role: "user",
+            content: JSON.stringify({
+              tags: tags.map((tag) => ({
+                name: tag.name,
+                description: tag.description,
+                status: tag.status,
+                source: tag.source,
+                postCount: tag._count.assignments,
+                lastUsedAt: tag.lastUsedAt?.toISOString() ?? null,
+              })),
+              recentPosts: posts.map((post) => ({
+                displayId: post.displayId,
+                createdAt: post.createdAt.toISOString(),
+                text: post.text.slice(0, tagPromptMaxTextChars),
+                tags: post.tagAssignments.map((assignment) => assignment.tag.name),
+              })),
+            }),
+          },
+        ],
+      }),
+    });
+    const data = (await response.json().catch(() => null)) as
+      | { choices?: Array<{ message?: { content?: string } }>; error?: { message?: string } }
+      | null;
+    if (!response.ok) {
+      options.logger.warn({ tenantId: options.tenantId, status: response.status, error: data?.error?.message }, "post tag maintenance: LLM request failed");
+      return { created: [], archived: [], deleted: [] };
+    }
+    const actions = parsePostTagMaintenanceJson(data?.choices?.[0]?.message?.content ?? "");
+    if (!actions) {
+      return { created: [], archived: [], deleted: [] };
+    }
+    return applyTagMaintenanceActions(options.tenantId, actions);
+  } catch (error) {
+    const aborted = error instanceof Error && error.name === "AbortError";
+    options.logger.warn({ error, tenantId: options.tenantId, aborted }, "post tag maintenance: LLM call errored");
+    return { created: [], archived: [], deleted: [] };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function parsePostTagMaintenanceJson(raw: string) {
+  const parsed = parseJsonObject(raw);
+  if (!parsed) {
+    return null;
+  }
+  const create = Array.isArray(parsed.create)
+    ? parsed.create.flatMap((item) => {
+        if (!item || typeof item !== "object") {
+          return [];
+        }
+        const record = item as Record<string, unknown>;
+        const name = normalizeTagName(record.name);
+        if (!name) {
+          return [];
+        }
+        return [{
+          name,
+          description: typeof record.description === "string" ? record.description.trim().slice(0, 80) || null : null,
+          color: normalizeHexColor(record.color) ?? tagColorForName(name),
+        }];
+      }).slice(0, 5)
+    : [];
+  return {
+    create,
+    archive: normalizeSuggestedNames(parsed.archive).slice(0, 10),
+    delete: normalizeSuggestedNames(parsed.delete).slice(0, 10),
+  };
+}
+
+async function applyTagMaintenanceActions(
+  tenantId: string,
+  actions: NonNullable<ReturnType<typeof parsePostTagMaintenanceJson>>,
+): Promise<PostTagMaintenanceResult> {
+  const created: string[] = [];
+  const archived: string[] = [];
+  const deleted: string[] = [];
+
+  for (const item of actions.create) {
+    const tag = await prisma.postTag.upsert({
+      where: {
+        tenantId_name: {
+          tenantId,
+          name: item.name,
+        },
+      },
+      update: {
+        status: "active",
+        ...(item.description ? { description: item.description } : {}),
+      },
+      create: {
+        tenantId,
+        name: item.name,
+        description: item.description,
+        color: item.color,
+        source: "llm",
+      },
+    });
+    created.push(tag.name);
+  }
+
+  if (actions.archive.length > 0) {
+    const result = await prisma.postTag.updateMany({
+      where: {
+        tenantId,
+        name: { in: actions.archive },
+        status: "active",
+      },
+      data: {
+        status: "archived",
+      },
+    });
+    if (result.count > 0) {
+      archived.push(...actions.archive);
+    }
+  }
+
+  if (actions.delete.length > 0) {
+    const candidates = await prisma.postTag.findMany({
+      where: {
+        tenantId,
+        name: { in: actions.delete },
+      },
+      include: {
+        _count: {
+          select: {
+            assignments: true,
+          },
+        },
+      },
+    });
+    const deletable = candidates.filter((tag) => tag._count.assignments === 0);
+    if (deletable.length > 0) {
+      await prisma.postTag.deleteMany({
+        where: {
+          id: { in: deletable.map((tag) => tag.id) },
+        },
+      });
+      deleted.push(...deletable.map((tag) => tag.name));
+    }
+  }
+
+  return { created: uniqueStrings(created), archived: uniqueStrings(archived), deleted: uniqueStrings(deleted) };
+}
+
+export function registerPostTagMaintenanceScheduler(options: { logger: FastifyBaseLogger }) {
+  let stopped = false;
+  async function run() {
+    if (stopped) {
+      return;
+    }
+    const tenants = await prisma.tenant.findMany({
+      where: {
+        status: "active",
+        aiSettings: {
+          isNot: null,
+        },
+      },
+      select: { id: true },
+      take: 100,
+    });
+    for (const tenant of tenants) {
+      await maintainTenantPostTags({ tenantId: tenant.id, logger: options.logger }).catch((error) => {
+        options.logger.warn({ error, tenantId: tenant.id }, "post tag maintenance scheduler failed");
+      });
+    }
+  }
+
+  const initial = setTimeout(() => {
+    void run().catch((error) => options.logger.warn({ error }, "post tag maintenance initial run failed"));
+  }, 2 * 60 * 1000);
+  const interval = setInterval(() => {
+    void run().catch((error) => options.logger.warn({ error }, "post tag maintenance run failed"));
+  }, 6 * 60 * 60 * 1000);
+
+  return () => {
+    stopped = true;
+    clearTimeout(initial);
+    clearInterval(interval);
+  };
+}
+
+function normalizeSuggestedNames(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return uniqueStrings(value.map(normalizeTagName).filter(Boolean));
+}
+
+function normalizeHexColor(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return /^#[0-9a-fA-F]{6}$/.test(trimmed) ? trimmed.toLowerCase() : null;
+}
+
+function parseJsonObject(raw: string): Record<string, unknown> | null {
+  const trimmed = raw.trim().replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "").trim();
+  if (!trimmed) {
+    return null;
+  }
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+  if (start < 0 || end <= start) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(trimmed.slice(start, end + 1));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : null;
+  } catch {
+    return null;
+  }
+}
+
+function uniqueStrings(values: string[]): string[] {
+  const result: string[] = [];
+  for (const value of values) {
+    if (value && !result.includes(value)) {
+      result.push(value);
+    }
+  }
+  return result;
+}
+
+function clampNumber(value: number, min: number, max: number, fallback: number) {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(min, Math.min(max, value));
+}

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -5,6 +5,7 @@ import type { PostStatus } from "@campux/db";
 import { getStorageDriver, publishToQZone, QZonePublishError } from "@campux/integrations";
 import { renderPostCard } from "@campux/render";
 import { qzoneCookieDomain } from "../lib/bot-workflows";
+import { serializeAssignedPostTags } from "../lib/post-tags";
 import { prisma } from "../lib/prisma";
 import { decryptJson } from "../lib/secret-json";
 import { checkAndUpdateQZoneSession } from "../lib/qzone-cookies";
@@ -532,6 +533,10 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
         include: {
           tenant: true,
           author: true,
+          tagAssignments: {
+            include: { tag: true },
+            orderBy: { createdAt: "asc" },
+          },
         },
       },
       batch: {
@@ -543,6 +548,10 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
                 include: {
                   tenant: true,
                   author: true,
+                  tagAssignments: {
+                    include: { tag: true },
+                    orderBy: { createdAt: "asc" },
+                  },
                 },
               },
             },
@@ -636,6 +645,10 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
         bgColor: (target as { bgColor?: string | null }).bgColor ?? null,
         textColor: (target as { textColor?: string | null }).textColor ?? null,
         font: (target as { font?: string | null }).font ?? null,
+        tags: serializeAssignedPostTags((target as { tagAssignments?: Parameters<typeof serializeAssignedPostTags>[0] }).tagAssignments).map((tag) => ({
+          name: tag.name,
+          color: tag.color,
+        })),
       });
       captionParts.push(
         renderPublishCaption(attempt.publishTarget.botAccount.publishTextTemplate, {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,7 +4,7 @@ import { toast } from "sonner";
 import { api, createPostWithAttachments, CreatePostError } from "@/lib/api";
 import { canAccess, defaultMetadata, navItems } from "@/lib/app-model";
 import { readQueryInt, writeQueryParams } from "@/lib/url-query";
-import type { ActiveBan, AdminTab, AuthenticatedMe, CurrentMembership, MainTab, MeResponse, OAuthAuthorizeClientResponse, Pagination, PostItem, PostsTab, TenantMetadata } from "@/types/app";
+import type { ActiveBan, AdminTab, AuthenticatedMe, CurrentMembership, MainTab, MeResponse, OAuthAuthorizeClientResponse, Pagination, PostItem, PostTag, PostsTab, TenantMetadata } from "@/types/app";
 import { usePendingAttachments } from "@/hooks/useUploadImages";
 import { LoadingScreen } from "@/features/auth/LoadingScreen";
 import { LoginScreen } from "@/features/auth/LoginScreen";
@@ -96,6 +96,9 @@ export function App() {
   const [postBgColor, setPostBgColor] = useState<string>("");
   const [postTextColor, setPostTextColor] = useState<string>("");
   const [postFont, setPostFont] = useState<string>("");
+  const [postTags, setPostTags] = useState<PostTag[]>([]);
+  const [selectedPostTagIds, setSelectedPostTagIds] = useState<string[]>([]);
+  const [selectedPostTagNames, setSelectedPostTagNames] = useState<string[]>([]);
   const [adminUserDetailTarget, setAdminUserDetailTarget] = useState<{ userId: string; nonce: number } | null>(null);
   const [error, setError] = useState("");
   const [busy, setBusy] = useState(false);
@@ -215,12 +218,14 @@ export function App() {
   async function loadTenantData(page = postsPage) {
     setTenantDataLoading(true);
     try {
-      const [metadataData, postsData] = await Promise.all([
+      const [metadataData, postsData, tagData] = await Promise.all([
         api<TenantMetadata>("/api/tenant/metadata"),
         api<{ posts: PostItem[]; pagination: Pagination }>(`/api/posts/mine?page=${page}&limit=${postsPagination.limit}`),
+        api<{ tags: PostTag[] }>("/api/post-tags").catch(() => ({ tags: [] })),
       ]);
       setMetadata(metadataData);
       setPosts(postsData.posts);
+      setPostTags(tagData.tags);
       setPostsPagination(postsData.pagination);
       setPostsPage(postsData.pagination.page);
     } finally {
@@ -405,6 +410,9 @@ export function App() {
     await api<{ ok: true }>("/api/auth/logout", { method: "POST" }).catch(() => undefined);
     setMe({ authenticated: false });
     setPostText("");
+    setSelectedPostTagIds([]);
+    setSelectedPostTagNames([]);
+    setPostTags([]);
     clearAttachments();
     setPosts([]);
     navigate({ kind: "login" }, "replace");
@@ -423,6 +431,9 @@ export function App() {
     setPostText("");
     setAnonymous(false);
     setAnonymousAvatar("");
+    setSelectedPostTagIds([]);
+    setSelectedPostTagNames([]);
+    setPostTags([]);
     setMe((current) => current?.authenticated ? {
       ...current,
       currentTenant: data.currentTenant,
@@ -475,6 +486,8 @@ export function App() {
         postTextColor || undefined,
         postFont || undefined,
         anonymousAvatar || undefined,
+        selectedPostTagIds,
+        selectedPostTagNames,
       );
       clearAttachments();
       setPostText("");
@@ -483,9 +496,15 @@ export function App() {
       setPostBgColor("");
       setPostTextColor("");
       setPostFont("");
+      setSelectedPostTagIds([]);
+      setSelectedPostTagNames([]);
       toast.success("投稿已提交，等待审核。");
-      const data = await api<{ posts: PostItem[]; pagination: Pagination }>("/api/posts/mine?page=1&limit=10");
+      const [data, tagData] = await Promise.all([
+        api<{ posts: PostItem[]; pagination: Pagination }>("/api/posts/mine?page=1&limit=10"),
+        api<{ tags: PostTag[] }>("/api/post-tags").catch(() => ({ tags: [] })),
+      ]);
       setPosts(data.posts);
+      setPostTags(tagData.tags);
       setPostsPagination(data.pagination);
       setPostsPage(1);
       setActiveTab("posts");
@@ -627,6 +646,9 @@ export function App() {
       postBgColor={postBgColor}
       postTextColor={postTextColor}
       postFont={postFont}
+      postTags={postTags}
+      selectedPostTagIds={selectedPostTagIds}
+      selectedPostTagNames={selectedPostTagNames}
       postsTab={route.kind === "tenant" && route.tab === "posts" ? (route.subTab as PostsTab | undefined) ?? defaultPostsTab : defaultPostsTab}
       postsPagination={postsPagination}
       anonymous={anonymous}
@@ -639,6 +661,8 @@ export function App() {
       onBgColorChange={setPostBgColor}
       onTextColorChange={setPostTextColor}
       onFontChange={setPostFont}
+      onSelectedPostTagIdsChange={setSelectedPostTagIds}
+      onSelectedPostTagNamesChange={setSelectedPostTagNames}
       onFilesSelected={handleUploadFiles}
       onLogout={logout}
       onOpenOps={showOpsUi && canOpenOps(me) ? () => navigate({ kind: "ops" }) : undefined}

--- a/apps/web/src/features/admin/AdminPage.tsx
+++ b/apps/web/src/features/admin/AdminPage.tsx
@@ -140,6 +140,8 @@ type AiSettingsForm = {
   temperature: number;
   timeoutSeconds: number;
   privatePostAiEnabled: boolean;
+  postTaggingEnabled: boolean;
+  postTagMaintenanceEnabled: boolean;
   privatePostAggregateDelaySeconds: number;
   postTriggerKeywordsText: string;
   privatePostPrompt: string;
@@ -559,6 +561,8 @@ export function AdminPage({
     if (!aiForm) return null;
     const rules: AiRules = {
       privatePostAiEnabled: aiForm.privatePostAiEnabled,
+      postTaggingEnabled: aiForm.postTaggingEnabled,
+      postTagMaintenanceEnabled: aiForm.postTagMaintenanceEnabled,
       privatePostAggregateDelaySeconds: aiForm.privatePostAggregateDelaySeconds,
       postTriggerKeywords: lines(aiForm.postTriggerKeywordsText),
       privatePostPrompt: aiForm.privatePostPrompt.trim(),
@@ -2064,6 +2068,25 @@ function AdminAiSettingsPanel({
             <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-3">
               <div className="flex items-center justify-between gap-3">
                 <div>
+                  <p className="text-sm font-medium text-slate-900">AI 标签</p>
+                  <p className="text-xs text-slate-500">用于投稿后自动打标，并定期按近期稿件维护标签库。</p>
+                </div>
+                <div className="grid gap-2">
+                  <label className="flex items-center justify-end gap-2 text-xs font-semibold text-slate-600">
+                    自动打标
+                    <Switch checked={form.postTaggingEnabled} disabled={busy || testing} onCheckedChange={(checked) => onFormChange({ ...form, postTaggingEnabled: checked })} aria-label="启用 AI 自动打标" />
+                  </label>
+                  <label className="flex items-center justify-end gap-2 text-xs font-semibold text-slate-600">
+                    自动维护
+                    <Switch checked={form.postTagMaintenanceEnabled} disabled={busy || testing} onCheckedChange={(checked) => onFormChange({ ...form, postTagMaintenanceEnabled: checked })} aria-label="启用 AI 标签维护" />
+                  </label>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-3">
+              <div className="flex items-center justify-between gap-3">
+                <div>
                   <p className="text-sm font-medium text-slate-900">AI 语义收稿</p>
                   <p className="text-xs text-slate-500">开启后，私聊可由 AI 自动判断投稿内容、匿名意图、分段和是否提交；关闭时仅保留 #投稿 等显式命令。</p>
                 </div>
@@ -3506,6 +3529,8 @@ function aiSettingsToForm(settings: TenantAiSettings): AiSettingsForm {
     temperature: settings.temperature,
     timeoutSeconds: settings.timeoutSeconds,
     privatePostAiEnabled: Boolean(settings.rules.privatePostAiEnabled),
+    postTaggingEnabled: settings.rules.postTaggingEnabled ?? true,
+    postTagMaintenanceEnabled: settings.rules.postTagMaintenanceEnabled ?? true,
     privatePostAggregateDelaySeconds: settings.rules.privatePostAggregateDelaySeconds ?? 8,
     postTriggerKeywordsText: (settings.rules.postTriggerKeywords ?? []).join("\n"),
     privatePostPrompt: settings.rules.privatePostPrompt ?? "",

--- a/apps/web/src/features/posts/PostPage.tsx
+++ b/apps/web/src/features/posts/PostPage.tsx
@@ -2,12 +2,13 @@ import { useEffect, useRef, useState } from "react";
 import type { ClipboardEvent } from "react";
 import type { TenantSummary } from "@campux/domain";
 import { FONT_OPTIONS } from "@campux/domain";
-import { ChevronDownIcon, ImagePlusIcon, LoaderIcon, MegaphoneIcon, SendIcon, EyeIcon } from "lucide-react";
+import { ChevronDownIcon, HashIcon, ImagePlusIcon, LoaderIcon, MegaphoneIcon, PlusIcon, SendIcon, XIcon } from "lucide-react";
 import { defaultMetadata } from "@/lib/app-model";
-import type { PendingAttachment, TenantMetadata } from "@/types/app";
+import type { PendingAttachment, PostTag, TenantMetadata } from "@/types/app";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { LoadingBlock } from "@/components/app/utility";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
@@ -33,6 +34,9 @@ const TEXT_COLOR_OPTIONS = [
   { value: "dark_orange", label: "深橙", hex: "#CC5500" },
 ] as const;
 
+function normalizeDraftTagName(value: string): string {
+  return value.trim().replace(/^#+/, "").replace(/\s+/g, " ").trim().slice(0, 16);
+}
 
 export function PostPage({
   busy,
@@ -42,6 +46,9 @@ export function PostPage({
   postBgColor,
   postTextColor,
   postFont,
+  postTags,
+  selectedPostTagIds,
+  selectedPostTagNames,
   anonymous,
   anonymousAvatar,
   pendingAttachments,
@@ -51,6 +58,8 @@ export function PostPage({
   onBgColorChange,
   onTextColorChange,
   onFontChange,
+  onSelectedPostTagIdsChange,
+  onSelectedPostTagNamesChange,
   onFilesSelected,
   onRemoveAttachment,
   onSubmit,
@@ -62,6 +71,9 @@ export function PostPage({
   postBgColor: string;
   postTextColor: string;
   postFont: string;
+  postTags: PostTag[];
+  selectedPostTagIds: string[];
+  selectedPostTagNames: string[];
   anonymous: boolean;
   anonymousAvatar: string;
   selectedTenant: TenantSummary;
@@ -72,6 +84,8 @@ export function PostPage({
   onBgColorChange: (value: string) => void;
   onTextColorChange: (value: string) => void;
   onFontChange: (value: string) => void;
+  onSelectedPostTagIdsChange: (value: string[]) => void;
+  onSelectedPostTagNamesChange: (value: string[]) => void;
   onFilesSelected: (files: ArrayLike<File> | null) => void;
   onRemoveAttachment: (id: string) => void;
   onSubmit: () => void;
@@ -82,11 +96,13 @@ export function PostPage({
   const [fontPreviewUrl, setFontPreviewUrl] = useState<string | null>(null);
   const [fontPreviewLoading, setFontPreviewLoading] = useState(false);
   const [svgAvatars, setSvgAvatars] = useState<string[]>([]);
+  const [draftTagName, setDraftTagName] = useState("");
   const rules = metadata.postRules.length > 0 ? metadata.postRules : defaultMetadata.postRules;
   const sortedAttachments = [...pendingAttachments].sort((left, right) => left.sortOrder - right.sortOrder);
   const hasConverting = pendingAttachments.some((p) => p.status === "converting");
   const hasUploading = pendingAttachments.some((p) => p.status === "uploading");
   const hasNonDefaultFont = postFont && postFont !== "default";
+  const selectedTagCount = selectedPostTagIds.length + selectedPostTagNames.length;
 
   useEffect(() => {
     if (metadata.enableAnonymousAvatarSelection) {
@@ -122,6 +138,35 @@ export function PostPage({
     }
     onRemoveAttachment(attachmentToRemove.id);
     setAttachmentToRemove(null);
+  }
+
+  function toggleTag(tagId: string) {
+    if (selectedPostTagIds.includes(tagId)) {
+      onSelectedPostTagIdsChange(selectedPostTagIds.filter((id) => id !== tagId));
+      return;
+    }
+    if (selectedTagCount >= 5) {
+      return;
+    }
+    onSelectedPostTagIdsChange([...selectedPostTagIds, tagId]);
+  }
+
+  function addDraftTag() {
+    const name = normalizeDraftTagName(draftTagName);
+    if (!name || selectedTagCount >= 5) {
+      return;
+    }
+    const duplicateExisting = postTags.some((tag) => tag.name === name && selectedPostTagIds.includes(tag.id));
+    if (duplicateExisting || selectedPostTagNames.includes(name)) {
+      setDraftTagName("");
+      return;
+    }
+    onSelectedPostTagNamesChange([...selectedPostTagNames, name]);
+    setDraftTagName("");
+  }
+
+  function removeDraftTag(name: string) {
+    onSelectedPostTagNamesChange(selectedPostTagNames.filter((tagName) => tagName !== name));
   }
 
   async function handleSubmit() {
@@ -196,6 +241,82 @@ export function PostPage({
           onChange={(event) => onPostTextChange(event.target.value)}
           onPaste={pasteImages}
         />
+
+        <div className="mt-3 rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <div className="flex items-center gap-1.5 text-sm font-semibold text-slate-800">
+              <HashIcon className="size-4 text-slate-500" />
+              标签
+            </div>
+            <Badge variant="secondary" className="rounded-md shadow-none">
+              {selectedTagCount}/5
+            </Badge>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {postTags.length > 0 ? postTags.map((tag) => {
+              const selected = selectedPostTagIds.includes(tag.id);
+              const disabled = !selected && selectedTagCount >= 5;
+              return (
+                <button
+                  key={tag.id}
+                  type="button"
+                  disabled={disabled || busy}
+                  className={`inline-flex min-h-7 items-center rounded-full border px-2.5 text-xs font-semibold transition-colors ${
+                    selected
+                      ? "border-slate-700 bg-slate-800 text-white"
+                      : "border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-white/80 disabled:opacity-45"
+                  }`}
+                  onClick={() => toggleTag(tag.id)}
+                  title={tag.description ?? tag.name}
+                >
+                  {tag.name}
+                </button>
+              );
+            }) : (
+              <span className="inline-flex min-h-7 items-center rounded-full border border-dashed border-slate-300 bg-white px-2.5 text-xs font-semibold text-slate-400">
+                暂无可选标签
+              </span>
+            )}
+            {selectedPostTagNames.map((name) => (
+              <button
+                key={name}
+                type="button"
+                className="inline-flex min-h-7 items-center gap-1 rounded-full border border-blue-200 bg-blue-50 px-2.5 text-xs font-semibold text-blue-700"
+                onClick={() => removeDraftTag(name)}
+                title="移除标签"
+              >
+                {name}
+                <XIcon className="size-3" />
+              </button>
+            ))}
+          </div>
+          <div className="mt-2 flex gap-2">
+            <Input
+              value={draftTagName}
+              disabled={busy || selectedTagCount >= 5}
+              className="h-8 rounded-md bg-white text-sm"
+              maxLength={16}
+              placeholder="新增标签"
+              onChange={(event) => setDraftTagName(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  addDraftTag();
+                }
+              }}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              className="h-8 shrink-0 px-2 text-xs font-bold"
+              disabled={busy || selectedTagCount >= 5 || !normalizeDraftTagName(draftTagName)}
+              onClick={addDraftTag}
+            >
+              <PlusIcon data-icon="inline-start" />
+              添加
+            </Button>
+          </div>
+        </div>
 
         <div className="mt-3 flex flex-wrap gap-2">
           {sortedAttachments.map((item) => (

--- a/apps/web/src/features/posts/PostsPage.tsx
+++ b/apps/web/src/features/posts/PostsPage.tsx
@@ -27,7 +27,7 @@ import {
 import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { renderMarkdown } from "@/lib/markdown";
-import type { Pagination, PostItem, PostsTab, PostTimelineEntry, PublishedFeedItem, ReviewPostItem, TenantRole } from "@/types/app";
+import type { AssignedPostTag, Pagination, PostItem, PostTag, PostsTab, PostTimelineEntry, PublishedFeedItem, ReviewPostItem, TenantRole } from "@/types/app";
 import { canAccess, statusLabels } from "@/lib/app-model";
 import { readListPreferences, writeListPreferences } from "@/lib/list-preferences";
 import { hasAnyQueryParam, readQueryInt, readQueryParam, writeQueryParams } from "@/lib/url-query";
@@ -269,6 +269,8 @@ export function PostsPage({
   const [reviewKeyword, setReviewKeyword] = useState(() => readReviewListPreferences(tenantId).keyword);
   const [reviewPage, setReviewPage] = useState(() => readQueryInt("page", 1, { min: 1 }));
   const [publishedItems, setPublishedItems] = useState<PublishedFeedItem[]>([]);
+  const [publishedTags, setPublishedTags] = useState<PostTag[]>([]);
+  const [publishedTagFilter, setPublishedTagFilter] = useState("all");
   const [publishedPagination, setPublishedPagination] = useState<Pagination>(() => defaultPagination());
   const [publishedLoading, setPublishedLoading] = useState(false);
   const [publishedPage, setPublishedPage] = useState(1);
@@ -349,10 +351,10 @@ export function PostsPage({
     if (activeTab !== "published") {
       return;
     }
-    void refreshPublishedFeed(publishedPage).catch((caught) => {
+    void Promise.all([refreshPublishedTags(), refreshPublishedFeed(publishedPage)]).catch((caught) => {
       toast.error(caught instanceof Error ? caught.message : "无法读取已发布稿件");
     });
-  }, [activeTab, publishedPage, tenantId]);
+  }, [activeTab, publishedPage, publishedTagFilter, tenantId]);
 
   async function refreshAll() {
     await onRefresh();
@@ -404,6 +406,9 @@ export function PostsPage({
       page: String(page),
       limit: String(publishedPagination.limit),
     });
+    if (publishedTagFilter !== "all") {
+      params.set("tag", publishedTagFilter);
+    }
     setPublishedLoading(true);
     try {
       const data = await api<{ items: PublishedFeedItem[]; pagination: Pagination }>(`/api/posts/published?${params}`);
@@ -412,6 +417,20 @@ export function PostsPage({
     } finally {
       setPublishedLoading(false);
     }
+  }
+
+  async function refreshPublishedTags() {
+    const data = await api<{ tags: PostTag[] }>("/api/post-tags");
+    setPublishedTags(data.tags);
+    if (publishedTagFilter !== "all" && !data.tags.some((tag) => tag.id === publishedTagFilter)) {
+      setPublishedTagFilter("all");
+      setPublishedPage(1);
+    }
+  }
+
+  function changePublishedTagFilter(value: string) {
+    setPublishedTagFilter(value);
+    setPublishedPage(1);
   }
 
   async function reviewPost(id: string, action: "approve" | "reject", comment?: string) {
@@ -772,10 +791,11 @@ export function PostsPage({
           )}
         </TabsContent>
         <TabsContent value="published" className="mt-3 min-h-0 flex-1 overflow-y-auto pb-24 pr-1 md:pb-6">
+          <PublishedTagFilter tags={publishedTags} value={publishedTagFilter} onChange={changePublishedTagFilter} />
           {publishedLoading ? (
             <LoadingBlock title="正在加载已发布稿件..." />
           ) : publishedItems.length === 0 ? (
-            <EmptyCard title="还没有已发布的稿件" />
+            <EmptyCard title={publishedTagFilter === "all" ? "还没有已发布的稿件" : "这个标签下还没有已发布稿件"} />
           ) : (
             <>
               <div className="space-y-3">
@@ -1491,6 +1511,8 @@ function ReviewCard({
           <span>QQ {authorQq}</span>
         </div>
 
+        <PostTagsInline tags={post.tags} />
+
         <PostTextBlock text={post.text} createdAt={post.createdAt} updatedAt={post.updatedAt} compact {...(cardTextColor ? { textColor: cardTextColor } : {})} />
 
         {images.length > 0 ? <ImageGallery images={images} compact onImageClick={onImagePreview} /> : null}
@@ -1649,6 +1671,8 @@ function PostCard({
           }
         />
 
+        <PostTagsInline tags={post.tags} />
+
         <PostTextBlock text={post.text} createdAt={post.createdAt} compact {...(cardTextColor ? { textColor: cardTextColor } : {})} />
 
         {images.length > 0 ? <ImageGallery images={images} compact onImageClick={onImagePreview} /> : null}
@@ -1779,6 +1803,58 @@ function FollowButton({ following, busy, onClick }: { following: boolean; busy: 
   );
 }
 
+function PostTagsInline({ tags }: { tags?: AssignedPostTag[] | undefined }) {
+  if (!tags || tags.length === 0) {
+    return null;
+  }
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {tags.map((tag) => (
+        <span
+          key={tag.id}
+          className="inline-flex min-h-6 items-center rounded-full border border-slate-200 px-2 text-[11px] font-bold text-slate-700"
+          style={{ backgroundColor: tag.color || "#f8fafc" }}
+          title={tag.description ?? tag.name}
+        >
+          {tag.name}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function PublishedTagFilter({ tags, value, onChange }: { tags: PostTag[]; value: string; onChange: (value: string) => void }) {
+  return (
+    <div className="mb-3 flex gap-2 overflow-x-auto pb-1">
+      <button
+        type="button"
+        className={`inline-flex min-h-8 shrink-0 items-center gap-1 rounded-full border px-3 text-xs font-bold transition-colors ${
+          value === "all" ? "border-slate-800 bg-slate-800 text-white" : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
+        }`}
+        onClick={() => onChange("all")}
+      >
+        <HashIcon className="size-3.5" />
+        全部
+      </button>
+      {tags.map((tag) => (
+        <button
+          key={tag.id}
+          type="button"
+          className={`inline-flex min-h-8 shrink-0 items-center gap-1 rounded-full border px-3 text-xs font-bold transition-colors ${
+            value === tag.id ? "border-slate-800 bg-slate-800 text-white" : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
+          }`}
+          onClick={() => onChange(tag.id)}
+          title={tag.description ?? tag.name}
+        >
+          <span className="size-2 rounded-full" style={{ backgroundColor: tag.color || "#cbd5e1" }} />
+          {tag.name}
+          {typeof tag.postCount === "number" ? <span className="text-[10px] opacity-70">{tag.postCount}</span> : null}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 function PublishedFeedAuthorLine({ post, canViewIdentity }: { post: PublishedFeedItem["posts"][number]; canViewIdentity: boolean }) {
   // 后端已脱敏：普通用户看匿名稿件时 author 为 null。
   if (post.author === null) {
@@ -1818,6 +1894,7 @@ function PublishedFeedPostBlock({
         <span className="inline-flex items-center rounded bg-sky-50 px-1.5 py-0.5 text-xs font-bold text-sky-700">稿件 {post.displayId}</span>
       </div>
       <PublishedFeedAuthorLine post={post} canViewIdentity={canViewIdentity} />
+      <PostTagsInline tags={post.tags} />
       <PostTextBlock text={post.text} createdAt={post.createdAt} {...(cardTextColor ? { textColor: cardTextColor } : {})} />
       {images.length > 0 ? (
         <ImageGallery images={images} compact onImageClick={(imgs, index) => onImagePreview(imgs, index, `稿件 ${post.displayId} 上传图片`)} />

--- a/apps/web/src/features/shell/AppShell.tsx
+++ b/apps/web/src/features/shell/AppShell.tsx
@@ -1,4 +1,4 @@
-import type { AdminTab, AuthenticatedMe, MainTab, Pagination, PendingAttachment, PostItem, PostsTab, TenantMetadata } from "@/types/app";
+import type { AdminTab, AuthenticatedMe, MainTab, Pagination, PendingAttachment, PostItem, PostTag, PostsTab, TenantMetadata } from "@/types/app";
 import type { NavItem } from "@/lib/app-model";
 import { AdminPage } from "@/features/admin/AdminPage";
 import { PostPage } from "@/features/posts/PostPage";
@@ -23,6 +23,9 @@ export function AppShell({
   postBgColor,
   postTextColor,
   postFont,
+  postTags,
+  selectedPostTagIds,
+  selectedPostTagNames,
   postsTab,
   postsPagination,
   anonymous,
@@ -35,6 +38,8 @@ export function AppShell({
   onBgColorChange,
   onTextColorChange,
   onFontChange,
+  onSelectedPostTagIdsChange,
+  onSelectedPostTagNamesChange,
   onFilesSelected,
   onLogout,
   onOpenOps,
@@ -63,6 +68,9 @@ export function AppShell({
   postBgColor: string;
   postTextColor: string;
   postFont: string;
+  postTags: PostTag[];
+  selectedPostTagIds: string[];
+  selectedPostTagNames: string[];
   postsTab: PostsTab;
   postsPagination: Pagination;
   anonymous: boolean;
@@ -75,6 +83,8 @@ export function AppShell({
   onBgColorChange: (value: string) => void;
   onTextColorChange: (value: string) => void;
   onFontChange: (value: string) => void;
+  onSelectedPostTagIdsChange: (value: string[]) => void;
+  onSelectedPostTagNamesChange: (value: string[]) => void;
   onFilesSelected: (files: ArrayLike<File> | null) => void;
   onLogout: () => void;
   onOpenOps: (() => void) | undefined;
@@ -117,6 +127,9 @@ export function AppShell({
                 postBgColor={postBgColor}
                 postTextColor={postTextColor}
                 postFont={postFont}
+                postTags={postTags}
+                selectedPostTagIds={selectedPostTagIds}
+                selectedPostTagNames={selectedPostTagNames}
                 anonymous={anonymous}
                 anonymousAvatar={anonymousAvatar}
                 selectedTenant={me.currentTenant}
@@ -126,6 +139,8 @@ export function AppShell({
                 onBgColorChange={onBgColorChange}
                 onTextColorChange={onTextColorChange}
                 onFontChange={onFontChange}
+                onSelectedPostTagIdsChange={onSelectedPostTagIdsChange}
+                onSelectedPostTagNamesChange={onSelectedPostTagNamesChange}
                 onFilesSelected={onFilesSelected}
                 onPostTextChange={onPostTextChange}
                 onSubmit={onSubmitPost}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -44,6 +44,8 @@ export function createPostWithAttachments(
   textColor?: string,
   font?: string,
   anonymousAvatar?: string,
+  tagIds?: string[],
+  tagNames?: string[],
 ): Promise<CreatePostResponse> {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
@@ -96,6 +98,12 @@ export function createPostWithAttachments(
     }
     if (font) {
       formData.append("font", font);
+    }
+    if (tagIds && tagIds.length > 0) {
+      formData.append("tagIds", JSON.stringify(tagIds));
+    }
+    if (tagNames && tagNames.length > 0) {
+      formData.append("tagNames", JSON.stringify(tagNames));
     }
     for (const file of files) {
       formData.append("images", file, file.name);

--- a/apps/web/src/types/app.ts
+++ b/apps/web/src/types/app.ts
@@ -216,6 +216,7 @@ export type PostItem = {
     otherDisplayIds: number[];
     collecting: boolean;
   } | null;
+  tags: AssignedPostTag[];
 };
 
 export type PostTimelineEntry = {
@@ -253,6 +254,7 @@ export type PublishedFeedPost = {
   textColor: string | null;
   font: string | null;
   createdAt: string;
+  tags: AssignedPostTag[];
 };
 
 export type PublishedFeedItem = {
@@ -433,12 +435,34 @@ export type AdminBotAccount = {
 export type AiRules = {
   /** 是否启用私聊投稿 AI 语义收稿 */
   privatePostAiEnabled?: boolean;
+  /** 是否启用投稿后的 LLM 自动打标 */
+  postTaggingEnabled?: boolean;
+  /** 是否启用 LLM 定期维护标签库 */
+  postTagMaintenanceEnabled?: boolean;
   /** 私聊 AI 聚合收稿等待秒数，0 表示不聚合 */
   privatePostAggregateDelaySeconds?: number;
   /** 对话投稿额外触发关键词，如 ["发帖", "吐槽", "表白"] */
   postTriggerKeywords?: string[];
   /** 私聊投稿 AI 语义收稿的完整系统提示词，留空使用内置默认提示词 */
   privatePostPrompt?: string;
+};
+
+export type PostTag = {
+  id: string;
+  name: string;
+  description: string | null;
+  color: string;
+  status: string;
+  source: string;
+  lastUsedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  postCount?: number;
+};
+
+export type AssignedPostTag = PostTag & {
+  assignmentSource: string;
+  confidence: number | null;
 };
 
 export type TenantAiSettings = {

--- a/packages/db/prisma/migrations/20260628143000_add_post_tags/migration.sql
+++ b/packages/db/prisma/migrations/20260628143000_add_post_tags/migration.sql
@@ -1,0 +1,37 @@
+CREATE TABLE "PostTag" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "color" TEXT NOT NULL DEFAULT '#e2e8f0',
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "source" TEXT NOT NULL DEFAULT 'manual',
+    "lastUsedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PostTag_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "PostTagAssignment" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "tagId" TEXT NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'manual',
+    "confidence" DOUBLE PRECISION,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PostTagAssignment_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "PostTag_tenantId_name_key" ON "PostTag"("tenantId", "name");
+CREATE INDEX "PostTag_tenantId_status_updatedAt_idx" ON "PostTag"("tenantId", "status", "updatedAt");
+
+CREATE UNIQUE INDEX "PostTagAssignment_postId_tagId_key" ON "PostTagAssignment"("postId", "tagId");
+CREATE INDEX "PostTagAssignment_tenantId_tagId_idx" ON "PostTagAssignment"("tenantId", "tagId");
+CREATE INDEX "PostTagAssignment_tenantId_postId_idx" ON "PostTagAssignment"("tenantId", "postId");
+
+ALTER TABLE "PostTag" ADD CONSTRAINT "PostTag_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PostTagAssignment" ADD CONSTRAINT "PostTagAssignment_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PostTagAssignment" ADD CONSTRAINT "PostTagAssignment_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "PostTag"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -74,6 +74,7 @@ model Tenant {
   oauthAuthorizationCodes OAuthAuthorizationCode[]
   oauthAccessTokens OAuthAccessToken[]
   posts          Post[]
+  postTags       PostTag[]
   botAccounts    BotAccount[]
   publishTargets PublishTarget[]
   auditLogs      AuditLog[]
@@ -255,11 +256,46 @@ model Post {
   publishAttempts PublishAttempt[]
   qzonePostMetrics QZonePostMetric[]
   follows         PostFollow[]
+  tagAssignments  PostTagAssignment[]
   batchItem       PublishBatchItem?
 
   @@unique([tenantId, displayId])
   @@unique([tenantId, legacyDisplayId])
   @@index([tenantId, status, createdAt])
+}
+
+model PostTag {
+  id          String              @id @default(uuid())
+  tenantId    String
+  name        String
+  description String?
+  color       String              @default("#e2e8f0")
+  status      String              @default("active")
+  source      String              @default("manual")
+  lastUsedAt  DateTime?
+  createdAt   DateTime            @default(now())
+  updatedAt   DateTime            @updatedAt
+  tenant      Tenant              @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  assignments PostTagAssignment[]
+
+  @@unique([tenantId, name])
+  @@index([tenantId, status, updatedAt])
+}
+
+model PostTagAssignment {
+  id         String   @id @default(uuid())
+  tenantId   String
+  postId     String
+  tagId      String
+  source     String   @default("manual")
+  confidence Float?
+  createdAt  DateTime @default(now())
+  post       Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
+  tag        PostTag  @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@unique([postId, tagId])
+  @@index([tenantId, tagId])
+  @@index([tenantId, postId])
 }
 
 model PostFollow {

--- a/packages/db/prisma/schema.sqlite.prisma
+++ b/packages/db/prisma/schema.sqlite.prisma
@@ -76,6 +76,7 @@ model Tenant {
   oauthAuthorizationCodes OAuthAuthorizationCode[]
   oauthAccessTokens OAuthAccessToken[]
   posts          Post[]
+  postTags       PostTag[]
   botAccounts    BotAccount[]
   publishTargets PublishTarget[]
   auditLogs      AuditLog[]
@@ -257,11 +258,46 @@ model Post {
   publishAttempts PublishAttempt[]
   qzonePostMetrics QZonePostMetric[]
   follows         PostFollow[]
+  tagAssignments  PostTagAssignment[]
   batchItem       PublishBatchItem?
 
   @@unique([tenantId, displayId])
   @@unique([tenantId, legacyDisplayId])
   @@index([tenantId, status, createdAt])
+}
+
+model PostTag {
+  id          String              @id @default(uuid())
+  tenantId    String
+  name        String
+  description String?
+  color       String              @default("#e2e8f0")
+  status      String              @default("active")
+  source      String              @default("manual")
+  lastUsedAt  DateTime?
+  createdAt   DateTime            @default(now())
+  updatedAt   DateTime            @updatedAt
+  tenant      Tenant              @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  assignments PostTagAssignment[]
+
+  @@unique([tenantId, name])
+  @@index([tenantId, status, updatedAt])
+}
+
+model PostTagAssignment {
+  id         String   @id @default(uuid())
+  tenantId   String
+  postId     String
+  tagId      String
+  source     String   @default("manual")
+  confidence Float?
+  createdAt  DateTime @default(now())
+  post       Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
+  tag        PostTag  @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@unique([postId, tagId])
+  @@index([tenantId, tagId])
+  @@index([tenantId, postId])
 }
 
 model PostFollow {

--- a/packages/db/prisma/sqlite-baseline.sql
+++ b/packages/db/prisma/sqlite-baseline.sql
@@ -165,6 +165,34 @@ CREATE TABLE "Post" (
 );
 
 -- CreateTable
+CREATE TABLE "PostTag" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "tenantId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "color" TEXT NOT NULL DEFAULT '#e2e8f0',
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "source" TEXT NOT NULL DEFAULT 'manual',
+    "lastUsedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "PostTag_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "PostTagAssignment" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "tenantId" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "tagId" TEXT NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'manual',
+    "confidence" REAL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "PostTagAssignment_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "PostTagAssignment_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "PostTag" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
 CREATE TABLE "PostFollow" (
     "id" TEXT NOT NULL PRIMARY KEY,
     "tenantId" TEXT NOT NULL,
@@ -472,6 +500,21 @@ CREATE UNIQUE INDEX "Post_tenantId_displayId_key" ON "Post"("tenantId", "display
 
 -- CreateIndex
 CREATE UNIQUE INDEX "Post_tenantId_legacyDisplayId_key" ON "Post"("tenantId", "legacyDisplayId");
+
+-- CreateIndex
+CREATE INDEX "PostTag_tenantId_status_updatedAt_idx" ON "PostTag"("tenantId", "status", "updatedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PostTag_tenantId_name_key" ON "PostTag"("tenantId", "name");
+
+-- CreateIndex
+CREATE INDEX "PostTagAssignment_tenantId_tagId_idx" ON "PostTagAssignment"("tenantId", "tagId");
+
+-- CreateIndex
+CREATE INDEX "PostTagAssignment_tenantId_postId_idx" ON "PostTagAssignment"("tenantId", "postId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PostTagAssignment_postId_tagId_key" ON "PostTagAssignment"("postId", "tagId");
 
 -- CreateIndex
 CREATE INDEX "PostFollow_userId_idx" ON "PostFollow"("userId");

--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -145,6 +145,7 @@ export type RenderPostCardInput = {
   bgColor?: string | null;
   textColor?: string | null;
   font?: string | null;
+  tags?: Array<{ name: string; color?: string | null }> | null;
 };
 
 let browserPromise: Promise<Browser> | null = null;
@@ -289,6 +290,7 @@ async function renderPostHtml(input: RenderPostCardInput) {
   const bgColor = resolveBgColor(input.bgColor);
   const textColor = resolveTextColor(input.textColor);
   const font = input.font && input.font !== "default" ? input.font : null;
+  const tagsHtml = renderTagsHtml(input.tags);
 
   return `<!DOCTYPE html>
 <html>
@@ -489,6 +491,22 @@ async function renderPostHtml(input: RenderPostCardInput) {
       letter-spacing: 0.05rem;
     }
 
+    .post-tag {
+      flex: none;
+      display: inline-flex;
+      align-items: center;
+      max-width: 14rem;
+      padding: 0.2rem 0.8rem;
+      border-radius: 999px;
+      background: #F1F5F9;
+      color: #334155;
+      font-size: 1.7rem;
+      font-weight: 700;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
     #bg-fixed-br {
       position: fixed;
       top: -120px;
@@ -517,6 +535,7 @@ async function renderPostHtml(input: RenderPostCardInput) {
   <div id="footer">
     <span style="display: flex; align-items: center; gap: 1.2rem;">
       ${postIdTag ? `<span id="post-id-tag">${escapeHtml(postIdTag)}</span>` : ""}
+      ${tagsHtml}
       <span>${escapeHtml(footer)}</span>
     </span>
     <span>${escapeHtml(displayHost)}</span>
@@ -541,6 +560,25 @@ function normalizeDisplayHost(value: string | null | undefined) {
     return "https://campux.top";
   }
   return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+}
+
+function renderTagsHtml(tags: RenderPostCardInput["tags"]) {
+  const normalized = (tags ?? [])
+    .map((tag) => ({
+      name: tag.name.trim(),
+      color: tag.color?.trim() ?? "",
+    }))
+    .filter((tag) => tag.name)
+    .slice(0, 3);
+  if (normalized.length === 0) {
+    return "";
+  }
+  return normalized
+    .map((tag) => {
+      const background = /^#[0-9a-fA-F]{6}$/.test(tag.color) ? tag.color : "#F1F5F9";
+      return `<span class="post-tag" style="background:${background};">${escapeHtml(tag.name)}</span>`;
+    })
+    .join("");
 }
 
 async function qqAvatarDataUrl(qq: string | undefined) {


### PR DESCRIPTION
## Summary
- add tenant-scoped post tags with Prisma models, migrations, SQLite baseline, and tag assignment serialization
- add manual tag selection on post creation plus tag chips/filtering in mine/review/published views
- add LLM auto-tagging after submission and scheduled/manual tag maintenance using existing AI settings
- include tags in published feed and render-card output; retain round corner avatar styling

## Verification
- bun test apps/server/src/lib/post-tags.test.ts apps/server/src/runtime/post-tagging.test.ts apps/server/src/lib/published-feed.test.ts
- bun --cwd apps/server typecheck
- bun --cwd apps/web typecheck
- bun run scripts/generate-sqlite-schema.ts --check
- bun run build
- local API smoke: manual tag creation, LLM auto-tagging, tag maintenance, and published feed tag filtering

## Summary by Sourcery

为租户范围的帖子标签添加全栈支持，包括手动选择、LLM 自动打标与维护、支持标签的 feed 与渲染，以及管理端控制。

New Features:
- 引入租户范围的帖子标签，在创建帖子时可手动选择，并在审核卡片与已发布帖子卡片中展示。
- 通过新的服务器路由和后台调度器暴露帖子标签列表以及基于 AI 的标签维护/自动打标功能，可在管理端的 AI 设置中进行配置。
- 为已发布帖子 feed 和 UI 添加基于标签的筛选功能，包括按标签的 chips 与计数，并在 render-card 的输出中包含标签。

Enhancements:
- 扩展帖子创建、发布和 feed 序列化管线，使标签分配在端到端流程中传递，包括 Prisma 模型、迁移以及 SQLite 基线更新。

Tests:
- 为已发布 feed 的标签筛选、服务端帖子标签逻辑及 LLM 集成添加单元测试，并增加新的迁移覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add full-stack support for tenant-scoped post tags, including manual selection, LLM auto-tagging and maintenance, tag-aware feeds and rendering, and admin controls.

New Features:
- Introduce tenant-scoped post tags with manual selection during post creation and display in review and published post cards.
- Expose post tag lists and AI-driven tag maintenance/auto-tagging via new server routes and background scheduler, configurable through admin AI settings.
- Add tag-based filtering to the published posts feed and UI, including per-tag chips and counts, and include tags in the render-card output.

Enhancements:
- Extend post creation, publishing, and feed serialization pipelines to carry tag assignments end-to-end, including Prisma models, migrations, and SQLite baseline updates.

Tests:
- Add unit tests for published feed tag filtering and server-side post tag logic and LLM integration, alongside new migration coverage.

</details>