### PR TITLE
refactor: 精简 SVG 头像处理逻辑，移除不必要的文件读取和目录解析

### DIFF
--- a/apps/server/src/lib/svg-avatars.ts
+++ b/apps/server/src/lib/svg-avatars.ts
@@ -1,43 +1,7 @@
-import { readFileSync, readdirSync } from "node:fs";
-import path from "node:path";
-import { builtInSvgAvatarContents, builtInSvgAvatarFilenames } from "./built-in-svg-avatars";
+import { builtInSvgAvatarContents } from "./built-in-svg-avatars";
 
-/**
- * Resolve the project root by walking up from this file's location.
- * This file: apps/server/src/lib/svg-avatars.ts
- * Project root: apps/server/src/lib/../../../..
- */
-function resolveProjectRoot(): string {
-  return path.resolve(import.meta.dirname!, "..", "..", "..", "..");
-}
-
-function resolveSvgDir(): string {
-  // standalone 单文件形态下，svg 头像被解包到临时目录并通过 CAMPUX_SVG_DIR 指定。
-  if (process.env.CAMPUX_SVG_DIR) {
-    return process.env.CAMPUX_SVG_DIR;
-  }
-  return path.join(resolveProjectRoot(), "svg");
-}
-
-export function getSvgAvatarDir(): string {
-  return resolveSvgDir();
-}
-
-/**
- * List all SVG avatar filenames available in the svg/ directory.
- */
-export function listSvgAvatars(): string[] {
-  if (builtInSvgAvatarFilenames.length > 0) {
-    return [...builtInSvgAvatarFilenames];
-  }
-
-  const svgDir = resolveSvgDir();
-  try {
-    const files = readdirSync(svgDir);
-    return files.filter((file: string) => file.endsWith(".svg")).sort();
-  } catch {
-    return [];
-  }
+export function readSvgAvatarContent(filename: string): string | null {
+  return builtInSvgAvatarContents[filename as keyof typeof builtInSvgAvatarContents] ?? null;
 }
 
 /**
@@ -45,19 +9,11 @@ export function listSvgAvatars(): string[] {
  * Returns `null` if the file doesn't exist or can't be read.
  */
 export function readSvgAvatarDataUrl(filename: string): string | null {
-  const builtInSvg = builtInSvgAvatarContents[filename as keyof typeof builtInSvgAvatarContents];
+  const builtInSvg = readSvgAvatarContent(filename);
   if (builtInSvg) {
     const base64 = Buffer.from(builtInSvg, "utf-8").toString("base64");
     return `data:image/svg+xml;base64,${base64}`;
   }
 
-  const svgDir = resolveSvgDir();
-  const filePath = path.join(svgDir, filename);
-  try {
-    const content = readFileSync(filePath, "utf-8");
-    const base64 = Buffer.from(content, "utf-8").toString("base64");
-    return `data:image/svg+xml;base64,${base64}`;
-  } catch {
-    return null;
-  }
+  return null;
 }

--- a/apps/server/src/routes/svg.ts
+++ b/apps/server/src/routes/svg.ts
@@ -1,8 +1,6 @@
-import { readFileSync } from "node:fs";
-import path from "node:path";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
-import { getSvgAvatarDir } from "../lib/svg-avatars";
+import { readSvgAvatarContent } from "../lib/svg-avatars";
 
 const svgParamsSchema = z.object({
   filename: z.string().min(1),
@@ -19,16 +17,13 @@ export function registerSvgRoutes(app: FastifyInstance) {
       return reply.code(400).send({ message: "Invalid filename" });
     }
 
-    const svgDir = getSvgAvatarDir();
-    const filePath = path.join(svgDir, filename);
-
-    try {
-      const content = readFileSync(filePath, "utf-8");
-      reply.header("Content-Type", "image/svg+xml");
-      reply.header("Cache-Control", "public, max-age=86400");
-      return reply.send(content);
-    } catch {
+    const content = readSvgAvatarContent(filename);
+    if (!content) {
       return reply.code(404).send({ message: "SVG not found" });
     }
+
+    reply.header("Content-Type", "image/svg+xml");
+    reply.header("Cache-Control", "public, max-age=86400");
+    return reply.send(content);
   });
 }


### PR DESCRIPTION
## Summary by Sourcery

简化 SVG 头像处理逻辑，仅依赖内置资源，并移除基于文件系统的查找。

增强内容：
- 引入一个辅助方法，从内置头像映射中读取 SVG 头像内容。
- 重构 SVG 路由，从内置内容中提供头像，并在头像缺失时返回 404。
- 移除项目根路径解析、目录发现以及基于环境变量的 SVG 头像目录配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify SVG avatar handling to rely solely on built-in assets and remove filesystem-based lookup.

Enhancements:
- Introduce a helper to read SVG avatar content from the built-in avatar map.
- Refactor the SVG route to serve avatars from built-in content and return 404 when an avatar is missing.
- Remove project-root resolution, directory discovery, and environment-based SVG directory configuration for avatars.

</details>