### PR TITLE
fix: 更新发布尝试状态管理，避免重复发布

### DIFF
--- a/apps/server/src/lib/svg-avatars.ts
+++ b/apps/server/src/lib/svg-avatars.ts
@@ -4,10 +4,10 @@ import path from "node:path";
 /**
  * Resolve the project root by walking up from this file's location.
  * This file: apps/server/src/lib/svg-avatars.ts
- * Project root: apps/server/src/lib/../../..
+ * Project root: apps/server/src/lib/../../../..
  */
 function resolveProjectRoot(): string {
-  return path.resolve(import.meta.dirname!, "..", "..", "..");
+  return path.resolve(import.meta.dirname!, "..", "..", "..", "..");
 }
 
 function resolveSvgDir(): string {
@@ -25,7 +25,7 @@ export function listSvgAvatars(): string[] {
   const svgDir = resolveSvgDir();
   try {
     const files = readdirSync(svgDir);
-    return files.filter((f) => f.endsWith(".svg")).sort();
+    return files.filter((file: string) => file.endsWith(".svg")).sort();
   } catch {
     return [];
   }

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -19,7 +19,7 @@ import type { RuntimeJob, RuntimeQueue } from "./queue";
 const maxPublishAttempts = 3;
 export const defaultPublishIntervalSeconds = 10;
 
-const activePublishAttemptStatuses = new Set(["queued", "running", "succeeded"]);
+const duplicateBlockingPublishAttemptStatuses = new Set(["queued", "running", "succeeded"]);
 
 const publishSkipReasons = {
   postAlreadyPublished: "稿件已发布，跳过重复任务",
@@ -43,7 +43,31 @@ type ImagePayload = {
 };
 
 function hasActiveOrSucceededAttempts(attempts: Array<{ status: string }>) {
-  return attempts.some((attempt) => activePublishAttemptStatuses.has(attempt.status));
+  return attempts.some((attempt) => duplicateBlockingPublishAttemptStatuses.has(attempt.status));
+}
+
+function shouldSkipPublishFanout(options: {
+  ownerStatus: string;
+  attempts: Array<{ status: string }>;
+}) {
+  if (options.ownerStatus === "published") {
+    return true;
+  }
+
+  return hasActiveOrSucceededAttempts(options.attempts);
+}
+
+async function markPublishAttemptSkipped(attemptId: string, attempt: { postId: string; batchId: string | null }, reason: string) {
+  await prisma.publishAttempt.update({
+    where: {
+      id: attemptId,
+    },
+    data: {
+      status: "skipped",
+      lastError: reason,
+    },
+  });
+  await refreshAttemptPostStatuses(attempt);
 }
 
 export function registerPublishingWorker(queue: RuntimeQueue, logger: FastifyBaseLogger, config: CampuxConfig, notifier?: PublishingNotifier) {
@@ -127,12 +151,12 @@ export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string
     return [];
   }
 
-  if (post.status === "published") {
-    return [];
-  }
-
-  const hasActiveOrSucceededAttempt = hasActiveOrSucceededAttempts(post.publishAttempts);
-  if (hasActiveOrSucceededAttempt) {
+  if (
+    shouldSkipPublishFanout({
+      ownerStatus: post.status,
+      attempts: post.publishAttempts,
+    })
+  ) {
     return [];
   }
 
@@ -229,12 +253,12 @@ export async function enqueueBatchPublishFanout(queue: RuntimeQueue, tenantId: s
     return [];
   }
 
-  if (batch.status === "published") {
-    return [];
-  }
-
-  const hasActiveOrSucceededAttempt = hasActiveOrSucceededAttempts(batch.attempts);
-  if (hasActiveOrSucceededAttempt) {
+  if (
+    shouldSkipPublishFanout({
+      ownerStatus: batch.status,
+      attempts: batch.attempts,
+    })
+  ) {
     return [];
   }
 
@@ -621,31 +645,13 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
   }
 
   if (!attempt.publishTarget.enabled || !attempt.publishTarget.botAccount.enabled) {
-    await prisma.publishAttempt.update({
-      where: {
-        id: attempt.id,
-      },
-      data: {
-        status: "skipped",
-        lastError: "发布目标已停用",
-      },
-    });
-    await refreshAttemptPostStatuses(attempt);
+    await markPublishAttemptSkipped(attempt.id, attempt, "发布目标已停用");
     return;
   }
 
   if (!attempt.batch) {
     if (attempt.post.status === "published") {
-      await prisma.publishAttempt.update({
-        where: {
-          id: attempt.id,
-        },
-        data: {
-          status: "skipped",
-          lastError: publishSkipReasons.postAlreadyPublished,
-        },
-      });
-      await refreshAttemptPostStatuses(attempt);
+      await markPublishAttemptSkipped(attempt.id, attempt, publishSkipReasons.postAlreadyPublished);
       return;
     }
 
@@ -663,16 +669,7 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
       },
     });
     if (hasSucceededSibling) {
-      await prisma.publishAttempt.update({
-        where: {
-          id: attempt.id,
-        },
-        data: {
-          status: "skipped",
-          lastError: publishSkipReasons.targetAlreadySucceeded,
-        },
-      });
-      await refreshAttemptPostStatuses(attempt);
+      await markPublishAttemptSkipped(attempt.id, attempt, publishSkipReasons.targetAlreadySucceeded);
       return;
     }
   }

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -19,6 +19,13 @@ import type { RuntimeJob, RuntimeQueue } from "./queue";
 const maxPublishAttempts = 3;
 export const defaultPublishIntervalSeconds = 10;
 
+const activePublishAttemptStatuses = new Set(["queued", "running", "succeeded"]);
+
+const publishSkipReasons = {
+  postAlreadyPublished: "稿件已发布，跳过重复任务",
+  targetAlreadySucceeded: "发布目标已有成功记录，跳过重复任务",
+} as const;
+
 type PublishScheduleClient = typeof prisma | Prisma.TransactionClient;
 
 type PublishingNotifier = {
@@ -34,6 +41,10 @@ type ImagePayload = {
   url?: string;
   fileName?: string;
 };
+
+function hasActiveOrSucceededAttempts(attempts: Array<{ status: string }>) {
+  return attempts.some((attempt) => activePublishAttemptStatuses.has(attempt.status));
+}
 
 export function registerPublishingWorker(queue: RuntimeQueue, logger: FastifyBaseLogger, config: CampuxConfig, notifier?: PublishingNotifier) {
   queue.registerHandler("publishPost", async (job) => {
@@ -120,9 +131,7 @@ export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string
     return [];
   }
 
-  const hasActiveOrSucceededAttempt = post.publishAttempts.some((attempt: { status: string }) =>
-    attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
-  );
+  const hasActiveOrSucceededAttempt = hasActiveOrSucceededAttempts(post.publishAttempts);
   if (hasActiveOrSucceededAttempt) {
     return [];
   }
@@ -224,9 +233,7 @@ export async function enqueueBatchPublishFanout(queue: RuntimeQueue, tenantId: s
     return [];
   }
 
-  const hasActiveOrSucceededAttempt = batch.attempts.some((attempt: { status: string }) =>
-    attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
-  );
+  const hasActiveOrSucceededAttempt = hasActiveOrSucceededAttempts(batch.attempts);
   if (hasActiveOrSucceededAttempt) {
     return [];
   }
@@ -635,7 +642,7 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
         },
         data: {
           status: "skipped",
-          lastError: "稿件已发布，跳过重复任务",
+          lastError: publishSkipReasons.postAlreadyPublished,
         },
       });
       await refreshAttemptPostStatuses(attempt);
@@ -662,7 +669,7 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
         },
         data: {
           status: "skipped",
-          lastError: "发布目标已有成功记录，跳过重复任务",
+          lastError: publishSkipReasons.targetAlreadySucceeded,
         },
       });
       await refreshAttemptPostStatuses(attempt);

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -103,7 +103,7 @@ export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string
     select: {
       id: true,
       status: true,
-      attempts: {
+      publishAttempts: {
         select: {
           id: true,
           status: true,
@@ -120,7 +120,7 @@ export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string
     return [];
   }
 
-  const hasActiveOrSucceededAttempt = post.attempts.some((attempt: { status: string }) =>
+  const hasActiveOrSucceededAttempt = post.publishAttempts.some((attempt: { status: string }) =>
     attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
   );
   if (hasActiveOrSucceededAttempt) {

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -96,6 +96,37 @@ export async function recoverPublishAttempts(queue: RuntimeQueue, logger: Fastif
 }
 
 export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string, postId: string, actorId?: string | null) {
+  const post = await prisma.post.findUnique({
+    where: {
+      id: postId,
+    },
+    select: {
+      id: true,
+      status: true,
+      attempts: {
+        select: {
+          id: true,
+          status: true,
+        },
+      },
+    },
+  });
+
+  if (!post) {
+    return [];
+  }
+
+  if (post.status === "published") {
+    return [];
+  }
+
+  const hasActiveOrSucceededAttempt = post.attempts.some((attempt: { status: string }) =>
+    attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
+  );
+  if (hasActiveOrSucceededAttempt) {
+    return [];
+  }
+
   const targets = await prisma.publishTarget.findMany({
     where: {
       tenantId,
@@ -172,6 +203,12 @@ export async function enqueueBatchPublishFanout(queue: RuntimeQueue, tenantId: s
   const batch = await prisma.publishBatch.findUnique({
     where: { id: batchId },
     include: {
+      attempts: {
+        select: {
+          id: true,
+          status: true,
+        },
+      },
       items: {
         orderBy: { position: "asc" },
         select: { postId: true },
@@ -180,6 +217,17 @@ export async function enqueueBatchPublishFanout(queue: RuntimeQueue, tenantId: s
   });
 
   if (!batch || batch.items.length === 0) {
+    return [];
+  }
+
+  if (batch.status === "published") {
+    return [];
+  }
+
+  const hasActiveOrSucceededAttempt = batch.attempts.some((attempt: { status: string }) =>
+    attempt.status === "queued" || attempt.status === "running" || attempt.status === "succeeded",
+  );
+  if (hasActiveOrSucceededAttempt) {
     return [];
   }
 
@@ -577,6 +625,49 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
     });
     await refreshAttemptPostStatuses(attempt);
     return;
+  }
+
+  if (!attempt.batch) {
+    if (attempt.post.status === "published") {
+      await prisma.publishAttempt.update({
+        where: {
+          id: attempt.id,
+        },
+        data: {
+          status: "skipped",
+          lastError: "稿件已发布，跳过重复任务",
+        },
+      });
+      await refreshAttemptPostStatuses(attempt);
+      return;
+    }
+
+    const hasSucceededSibling = await prisma.publishAttempt.findFirst({
+      where: {
+        postId: attempt.postId,
+        publishTargetId: attempt.publishTargetId,
+        status: "succeeded",
+        id: {
+          not: attempt.id,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+    if (hasSucceededSibling) {
+      await prisma.publishAttempt.update({
+        where: {
+          id: attempt.id,
+        },
+        data: {
+          status: "skipped",
+          lastError: "发布目标已有成功记录，跳过重复任务",
+        },
+      });
+      await refreshAttemptPostStatuses(attempt);
+      return;
+    }
   }
 
   try {


### PR DESCRIPTION
## Summary by Sourcery

改进发布尝试的调度逻辑，避免重复或冗余的发布任务，并修复 SVG 头像资源解析问题。

Bug 修复：
- 当帖子或批次已经发布，或已存在进行中/成功的尝试时，防止重新入队发布扇出任务。
- 当目标已被禁用、帖子已发布，或存在等效且已成功的尝试时，跳过新的发布尝试。
- 修正 SVG 头像的项目根路径解析，以确保头像目录能够被可靠定位。

增强功能：
- 将检测重复或冗余发布尝试的逻辑以及跳过原因的记录逻辑集中管理，以便更好地进行状态管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve publish attempt scheduling to avoid duplicate or redundant publishing tasks and fix SVG avatar asset resolution.

Bug Fixes:
- Prevent re-enqueuing publish fanout when posts or batches are already published or have active/succeeded attempts.
- Skip new publish attempts when the target is disabled, the post is already published, or an equivalent attempt has already succeeded.
- Correct the project root resolution for SVG avatars so the avatar directory is located reliably.

Enhancements:
- Centralize logic for detecting duplicate or redundant publish attempts and tracking skip reasons for better status management.

</details>