### PR TITLE
fix: 更新发布尝试状态管理，避免重复发布

### DIFF
--- a/apps/server/src/lib/svg-avatars.ts
+++ b/apps/server/src/lib/svg-avatars.ts
@@ -4,10 +4,10 @@ import path from "node:path";
 /**
  * Resolve the project root by walking up from this file's location.
  * This file: apps/server/src/lib/svg-avatars.ts
- * Project root: apps/server/src/lib/../../..
+ * Project root: apps/server/src/lib/../../../..
  */
 function resolveProjectRoot(): string {
-  return path.resolve(import.meta.dirname!, "..", "..", "..");
+  return path.resolve(import.meta.dirname!, "..", "..", "..", "..");
 }
 
 function resolveSvgDir(): string {
@@ -25,7 +25,7 @@ export function listSvgAvatars(): string[] {
   const svgDir = resolveSvgDir();
   try {
     const files = readdirSync(svgDir);
-    return files.filter((f) => f.endsWith(".svg")).sort();
+    return files.filter((file: string) => file.endsWith(".svg")).sort();
   } catch {
     return [];
   }

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -19,7 +19,7 @@ import type { RuntimeJob, RuntimeQueue } from "./queue";
 const maxPublishAttempts = 3;
 export const defaultPublishIntervalSeconds = 10;
 
-const activePublishAttemptStatuses = new Set(["queued", "running", "succeeded"]);
+const duplicateBlockingPublishAttemptStatuses = new Set(["queued", "running", "succeeded"]);
 
 const publishSkipReasons = {
   postAlreadyPublished: "稿件已发布，跳过重复任务",
@@ -43,7 +43,31 @@ type ImagePayload = {
 };
 
 function hasActiveOrSucceededAttempts(attempts: Array<{ status: string }>) {
-  return attempts.some((attempt) => activePublishAttemptStatuses.has(attempt.status));
+  return attempts.some((attempt) => duplicateBlockingPublishAttemptStatuses.has(attempt.status));
+}
+
+function shouldSkipPublishFanout(options: {
+  ownerStatus: string;
+  attempts: Array<{ status: string }>;
+}) {
+  if (options.ownerStatus === "published") {
+    return true;
+  }
+
+  return hasActiveOrSucceededAttempts(options.attempts);
+}
+
+async function markPublishAttemptSkipped(attemptId: string, attempt: { postId: string; batchId: string | null }, reason: string) {
+  await prisma.publishAttempt.update({
+    where: {
+      id: attemptId,
+    },
+    data: {
+      status: "skipped",
+      lastError: reason,
+    },
+  });
+  await refreshAttemptPostStatuses(attempt);
 }
 
 export function registerPublishingWorker(queue: RuntimeQueue, logger: FastifyBaseLogger, config: CampuxConfig, notifier?: PublishingNotifier) {
@@ -127,12 +151,12 @@ export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string
     return [];
   }
 
-  if (post.status === "published") {
-    return [];
-  }
-
-  const hasActiveOrSucceededAttempt = hasActiveOrSucceededAttempts(post.publishAttempts);
-  if (hasActiveOrSucceededAttempt) {
+  if (
+    shouldSkipPublishFanout({
+      ownerStatus: post.status,
+      attempts: post.publishAttempts,
+    })
+  ) {
     return [];
   }
 
@@ -229,12 +253,12 @@ export async function enqueueBatchPublishFanout(queue: RuntimeQueue, tenantId: s
     return [];
   }
 
-  if (batch.status === "published") {
-    return [];
-  }
-
-  const hasActiveOrSucceededAttempt = hasActiveOrSucceededAttempts(batch.attempts);
-  if (hasActiveOrSucceededAttempt) {
+  if (
+    shouldSkipPublishFanout({
+      ownerStatus: batch.status,
+      attempts: batch.attempts,
+    })
+  ) {
     return [];
   }
 
@@ -621,31 +645,13 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
   }
 
   if (!attempt.publishTarget.enabled || !attempt.publishTarget.botAccount.enabled) {
-    await prisma.publishAttempt.update({
-      where: {
-        id: attempt.id,
-      },
-      data: {
-        status: "skipped",
-        lastError: "发布目标已停用",
-      },
-    });
-    await refreshAttemptPostStatuses(attempt);
+    await markPublishAttemptSkipped(attempt.id, attempt, "发布目标已停用");
     return;
   }
 
   if (!attempt.batch) {
     if (attempt.post.status === "published") {
-      await prisma.publishAttempt.update({
-        where: {
-          id: attempt.id,
-        },
-        data: {
-          status: "skipped",
-          lastError: publishSkipReasons.postAlreadyPublished,
-        },
-      });
-      await refreshAttemptPostStatuses(attempt);
+      await markPublishAttemptSkipped(attempt.id, attempt, publishSkipReasons.postAlreadyPublished);
       return;
     }
 
@@ -663,16 +669,7 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
       },
     });
     if (hasSucceededSibling) {
-      await prisma.publishAttempt.update({
-        where: {
-          id: attempt.id,
-        },
-        data: {
-          status: "skipped",
-          lastError: publishSkipReasons.targetAlreadySucceeded,
-        },
-      });
-      await refreshAttemptPostStatuses(attempt);
+      await markPublishAttemptSkipped(attempt.id, attempt, publishSkipReasons.targetAlreadySucceeded);
       return;
     }
   }

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -19,6 +19,13 @@ import type { RuntimeJob, RuntimeQueue } from "./queue";
 const maxPublishAttempts = 3;
 export const defaultPublishIntervalSeconds = 10;
 
+const activePublishAttemptStatuses = new Set(["queued", "running", "succeeded"]);
+
+const publishSkipReasons = {
+  postAlreadyPublished: "稿件已发布，跳过重复任务",
+  targetAlreadySucceeded: "发布目标已有成功记录，跳过重复任务",
+} as const;
+
 type PublishScheduleClient = typeof prisma | Prisma.TransactionClient;
 
 type PublishingNotifier = {
@@ -34,6 +41,10 @@ type ImagePayload = {
   url?: string;
   fileName?: string;
 };
+
+function hasActiveOrSucceededAttempts(attempts: Array<{ status: string }>) {
+  return attempts.some((attempt) => activePublishAttemptStatuses.has(attempt.status));
+}
 
 export function registerPublishingWorker(queue: RuntimeQueue, logger: FastifyBaseLogger, config: CampuxConfig, notifier?: PublishingNotifier) {
   queue.registerHandler("publishPost", async (job) => {
@@ -120,9 +131,7 @@ export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string
     return [];
   }
 
-  const hasActiveOrSucceededAttempt = post.publishAttempts.some((attempt: { status: string }) =>
-    attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
-  );
+  const hasActiveOrSucceededAttempt = hasActiveOrSucceededAttempts(post.publishAttempts);
   if (hasActiveOrSucceededAttempt) {
     return [];
   }
@@ -224,9 +233,7 @@ export async function enqueueBatchPublishFanout(queue: RuntimeQueue, tenantId: s
     return [];
   }
 
-  const hasActiveOrSucceededAttempt = batch.attempts.some((attempt: { status: string }) =>
-    attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
-  );
+  const hasActiveOrSucceededAttempt = hasActiveOrSucceededAttempts(batch.attempts);
   if (hasActiveOrSucceededAttempt) {
     return [];
   }
@@ -635,7 +642,7 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
         },
         data: {
           status: "skipped",
-          lastError: "稿件已发布，跳过重复任务",
+          lastError: publishSkipReasons.postAlreadyPublished,
         },
       });
       await refreshAttemptPostStatuses(attempt);
@@ -662,7 +669,7 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
         },
         data: {
           status: "skipped",
-          lastError: "发布目标已有成功记录，跳过重复任务",
+          lastError: publishSkipReasons.targetAlreadySucceeded,
         },
       });
       await refreshAttemptPostStatuses(attempt);

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -103,7 +103,7 @@ export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string
     select: {
       id: true,
       status: true,
-      attempts: {
+      publishAttempts: {
         select: {
           id: true,
           status: true,
@@ -120,7 +120,7 @@ export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string
     return [];
   }
 
-  const hasActiveOrSucceededAttempt = post.attempts.some((attempt: { status: string }) =>
+  const hasActiveOrSucceededAttempt = post.publishAttempts.some((attempt: { status: string }) =>
     attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
   );
   if (hasActiveOrSucceededAttempt) {

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -96,6 +96,37 @@ export async function recoverPublishAttempts(queue: RuntimeQueue, logger: Fastif
 }
 
 export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string, postId: string, actorId?: string | null) {
+  const post = await prisma.post.findUnique({
+    where: {
+      id: postId,
+    },
+    select: {
+      id: true,
+      status: true,
+      attempts: {
+        select: {
+          id: true,
+          status: true,
+        },
+      },
+    },
+  });
+
+  if (!post) {
+    return [];
+  }
+
+  if (post.status === "published") {
+    return [];
+  }
+
+  const hasActiveOrSucceededAttempt = post.attempts.some((attempt: { status: string }) =>
+    attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
+  );
+  if (hasActiveOrSucceededAttempt) {
+    return [];
+  }
+
   const targets = await prisma.publishTarget.findMany({
     where: {
       tenantId,
@@ -172,6 +203,12 @@ export async function enqueueBatchPublishFanout(queue: RuntimeQueue, tenantId: s
   const batch = await prisma.publishBatch.findUnique({
     where: { id: batchId },
     include: {
+      attempts: {
+        select: {
+          id: true,
+          status: true,
+        },
+      },
       items: {
         orderBy: { position: "asc" },
         select: { postId: true },
@@ -180,6 +217,17 @@ export async function enqueueBatchPublishFanout(queue: RuntimeQueue, tenantId: s
   });
 
   if (!batch || batch.items.length === 0) {
+    return [];
+  }
+
+  if (batch.status === "published") {
+    return [];
+  }
+
+  const hasActiveOrSucceededAttempt = batch.attempts.some((attempt: { status: string }) =>
+    attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
+  );
+  if (hasActiveOrSucceededAttempt) {
     return [];
   }
 
@@ -577,6 +625,49 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
     });
     await refreshAttemptPostStatuses(attempt);
     return;
+  }
+
+  if (!attempt.batch) {
+    if (attempt.post.status === "published") {
+      await prisma.publishAttempt.update({
+        where: {
+          id: attempt.id,
+        },
+        data: {
+          status: "skipped",
+          lastError: "稿件已发布，跳过重复任务",
+        },
+      });
+      await refreshAttemptPostStatuses(attempt);
+      return;
+    }
+
+    const hasSucceededSibling = await prisma.publishAttempt.findFirst({
+      where: {
+        postId: attempt.postId,
+        publishTargetId: attempt.publishTargetId,
+        status: "succeeded",
+        id: {
+          not: attempt.id,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+    if (hasSucceededSibling) {
+      await prisma.publishAttempt.update({
+        where: {
+          id: attempt.id,
+        },
+        data: {
+          status: "skipped",
+          lastError: "发布目标已有成功记录，跳过重复任务",
+        },
+      });
+      await refreshAttemptPostStatuses(attempt);
+      return;
+    }
   }
 
   try {


### PR DESCRIPTION
## Summary by Sourcery

防止重复发布扇出任务，并为已发布的帖子或目标跳过冗余的发布尝试，同时修复 SVG 头像目录解析问题。

Bug 修复：
- 对已经发布或已有活动/成功发布尝试的帖子或批次，跳过入队发布扇出任务。
- 当发布目标或机器人账户被禁用，或者帖子已发布、或该目标已经存在成功发布尝试时，将发布尝试标记为已跳过。
- 修正 SVG 头像的项目根路径解析，使其指向正确的目录。
- 收紧 SVG 头像列表逻辑，通过使用带类型的文件名仅筛选 `.svg` 文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent duplicate publish fanout jobs and skip redundant publish attempts for already-published posts or targets, and fix SVG avatar directory resolution.

Bug Fixes:
- Skip enqueueing publish fanout for posts or batches that are already published or have active/succeeded attempts.
- Mark publish attempts as skipped when the publish target or bot account is disabled, or when the post is already published or already has a succeeded attempt for that target.
- Correct project root resolution for SVG avatars to point to the proper directory.
- Tighten SVG avatar listing to filter by .svg files using typed file names.

</details>