### PR TITLE
Fix/anonymous avatar publish regression

### DIFF
--- a/apps/server/src/lib/svg-avatars.ts
+++ b/apps/server/src/lib/svg-avatars.ts
@@ -4,10 +4,10 @@ import path from "node:path";
 /**
  * Resolve the project root by walking up from this file's location.
  * This file: apps/server/src/lib/svg-avatars.ts
- * Project root: apps/server/src/lib/../../..
+ * Project root: apps/server/src/lib/../../../..
  */
 function resolveProjectRoot(): string {
-  return path.resolve(import.meta.dirname!, "..", "..", "..");
+  return path.resolve(import.meta.dirname!, "..", "..", "..", "..");
 }
 
 function resolveSvgDir(): string {
@@ -25,7 +25,7 @@ export function listSvgAvatars(): string[] {
   const svgDir = resolveSvgDir();
   try {
     const files = readdirSync(svgDir);
-    return files.filter((f) => f.endsWith(".svg")).sort();
+    return files.filter((file: string) => file.endsWith(".svg")).sort();
   } catch {
     return [];
   }

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -19,6 +19,13 @@ import type { RuntimeJob, RuntimeQueue } from "./queue";
 const maxPublishAttempts = 3;
 export const defaultPublishIntervalSeconds = 10;
 
+const activePublishAttemptStatuses = new Set(["queued", "running", "succeeded"]);
+
+const publishSkipReasons = {
+  postAlreadyPublished: "稿件已发布，跳过重复任务",
+  targetAlreadySucceeded: "发布目标已有成功记录，跳过重复任务",
+} as const;
+
 type PublishScheduleClient = typeof prisma | Prisma.TransactionClient;
 
 type PublishingNotifier = {
@@ -34,6 +41,10 @@ type ImagePayload = {
   url?: string;
   fileName?: string;
 };
+
+function hasActiveOrSucceededAttempts(attempts: Array<{ status: string }>) {
+  return attempts.some((attempt) => activePublishAttemptStatuses.has(attempt.status));
+}
 
 export function registerPublishingWorker(queue: RuntimeQueue, logger: FastifyBaseLogger, config: CampuxConfig, notifier?: PublishingNotifier) {
   queue.registerHandler("publishPost", async (job) => {
@@ -120,9 +131,7 @@ export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string
     return [];
   }
 
-  const hasActiveOrSucceededAttempt = post.publishAttempts.some((attempt: { status: string }) =>
-    attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
-  );
+  const hasActiveOrSucceededAttempt = hasActiveOrSucceededAttempts(post.publishAttempts);
   if (hasActiveOrSucceededAttempt) {
     return [];
   }
@@ -224,9 +233,7 @@ export async function enqueueBatchPublishFanout(queue: RuntimeQueue, tenantId: s
     return [];
   }
 
-  const hasActiveOrSucceededAttempt = batch.attempts.some((attempt: { status: string }) =>
-    attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
-  );
+  const hasActiveOrSucceededAttempt = hasActiveOrSucceededAttempts(batch.attempts);
   if (hasActiveOrSucceededAttempt) {
     return [];
   }
@@ -635,7 +642,7 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
         },
         data: {
           status: "skipped",
-          lastError: "稿件已发布，跳过重复任务",
+          lastError: publishSkipReasons.postAlreadyPublished,
         },
       });
       await refreshAttemptPostStatuses(attempt);
@@ -662,7 +669,7 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
         },
         data: {
           status: "skipped",
-          lastError: "发布目标已有成功记录，跳过重复任务",
+          lastError: publishSkipReasons.targetAlreadySucceeded,
         },
       });
       await refreshAttemptPostStatuses(attempt);

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -103,7 +103,7 @@ export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string
     select: {
       id: true,
       status: true,
-      attempts: {
+      publishAttempts: {
         select: {
           id: true,
           status: true,
@@ -120,7 +120,7 @@ export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string
     return [];
   }
 
-  const hasActiveOrSucceededAttempt = post.attempts.some((attempt: { status: string }) =>
+  const hasActiveOrSucceededAttempt = post.publishAttempts.some((attempt: { status: string }) =>
     attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
   );
   if (hasActiveOrSucceededAttempt) {

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -96,6 +96,37 @@ export async function recoverPublishAttempts(queue: RuntimeQueue, logger: Fastif
 }
 
 export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string, postId: string, actorId?: string | null) {
+  const post = await prisma.post.findUnique({
+    where: {
+      id: postId,
+    },
+    select: {
+      id: true,
+      status: true,
+      attempts: {
+        select: {
+          id: true,
+          status: true,
+        },
+      },
+    },
+  });
+
+  if (!post) {
+    return [];
+  }
+
+  if (post.status === "published") {
+    return [];
+  }
+
+  const hasActiveOrSucceededAttempt = post.attempts.some((attempt: { status: string }) =>
+    attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
+  );
+  if (hasActiveOrSucceededAttempt) {
+    return [];
+  }
+
   const targets = await prisma.publishTarget.findMany({
     where: {
       tenantId,
@@ -172,6 +203,12 @@ export async function enqueueBatchPublishFanout(queue: RuntimeQueue, tenantId: s
   const batch = await prisma.publishBatch.findUnique({
     where: { id: batchId },
     include: {
+      attempts: {
+        select: {
+          id: true,
+          status: true,
+        },
+      },
       items: {
         orderBy: { position: "asc" },
         select: { postId: true },
@@ -180,6 +217,17 @@ export async function enqueueBatchPublishFanout(queue: RuntimeQueue, tenantId: s
   });
 
   if (!batch || batch.items.length === 0) {
+    return [];
+  }
+
+  if (batch.status === "published") {
+    return [];
+  }
+
+  const hasActiveOrSucceededAttempt = batch.attempts.some((attempt: { status: string }) =>
+    attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
+  );
+  if (hasActiveOrSucceededAttempt) {
     return [];
   }
 
@@ -577,6 +625,49 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
     });
     await refreshAttemptPostStatuses(attempt);
     return;
+  }
+
+  if (!attempt.batch) {
+    if (attempt.post.status === "published") {
+      await prisma.publishAttempt.update({
+        where: {
+          id: attempt.id,
+        },
+        data: {
+          status: "skipped",
+          lastError: "稿件已发布，跳过重复任务",
+        },
+      });
+      await refreshAttemptPostStatuses(attempt);
+      return;
+    }
+
+    const hasSucceededSibling = await prisma.publishAttempt.findFirst({
+      where: {
+        postId: attempt.postId,
+        publishTargetId: attempt.publishTargetId,
+        status: "succeeded",
+        id: {
+          not: attempt.id,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+    if (hasSucceededSibling) {
+      await prisma.publishAttempt.update({
+        where: {
+          id: attempt.id,
+        },
+        data: {
+          status: "skipped",
+          lastError: "发布目标已有成功记录，跳过重复任务",
+        },
+      });
+      await refreshAttemptPostStatuses(attempt);
+      return;
+    }
   }
 
   try {


### PR DESCRIPTION
fix: restore anonymous avatar presets and avoid duplicate publishing

## Summary by Sourcery

防止对帖子和批次进行重复的发布尝试，并恢复匿名头像预设的正确加载。

Bug 修复：
- 当帖子或批次已经发布，或已有活动/成功的尝试时，跳过加入发布 fanout 队列。
- 当帖子已经发布，或同一目标的兄弟尝试已经成功时，跳过单独的发布尝试。
- 修复 SVG 头像目录解析，使匿名头像预设能够被正确发现。
- 加强 SVG 头像列表处理，可靠地筛选并排序 `.svg` 文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent duplicate publish attempts for posts and batches and restore proper anonymous avatar preset loading.

Bug Fixes:
- Skip enqueuing publish fanout when the post or batch is already published or has active/succeeded attempts.
- Skip individual publish attempts when the post is already published or when a sibling attempt for the same target has already succeeded.
- Fix SVG avatar directory resolution so anonymous avatar presets are correctly discovered.
- Harden SVG avatar listing to reliably filter and sort .svg files.

</details>