### PR TITLE
fix(posts): 修复默认字体误触发自动封禁

### DIFF
--- a/apps/server/src/lib/sanitize.test.ts
+++ b/apps/server/src/lib/sanitize.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { detectPostInjection, validateFont } from "./sanitize";
+
+describe("validateFont", () => {
+  test("accepts empty and default font values", () => {
+    expect(validateFont(undefined)).toBe(true);
+    expect(validateFont(null)).toBe(true);
+    expect(validateFont("")).toBe(true);
+    expect(validateFont("default")).toBe(true);
+  });
+
+  test("rejects unknown font values", () => {
+    expect(validateFont("Comic Sans MS")).toBe(false);
+  });
+});
+
+describe("detectPostInjection font validation", () => {
+  test("does not flag the default font as unsafe", () => {
+    expect(detectPostInjection({ text: "正常投稿", font: "default" })).toEqual({ detected: false });
+  });
+
+  test("flags unknown font values as unsafe", () => {
+    expect(detectPostInjection({ text: "正常投稿", font: "Comic Sans MS" })).toEqual({
+      detected: true,
+      type: "css_injection",
+      reason: "不允许的字体：Comic Sans MS",
+    });
+  });
+});

--- a/apps/server/src/lib/sanitize.test.ts
+++ b/apps/server/src/lib/sanitize.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { postFontDefault } from "@campux/domain";
 import { detectPostInjection, validateFont } from "./sanitize";
 
 describe("validateFont", () => {
@@ -6,7 +7,7 @@ describe("validateFont", () => {
     expect(validateFont(undefined)).toBe(true);
     expect(validateFont(null)).toBe(true);
     expect(validateFont("")).toBe(true);
-    expect(validateFont("default")).toBe(true);
+    expect(validateFont(postFontDefault)).toBe(true);
   });
 
   test("rejects unknown font values", () => {
@@ -16,7 +17,7 @@ describe("validateFont", () => {
 
 describe("detectPostInjection font validation", () => {
   test("does not flag the default font as unsafe", () => {
-    expect(detectPostInjection({ text: "正常投稿", font: "default" })).toEqual({ detected: false });
+    expect(detectPostInjection({ text: "正常投稿", font: postFontDefault })).toEqual({ detected: false });
   });
 
   test("flags unknown font values as unsafe", () => {

--- a/apps/server/src/lib/sanitize.ts
+++ b/apps/server/src/lib/sanitize.ts
@@ -1,4 +1,5 @@
 import { URL } from "node:url";
+import { isDefaultFont } from "@campux/domain";
 import { prisma } from "./prisma";
 
 // ── 允许的背景色名称 ──────────────────────────────────
@@ -220,9 +221,8 @@ export function validateTextColor(value: string | null | undefined): boolean {
 }
 
 export function validateFont(value: string | null | undefined): boolean {
-  if (!value) return true;
-  if (value === "default") return true;
-  return ALLOWED_FONTS.has(value);
+  if (isDefaultFont(value)) return true;
+  return typeof value === "string" && ALLOWED_FONTS.has(value);
 }
 
 /**

--- a/apps/server/src/lib/sanitize.ts
+++ b/apps/server/src/lib/sanitize.ts
@@ -221,6 +221,7 @@ export function validateTextColor(value: string | null | undefined): boolean {
 
 export function validateFont(value: string | null | undefined): boolean {
   if (!value) return true;
+  if (value === "default") return true;
   return ALLOWED_FONTS.has(value);
 }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -473,7 +473,7 @@ export function App() {
         remoteGifUrls.length > 0 ? remoteGifUrls : undefined,
         postBgColor || undefined,
         postTextColor || undefined,
-        postFont || undefined,
+        postFont && postFont !== "default" ? postFont : undefined,
         anonymousAvatar || undefined,
       );
       clearAttachments();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { TenantSummary } from "@campux/domain";
 import { toast } from "sonner";
-import { api, createPostWithAttachments, CreatePostError, normalizePostFont } from "@/lib/api";
+import { api, createPostWithAttachments, CreatePostError } from "@/lib/api";
 import { canAccess, defaultMetadata, navItems } from "@/lib/app-model";
 import { readQueryInt, writeQueryParams } from "@/lib/url-query";
 import type { ActiveBan, AdminTab, AuthenticatedMe, CurrentMembership, MainTab, MeResponse, OAuthAuthorizeClientResponse, Pagination, PostItem, PostsTab, TenantMetadata } from "@/types/app";
@@ -473,7 +473,7 @@ export function App() {
         remoteGifUrls.length > 0 ? remoteGifUrls : undefined,
         postBgColor || undefined,
         postTextColor || undefined,
-        normalizePostFont(postFont),
+        postFont || undefined,
         anonymousAvatar || undefined,
       );
       clearAttachments();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { TenantSummary } from "@campux/domain";
 import { toast } from "sonner";
-import { api, createPostWithAttachments, CreatePostError } from "@/lib/api";
+import { api, createPostWithAttachments, CreatePostError, normalizePostFont } from "@/lib/api";
 import { canAccess, defaultMetadata, navItems } from "@/lib/app-model";
 import { readQueryInt, writeQueryParams } from "@/lib/url-query";
 import type { ActiveBan, AdminTab, AuthenticatedMe, CurrentMembership, MainTab, MeResponse, OAuthAuthorizeClientResponse, Pagination, PostItem, PostsTab, TenantMetadata } from "@/types/app";
@@ -473,7 +473,7 @@ export function App() {
         remoteGifUrls.length > 0 ? remoteGifUrls : undefined,
         postBgColor || undefined,
         postTextColor || undefined,
-        postFont && postFont !== "default" ? postFont : undefined,
+        normalizePostFont(postFont),
         anonymousAvatar || undefined,
       );
       clearAttachments();

--- a/apps/web/src/features/posts/PostPage.tsx
+++ b/apps/web/src/features/posts/PostPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { ClipboardEvent } from "react";
 import type { TenantSummary } from "@campux/domain";
-import { FONT_OPTIONS } from "@campux/domain";
+import { FONT_OPTIONS, isDefaultFont } from "@campux/domain";
 import { ChevronDownIcon, ImagePlusIcon, LoaderIcon, MegaphoneIcon, SendIcon } from "lucide-react";
 import { defaultMetadata } from "@/lib/app-model";
 import type { PendingAttachment, TenantMetadata } from "@/types/app";
@@ -85,7 +85,7 @@ export function PostPage({
   const sortedAttachments = [...pendingAttachments].sort((left, right) => left.sortOrder - right.sortOrder);
   const hasConverting = pendingAttachments.some((p) => p.status === "converting");
   const hasUploading = pendingAttachments.some((p) => p.status === "uploading");
-  const hasNonDefaultFont = postFont && postFont !== "default";
+  const hasNonDefaultFont = !isDefaultFont(postFont);
 
   useEffect(() => {
     if (metadata.enableAnonymousAvatarSelection) {
@@ -373,7 +373,7 @@ export function PostPage({
                             : "border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50"
                         }`}
                         onClick={() => onFontChange(postFont === opt.value ? "" : opt.value)}
-                        style={opt.value !== "default" && postFont === opt.value ? { fontFamily: opt.value } : {}}
+                        style={!isDefaultFont(opt.value) && postFont === opt.value ? { fontFamily: opt.value } : {}}
                       >
                         {opt.label}
                       </button>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,3 +1,4 @@
+import { isDefaultFont } from "@campux/domain";
 import type { PostItem } from "../types/app";
 
 export async function api<T>(path: string, options: RequestInit = {}) {
@@ -33,6 +34,10 @@ export class CreatePostError extends Error {
 export type CreatePostResponse = {
   post: PostItem;
 };
+
+export function normalizePostFont(font: string | null | undefined): string | undefined {
+  return font && !isDefaultFont(font) ? font : undefined;
+}
 
 export function createPostWithAttachments(
   text: string,
@@ -94,8 +99,9 @@ export function createPostWithAttachments(
     if (textColor) {
       formData.append("textColor", textColor);
     }
-    if (font && font !== "default") {
-      formData.append("font", font);
+    const normalizedFont = normalizePostFont(font);
+    if (normalizedFont) {
+      formData.append("font", normalizedFont);
     }
     for (const file of files) {
       formData.append("images", file, file.name);

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -94,7 +94,7 @@ export function createPostWithAttachments(
     if (textColor) {
       formData.append("textColor", textColor);
     }
-    if (font) {
+    if (font && font !== "default") {
       formData.append("font", font);
     }
     for (const file of files) {

--- a/packages/domain/src/fonts.ts
+++ b/packages/domain/src/fonts.ts
@@ -14,7 +14,7 @@ export type PostFont = z.infer<typeof postFontSchema>;
 export const postFontDefault = "default";
 
 export const FONT_OPTIONS: Array<{ value: PostFont; label: string; fileName: string }> = [
-  { value: "default", label: "默认字体", fileName: "" },
+  { value: postFontDefault, label: "默认字体", fileName: "" },
   { value: "beinidekeaitianyunle", label: "贝尼的可爱云乐体", fileName: "beinidekeaitianyunle.ttf" },
   { value: "dunhuangfeitiankai", label: "敦煌飞天楷", fileName: "dunhuangfeitiankai.ttf" },
   { value: "mengxiangchaoyanningti", label: "梦想超妍宁体", fileName: "mengxiangchaoyanningti.ttf" },
@@ -24,9 +24,9 @@ export const FONT_OPTIONS: Array<{ value: PostFont; label: string; fileName: str
 ];
 
 export const FONT_FILE_MAP: Record<string, string> = Object.fromEntries(
-  FONT_OPTIONS.filter((f) => f.value !== "default").map((f) => [f.value, f.fileName]),
+  FONT_OPTIONS.filter((f) => f.value !== postFontDefault).map((f) => [f.value, f.fileName]),
 );
 
 export function isDefaultFont(font: string | null | undefined): boolean {
-  return !font || font === "default";
+  return !font || font === postFontDefault;
 }


### PR DESCRIPTION
## 变更

- 后端字体安全校验将 `default` 视为合法默认字体，不再触发“不允许的字体：default”。
- 前端提交投稿时不再发送 `font=default`，默认字体按未选择自定义字体处理。
- 新增 `sanitize` 单测，覆盖默认字体、空字体和未知字体的校验行为。

## 原因

校园墙开启字体选择后，用户点选“默认字体”会提交 `font=default`。领域模型中 `default` 是合法默认值，但后端注入防护白名单只包含自定义字体，导致默认值被误判为 CSS 注入并自动封禁 24 小时。

## 验证

- `bun test apps/server/src/lib/sanitize.test.ts`
- `bun --cwd apps/web typecheck`
- `bun run db:generate`
- `bun --cwd apps/server typecheck`
- `git diff --check`

## Summary by Sourcery

在域、Web 和服务器各层中将默认帖子字体视为安全的非自定义字体，以防止在用户选择默认字体时出现误报的 CSS 注入封禁。

Bug Fixes:
- 确保后端的字体清理逻辑接受默认字体值，并不再将其标记为不安全的 CSS 注入。
- 阻止 Web 客户端发送显式的默认字体值，使默认选择被视为“无自定义字体”。

Enhancements:
- 将默认字体处理逻辑集中到共享的域模块中，并在客户端和服务器上复用 `isDefaultFont` 辅助方法。

Tests:
- 为字体清理和注入检测添加单元测试，覆盖默认、空以及未知字体值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Treat the default post font as a safe, non-custom font across domain, web, and server layers to prevent false CSS injection bans when users select the default font.

Bug Fixes:
- Ensure backend font sanitization accepts the default font value and no longer flags it as an unsafe CSS injection.
- Stop the web client from sending an explicit default font value so default selections are treated as no custom font.

Enhancements:
- Centralize default font handling in the shared domain module and reuse the isDefaultFont helper on both client and server.

Tests:
- Add unit tests for font sanitization and injection detection to cover default, empty, and unknown font values.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在域、Web 和服务器各层中将默认帖子字体视为安全的非自定义字体，以防止在用户选择默认字体时出现误报的 CSS 注入封禁。

Bug Fixes:
- 确保后端的字体清理逻辑接受默认字体值，并不再将其标记为不安全的 CSS 注入。
- 阻止 Web 客户端发送显式的默认字体值，使默认选择被视为“无自定义字体”。

Enhancements:
- 将默认字体处理逻辑集中到共享的域模块中，并在客户端和服务器上复用 `isDefaultFont` 辅助方法。

Tests:
- 为字体清理和注入检测添加单元测试，覆盖默认、空以及未知字体值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Treat the default post font as a safe, non-custom font across domain, web, and server layers to prevent false CSS injection bans when users select the default font.

Bug Fixes:
- Ensure backend font sanitization accepts the default font value and no longer flags it as an unsafe CSS injection.
- Stop the web client from sending an explicit default font value so default selections are treated as no custom font.

Enhancements:
- Centralize default font handling in the shared domain module and reuse the isDefaultFont helper on both client and server.

Tests:
- Add unit tests for font sanitization and injection detection to cover default, empty, and unknown font values.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在域、Web 和服务器各层中将默认帖子字体视为安全的非自定义字体，以防止在用户选择默认字体时出现误报的 CSS 注入封禁。

Bug Fixes:
- 确保后端的字体清理逻辑接受默认字体值，并不再将其标记为不安全的 CSS 注入。
- 阻止 Web 客户端发送显式的默认字体值，使默认选择被视为“无自定义字体”。

Enhancements:
- 将默认字体处理逻辑集中到共享的域模块中，并在客户端和服务器上复用 `isDefaultFont` 辅助方法。

Tests:
- 为字体清理和注入检测添加单元测试，覆盖默认、空以及未知字体值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Treat the default post font as a safe, non-custom font across domain, web, and server layers to prevent false CSS injection bans when users select the default font.

Bug Fixes:
- Ensure backend font sanitization accepts the default font value and no longer flags it as an unsafe CSS injection.
- Stop the web client from sending an explicit default font value so default selections are treated as no custom font.

Enhancements:
- Centralize default font handling in the shared domain module and reuse the isDefaultFont helper on both client and server.

Tests:
- Add unit tests for font sanitization and injection detection to cover default, empty, and unknown font values.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在域、Web 和服务器各层中将默认帖子字体视为安全的非自定义字体，以防止在用户选择默认字体时出现误报的 CSS 注入封禁。

Bug Fixes:
- 确保后端的字体清理逻辑接受默认字体值，并不再将其标记为不安全的 CSS 注入。
- 阻止 Web 客户端发送显式的默认字体值，使默认选择被视为“无自定义字体”。

Enhancements:
- 将默认字体处理逻辑集中到共享的域模块中，并在客户端和服务器上复用 `isDefaultFont` 辅助方法。

Tests:
- 为字体清理和注入检测添加单元测试，覆盖默认、空以及未知字体值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Treat the default post font as a safe, non-custom font across domain, web, and server layers to prevent false CSS injection bans when users select the default font.

Bug Fixes:
- Ensure backend font sanitization accepts the default font value and no longer flags it as an unsafe CSS injection.
- Stop the web client from sending an explicit default font value so default selections are treated as no custom font.

Enhancements:
- Centralize default font handling in the shared domain module and reuse the isDefaultFont helper on both client and server.

Tests:
- Add unit tests for font sanitization and injection detection to cover default, empty, and unknown font values.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在域、Web 和服务器各层中将默认帖子字体视为安全的非自定义字体，以防止在用户选择默认字体时出现误报的 CSS 注入封禁。

Bug Fixes:
- 确保后端的字体清理逻辑接受默认字体值，并不再将其标记为不安全的 CSS 注入。
- 阻止 Web 客户端发送显式的默认字体值，使默认选择被视为“无自定义字体”。

Enhancements:
- 将默认字体处理逻辑集中到共享的域模块中，并在客户端和服务器上复用 `isDefaultFont` 辅助方法。

Tests:
- 为字体清理和注入检测添加单元测试，覆盖默认、空以及未知字体值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Treat the default post font as a safe, non-custom font across domain, web, and server layers to prevent false CSS injection bans when users select the default font.

Bug Fixes:
- Ensure backend font sanitization accepts the default font value and no longer flags it as an unsafe CSS injection.
- Stop the web client from sending an explicit default font value so default selections are treated as no custom font.

Enhancements:
- Centralize default font handling in the shared domain module and reuse the isDefaultFont helper on both client and server.

Tests:
- Add unit tests for font sanitization and injection detection to cover default, empty, and unknown font values.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在域、Web 和服务器各层中将默认帖子字体视为安全的非自定义字体，以防止在用户选择默认字体时出现误报的 CSS 注入封禁。

Bug Fixes:
- 确保后端的字体清理逻辑接受默认字体值，并不再将其标记为不安全的 CSS 注入。
- 阻止 Web 客户端发送显式的默认字体值，使默认选择被视为“无自定义字体”。

Enhancements:
- 将默认字体处理逻辑集中到共享的域模块中，并在客户端和服务器上复用 `isDefaultFont` 辅助方法。

Tests:
- 为字体清理和注入检测添加单元测试，覆盖默认、空以及未知字体值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Treat the default post font as a safe, non-custom font across domain, web, and server layers to prevent false CSS injection bans when users select the default font.

Bug Fixes:
- Ensure backend font sanitization accepts the default font value and no longer flags it as an unsafe CSS injection.
- Stop the web client from sending an explicit default font value so default selections are treated as no custom font.

Enhancements:
- Centralize default font handling in the shared domain module and reuse the isDefaultFont helper on both client and server.

Tests:
- Add unit tests for font sanitization and injection detection to cover default, empty, and unknown font values.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在域、Web 和服务器各层中将默认帖子字体视为安全的非自定义字体，以防止在用户选择默认字体时出现误报的 CSS 注入封禁。

Bug Fixes:
- 确保后端的字体清理逻辑接受默认字体值，并不再将其标记为不安全的 CSS 注入。
- 阻止 Web 客户端发送显式的默认字体值，使默认选择被视为“无自定义字体”。

Enhancements:
- 将默认字体处理逻辑集中到共享的域模块中，并在客户端和服务器上复用 `isDefaultFont` 辅助方法。

Tests:
- 为字体清理和注入检测添加单元测试，覆盖默认、空以及未知字体值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Treat the default post font as a safe, non-custom font across domain, web, and server layers to prevent false CSS injection bans when users select the default font.

Bug Fixes:
- Ensure backend font sanitization accepts the default font value and no longer flags it as an unsafe CSS injection.
- Stop the web client from sending an explicit default font value so default selections are treated as no custom font.

Enhancements:
- Centralize default font handling in the shared domain module and reuse the isDefaultFont helper on both client and server.

Tests:
- Add unit tests for font sanitization and injection detection to cover default, empty, and unknown font values.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在域、Web 和服务器各层中将默认帖子字体视为安全的非自定义字体，以防止在用户选择默认字体时出现误报的 CSS 注入封禁。

Bug Fixes:
- 确保后端的字体清理逻辑接受默认字体值，并不再将其标记为不安全的 CSS 注入。
- 阻止 Web 客户端发送显式的默认字体值，使默认选择被视为“无自定义字体”。

Enhancements:
- 将默认字体处理逻辑集中到共享的域模块中，并在客户端和服务器上复用 `isDefaultFont` 辅助方法。

Tests:
- 为字体清理和注入检测添加单元测试，覆盖默认、空以及未知字体值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Treat the default post font as a safe, non-custom font across domain, web, and server layers to prevent false CSS injection bans when users select the default font.

Bug Fixes:
- Ensure backend font sanitization accepts the default font value and no longer flags it as an unsafe CSS injection.
- Stop the web client from sending an explicit default font value so default selections are treated as no custom font.

Enhancements:
- Centralize default font handling in the shared domain module and reuse the isDefaultFont helper on both client and server.

Tests:
- Add unit tests for font sanitization and injection detection to cover default, empty, and unknown font values.

</details>

</details>

</details>

</details>