### PR TITLE
Fix/anonymous avatar publish regression

### DIFF
--- a/apps/server/src/lib/svg-avatars.ts
+++ b/apps/server/src/lib/svg-avatars.ts
@@ -4,10 +4,10 @@ import path from "node:path";
 /**
  * Resolve the project root by walking up from this file's location.
  * This file: apps/server/src/lib/svg-avatars.ts
- * Project root: apps/server/src/lib/../../..
+ * Project root: apps/server/src/lib/../../../..
  */
 function resolveProjectRoot(): string {
-  return path.resolve(import.meta.dirname!, "..", "..", "..");
+  return path.resolve(import.meta.dirname!, "..", "..", "..", "..");
 }
 
 function resolveSvgDir(): string {
@@ -25,7 +25,7 @@ export function listSvgAvatars(): string[] {
   const svgDir = resolveSvgDir();
   try {
     const files = readdirSync(svgDir);
-    return files.filter((f) => f.endsWith(".svg")).sort();
+    return files.filter((file: string) => file.endsWith(".svg")).sort();
   } catch {
     return [];
   }

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -103,7 +103,7 @@ export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string
     select: {
       id: true,
       status: true,
-      attempts: {
+      publishAttempts: {
         select: {
           id: true,
           status: true,
@@ -120,7 +120,7 @@ export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string
     return [];
   }
 
-  const hasActiveOrSucceededAttempt = post.attempts.some((attempt: { status: string }) =>
+  const hasActiveOrSucceededAttempt = post.publishAttempts.some((attempt: { status: string }) =>
     attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
   );
   if (hasActiveOrSucceededAttempt) {

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -96,6 +96,37 @@ export async function recoverPublishAttempts(queue: RuntimeQueue, logger: Fastif
 }
 
 export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string, postId: string, actorId?: string | null) {
+  const post = await prisma.post.findUnique({
+    where: {
+      id: postId,
+    },
+    select: {
+      id: true,
+      status: true,
+      attempts: {
+        select: {
+          id: true,
+          status: true,
+        },
+      },
+    },
+  });
+
+  if (!post) {
+    return [];
+  }
+
+  if (post.status === "published") {
+    return [];
+  }
+
+  const hasActiveOrSucceededAttempt = post.attempts.some((attempt: { status: string }) =>
+    attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
+  );
+  if (hasActiveOrSucceededAttempt) {
+    return [];
+  }
+
   const targets = await prisma.publishTarget.findMany({
     where: {
       tenantId,
@@ -172,6 +203,12 @@ export async function enqueueBatchPublishFanout(queue: RuntimeQueue, tenantId: s
   const batch = await prisma.publishBatch.findUnique({
     where: { id: batchId },
     include: {
+      attempts: {
+        select: {
+          id: true,
+          status: true,
+        },
+      },
       items: {
         orderBy: { position: "asc" },
         select: { postId: true },
@@ -180,6 +217,17 @@ export async function enqueueBatchPublishFanout(queue: RuntimeQueue, tenantId: s
   });
 
   if (!batch || batch.items.length === 0) {
+    return [];
+  }
+
+  if (batch.status === "published") {
+    return [];
+  }
+
+  const hasActiveOrSucceededAttempt = batch.attempts.some((attempt: { status: string }) =>
+    attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
+  );
+  if (hasActiveOrSucceededAttempt) {
     return [];
   }
 
@@ -577,6 +625,49 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
     });
     await refreshAttemptPostStatuses(attempt);
     return;
+  }
+
+  if (!attempt.batch) {
+    if (attempt.post.status === "published") {
+      await prisma.publishAttempt.update({
+        where: {
+          id: attempt.id,
+        },
+        data: {
+          status: "skipped",
+          lastError: "稿件已发布，跳过重复任务",
+        },
+      });
+      await refreshAttemptPostStatuses(attempt);
+      return;
+    }
+
+    const hasSucceededSibling = await prisma.publishAttempt.findFirst({
+      where: {
+        postId: attempt.postId,
+        publishTargetId: attempt.publishTargetId,
+        status: "succeeded",
+        id: {
+          not: attempt.id,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+    if (hasSucceededSibling) {
+      await prisma.publishAttempt.update({
+        where: {
+          id: attempt.id,
+        },
+        data: {
+          status: "skipped",
+          lastError: "发布目标已有成功记录，跳过重复任务",
+        },
+      });
+      await refreshAttemptPostStatuses(attempt);
+      return;
+    }
   }
 
   try {


### PR DESCRIPTION
## Summary

This PR fixes two regressions in the post publishing flow:

1. Restore anonymous avatar preset loading by resolving SVG assets from the repository root `svg/` directory.
2. Avoid duplicate publishing by adding idempotency guards in publish fanout and publish worker execution.

## Details

- Fix incorrect SVG asset root resolution for anonymous avatar presets
- Prevent duplicate publish task fanout for already-published posts or posts with active/succeeded attempts
- Skip duplicate worker execution when the same target already has a succeeded publish record
- Fix Prisma relation usage from `attempts` to `publishAttempts` in publishing runtime

## Validation

- Branch build passed after fixing the Prisma relation field used in CI
- Latest fix included in commit `b3df181`

## Summary by Sourcery

为帖子和批量发布流程添加幂等性保护，并修复匿名头像 SVG 资源解析问题。

Bug 修复：
- 防止对已发布或已有进行中/成功发布尝试的帖子或批次重复触发发布分发。
- 当某个帖子目标已经存在成功的发布尝试时，跳过多余的发布 worker 执行。
- 在发布运行时中纠正用于批量发布尝试的 Prisma 关系用法。
- 修复从仓库根目录加载匿名头像 SVG 资源时的项目根路径解析问题。

改进：
- 在从解析后的 SVG 目录读取预设文件时收紧 SVG 头像的列出逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add idempotency safeguards to post and batch publishing flows and fix anonymous avatar SVG asset resolution.

Bug Fixes:
- Prevent duplicate publish fanout for posts or batches that are already published or have active/succeeded attempts.
- Skip redundant publish worker execution when a post target already has a successful publish attempt.
- Correct Prisma relation usage for batch publish attempts in the publishing runtime.
- Fix project root resolution for loading anonymous avatar SVG assets from the repository root directory.

Enhancements:
- Tighten SVG avatar listing logic while reading preset files from the resolved SVG directory.

</details>