### PR TITLE
feat: 添加自定义字体支持，更新字体选项和相关路由

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,25 @@ ARG BUN_VERSION=1.3.12
 FROM oven/bun:${BUN_VERSION}-alpine AS build
 WORKDIR /app
 
-RUN apk add --no-cache openssl
+RUN apk add --no-cache git openssl
 
 COPY package.json bun.lock tsconfig.base.json ./
 COPY apps ./apps
 COPY packages ./packages
-# 注：自定义字体（「字体选择」雕花功能）默认不随仓库分发，避免数十 MB TTF 进 git 历史。
-# packages/render 在 <项目根>/font 缺失时会自动回退到下方 apk 安装的 noto-cjk 系统字体。
-# 自托管者若需启用该功能，可自行在此 COPY 字体目录。
+RUN git clone --depth=1 https://github.com/idoknow/Campux-ttf.git /tmp/Campux-ttf \
+	&& mkdir -p /app/font \
+	&& cp /tmp/Campux-ttf/BeiShiDaJiaGuWenZiTi-1.ttf /app/font/ \
+	&& cp /tmp/Campux-ttf/chengmingshouxieti.ttf /app/font/ \
+	&& cp /tmp/Campux-ttf/hanchanhuokaiti.otf /app/font/ \
+	&& cp /tmp/Campux-ttf/lipinhuiziyouluoti.ttf /app/font/ \
+	&& cp /tmp/Campux-ttf/yishanbeizhuanti.ttf /app/font/ \
+	&& cp /tmp/Campux-ttf/cascadianextjianti.ttf /app/font/ \
+	&& cp /tmp/Campux-ttf/hanchanbanyuanti.ttf /app/font/ \
+	&& cp /tmp/Campux-ttf/hongmengsansscmediumziti.ttf /app/font/ \
+	&& cp /tmp/Campux-ttf/linhailishu.ttf /app/font/ \
+	&& cp /tmp/Campux-ttf/namidiansong.ttf /app/font/ \
+	&& cp /tmp/Campux-ttf/siyuanyuanti.ttf /app/font/ \
+	&& cp /tmp/Campux-ttf/zhouzisongti.otf /app/font/
 
 RUN bun install --frozen-lockfile
 RUN bun run db:generate
@@ -35,6 +46,7 @@ ENV TZ=Asia/Shanghai
 ENV CAMPUX_SERVER_HOST=0.0.0.0
 ENV CAMPUX_SERVER_PORT=8989
 ENV CAMPUX_WEB_DIST_DIR=/app/apps/web/dist
+ENV CAMPUX_FONT_DIR=/app/font
 ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 COPY --from=build /app /app

--- a/apps/server/src/lib/sanitize.ts
+++ b/apps/server/src/lib/sanitize.ts
@@ -1,5 +1,5 @@
 import { URL } from "node:url";
-import { isDefaultFont } from "@campux/domain";
+import { FONT_OPTIONS, isDefaultFont } from "@campux/domain";
 import { prisma } from "./prisma";
 
 // ── 允许的背景色名称 ──────────────────────────────────
@@ -15,12 +15,7 @@ const ALLOWED_BG_COLORS = new Set([
 
 // ── 允许的字体名称 ────────────────────────────────────
 const ALLOWED_FONTS = new Set([
-  "beinidekeaitianyunle",
-  "dunhuangfeitiankai",
-  "mengxiangchaoyanningti",
-  "unifontdianzhenhei",
-  "zhuoteqingyati",
-  "zihuisongkexietiw4",
+  ...FONT_OPTIONS.filter((font) => !isDefaultFont(font.value)).map((font) => font.value),
 ]);
 
 // ── 允许的文字颜色名称 ────────────────────────────────

--- a/apps/server/src/routes/svg.ts
+++ b/apps/server/src/routes/svg.ts
@@ -1,10 +1,21 @@
+import { createReadStream, existsSync } from "node:fs";
+import { join } from "node:path";
 import type { FastifyInstance } from "fastify";
+import { FONT_FILE_MAP } from "@campux/domain";
 import { z } from "zod";
 import { readSvgAvatarContent } from "../lib/svg-avatars";
 
 const svgParamsSchema = z.object({
   filename: z.string().min(1),
 });
+
+const fontParamsSchema = z.object({
+  filename: z.string().min(1),
+});
+
+function getBundledFontDir() {
+  return process.env.CAMPUX_FONT_DIR || "/app/font";
+}
 
 export function registerSvgRoutes(app: FastifyInstance) {
   /**
@@ -25,5 +36,27 @@ export function registerSvgRoutes(app: FastifyInstance) {
     reply.header("Content-Type", "image/svg+xml");
     reply.header("Cache-Control", "public, max-age=86400");
     return reply.send(content);
+  });
+
+  app.get("/api/fonts/:filename", async (request, reply) => {
+    const { filename } = fontParamsSchema.parse(request.params);
+
+    if (filename.includes("..") || filename.includes("/")) {
+      return reply.code(400).send({ message: "Invalid filename" });
+    }
+
+    const allowed = new Set(Object.values(FONT_FILE_MAP));
+    if (!allowed.has(filename)) {
+      return reply.code(404).send({ message: "Font not found" });
+    }
+
+    const filePath = join(getBundledFontDir(), filename);
+    if (!existsSync(filePath)) {
+      return reply.code(404).send({ message: "Font not found" });
+    }
+
+    reply.header("Content-Type", filename.endsWith(".otf") ? "font/otf" : "font/ttf");
+    reply.header("Cache-Control", "public, max-age=86400");
+    return reply.send(createReadStream(filePath));
   });
 }

--- a/apps/web/src/features/posts/PostPage.tsx
+++ b/apps/web/src/features/posts/PostPage.tsx
@@ -78,15 +78,11 @@ export function PostPage({
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [attachmentToRemove, setAttachmentToRemove] = useState<PendingAttachment | null>(null);
-  const [fontPreviewOpen, setFontPreviewOpen] = useState(false);
-  const [fontPreviewUrl, setFontPreviewUrl] = useState<string | null>(null);
-  const [fontPreviewLoading, setFontPreviewLoading] = useState(false);
   const svgAvatars = builtInSvgAvatarFilenames;
   const rules = metadata.postRules.length > 0 ? metadata.postRules : defaultMetadata.postRules;
   const sortedAttachments = [...pendingAttachments].sort((left, right) => left.sortOrder - right.sortOrder);
   const hasConverting = pendingAttachments.some((p) => p.status === "converting");
   const hasUploading = pendingAttachments.some((p) => p.status === "uploading");
-  const hasNonDefaultFont = !isDefaultFont(postFont);
 
   // 关闭匿名时清除已选头像
   useEffect(() => {
@@ -115,50 +111,8 @@ export function PostPage({
     setAttachmentToRemove(null);
   }
 
-  async function handleSubmit() {
-    if (hasNonDefaultFont) {
-      setFontPreviewLoading(true);
-      setFontPreviewOpen(true);
-      try {
-        const resp = await fetch("/api/posts/render-preview", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            text: postText,
-            font: postFont || undefined,
-            bgColor: postBgColor || undefined,
-            textColor: postTextColor || undefined,
-            anonymous,
-          }),
-        });
-        if (!resp.ok) throw new Error("预览生成失败");
-        const blob = await resp.blob();
-        setFontPreviewUrl(URL.createObjectURL(blob));
-      } catch {
-        setFontPreviewUrl(null);
-      } finally {
-        setFontPreviewLoading(false);
-      }
-    } else {
-      onSubmit();
-    }
-  }
-
-  function confirmFontPreview() {
-    if (fontPreviewUrl) URL.revokeObjectURL(fontPreviewUrl);
-    setFontPreviewUrl(null);
-    setFontPreviewOpen(false);
+  function handleSubmit() {
     onSubmit();
-  }
-
-  const selectedFontOption = FONT_OPTIONS.find((f) => f.value === postFont) ?? FONT_OPTIONS[0];
-
-  function handleFontPreviewClose() {
-    setFontPreviewOpen(false);
-    if (fontPreviewUrl) {
-      URL.revokeObjectURL(fontPreviewUrl);
-      setFontPreviewUrl(null);
-    }
   }
 
   return (
@@ -359,15 +313,17 @@ export function PostPage({
                       <button
                         key={opt.value}
                         type="button"
-                        className={`flex h-7 items-center gap-1.5 rounded-full border px-2.5 text-xs font-medium transition-all ${
+                        className={`flex min-h-12 min-w-28 items-center rounded-md border px-3 py-2 text-left text-sm transition-all ${
                           postFont === opt.value
                             ? "border-slate-700 bg-slate-700 text-white shadow-sm"
                             : "border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50"
                         }`}
                         onClick={() => onFontChange(postFont === opt.value ? "" : opt.value)}
-                        style={!isDefaultFont(opt.value) && postFont === opt.value ? { fontFamily: opt.value } : {}}
+                        title={opt.label}
                       >
-                        {opt.label}
+                        <span className={`block leading-5 campux-font-preview-${opt.value}`}>
+                          {opt.label}
+                        </span>
                       </button>
                     ))}
                   </div>
@@ -433,42 +389,6 @@ export function PostPage({
         </DialogContent>
       </Dialog>
 
-      <Dialog open={fontPreviewOpen} onOpenChange={(open) => { if (!open) handleFontPreviewClose(); }}>
-        <DialogContent className="w-[min(560px,calc(100vw-32px))]">
-          <DialogHeader>
-            <DialogTitle>字体预览</DialogTitle>
-            <DialogDescription>
-              你选择了「{selectedFontOption?.label}」，以下是使用该字体渲染的效果图。确认无误后提交进入审核。
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex items-center justify-center px-2">
-            {fontPreviewLoading ? (
-              <div className="flex min-h-[200px] items-center justify-center">
-                <LoaderIcon className="size-6 animate-spin text-slate-400" />
-              </div>
-            ) : fontPreviewUrl ? (
-              <img
-                src={fontPreviewUrl}
-                alt="字体预览"
-                className="max-h-[60vh] w-full rounded-md border border-slate-200 object-contain"
-              />
-            ) : (
-              <div className="flex min-h-[120px] items-center justify-center text-sm text-red-500">
-                预览生成失败，请重试或取消后直接投稿。
-              </div>
-            )}
-          </div>
-          <DialogFooter className="gap-2">
-            <Button variant="outline" onClick={handleFontPreviewClose}>
-              取消
-            </Button>
-            <Button onClick={confirmFontPreview} disabled={busy || fontPreviewLoading || postText.trim().length === 0}>
-              <SendIcon className="mr-1 inline size-4" />
-              确认投稿
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,7 +1,78 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
-@import "@fontsource-variable/geist";
+
+@font-face {
+  font-family: "CampuxFont-beishidajiaguwenziti1";
+  src: url("/api/fonts/BeiShiDaJiaGuWenZiTi-1.ttf") format("truetype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "CampuxFont-chengmingshouxieti";
+  src: url("/api/fonts/chengmingshouxieti.ttf") format("truetype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "CampuxFont-hanchanhuokaiti";
+  src: url("/api/fonts/hanchanhuokaiti.otf") format("opentype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "CampuxFont-lipinhuiziyouluoti";
+  src: url("/api/fonts/lipinhuiziyouluoti.ttf") format("truetype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "CampuxFont-yishanbeizhuanti";
+  src: url("/api/fonts/yishanbeizhuanti.ttf") format("truetype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "CampuxFont-cascadianextjianti";
+  src: url("/api/fonts/cascadianextjianti.ttf") format("truetype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "CampuxFont-hanchanbanyuanti";
+  src: url("/api/fonts/hanchanbanyuanti.ttf") format("truetype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "CampuxFont-hongmengsansscmediumziti";
+  src: url("/api/fonts/hongmengsansscmediumziti.ttf") format("truetype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "CampuxFont-linhailishu";
+  src: url("/api/fonts/linhailishu.ttf") format("truetype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "CampuxFont-namidiansong";
+  src: url("/api/fonts/namidiansong.ttf") format("truetype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "CampuxFont-siyuanyuanti";
+  src: url("/api/fonts/siyuanyuanti.ttf") format("truetype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "CampuxFont-zhouzisongti";
+  src: url("/api/fonts/zhouzisongti.otf") format("opentype");
+  font-display: swap;
+}
 
 @custom-variant dark (&:is(.dark *));
 
@@ -30,7 +101,7 @@
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
   --font-heading: var(--font-sans);
-  --font-sans: 'Geist Variable', sans-serif;
+  --font-sans: "PingFang SC", "Microsoft YaHei", system-ui, -apple-system, sans-serif;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -99,7 +170,6 @@
     min-height: 100dvh;
     background: var(--background);
     font-family:
-      "Geist Variable",
       "PingFang SC",
       "Microsoft YaHei",
       system-ui,
@@ -114,6 +184,58 @@
     background-color: oklch(0.85 0.06 250 / 0.4);
     color: inherit;
   }
+}
+
+.campux-font-preview-default {
+  font-family: "PingFang SC", "Microsoft YaHei", system-ui, -apple-system, sans-serif;
+}
+
+.campux-font-preview-beishidajiaguwenziti1 {
+  font-family: "CampuxFont-beishidajiaguwenziti1", "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+.campux-font-preview-chengmingshouxieti {
+  font-family: "CampuxFont-chengmingshouxieti", "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+.campux-font-preview-hanchanhuokaiti {
+  font-family: "CampuxFont-hanchanhuokaiti", "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+.campux-font-preview-lipinhuiziyouluoti {
+  font-family: "CampuxFont-lipinhuiziyouluoti", "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+.campux-font-preview-yishanbeizhuanti {
+  font-family: "CampuxFont-yishanbeizhuanti", "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+.campux-font-preview-cascadianextjianti {
+  font-family: "CampuxFont-cascadianextjianti", "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+.campux-font-preview-hanchanbanyuanti {
+  font-family: "CampuxFont-hanchanbanyuanti", "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+.campux-font-preview-hongmengsansscmediumziti {
+  font-family: "CampuxFont-hongmengsansscmediumziti", "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+.campux-font-preview-linhailishu {
+  font-family: "CampuxFont-linhailishu", "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+.campux-font-preview-namidiansong {
+  font-family: "CampuxFont-namidiansong", "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+.campux-font-preview-siyuanyuanti {
+  font-family: "CampuxFont-siyuanyuanti", "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+.campux-font-preview-zhouzisongti {
+  font-family: "CampuxFont-zhouzisongti", "PingFang SC", "Microsoft YaHei", sans-serif;
 }
 
 .campux-postbtn {

--- a/packages/domain/src/fonts.ts
+++ b/packages/domain/src/fonts.ts
@@ -2,12 +2,18 @@ import { z } from "zod";
 
 export const postFontSchema = z.enum([
   "default",
-  "beinidekeaitianyunle",
-  "dunhuangfeitiankai",
-  "mengxiangchaoyanningti",
-  "unifontdianzhenhei",
-  "zhuoteqingyati",
-  "zihuisongkexietiw4",
+  "beishidajiaguwenziti1",
+  "chengmingshouxieti",
+  "hanchanhuokaiti",
+  "lipinhuiziyouluoti",
+  "yishanbeizhuanti",
+  "cascadianextjianti",
+  "hanchanbanyuanti",
+  "hongmengsansscmediumziti",
+  "linhailishu",
+  "namidiansong",
+  "siyuanyuanti",
+  "zhouzisongti",
 ]);
 export type PostFont = z.infer<typeof postFontSchema>;
 
@@ -15,12 +21,18 @@ export const postFontDefault = "default";
 
 export const FONT_OPTIONS: Array<{ value: PostFont; label: string; fileName: string }> = [
   { value: postFontDefault, label: "默认字体", fileName: "" },
-  { value: "beinidekeaitianyunle", label: "贝尼的可爱云乐体", fileName: "beinidekeaitianyunle.ttf" },
-  { value: "dunhuangfeitiankai", label: "敦煌飞天楷", fileName: "dunhuangfeitiankai.ttf" },
-  { value: "mengxiangchaoyanningti", label: "梦想超妍宁体", fileName: "mengxiangchaoyanningti.ttf" },
-  { value: "unifontdianzhenhei", label: "点阵黑体", fileName: "unifontdianzhenhei.ttf" },
-  { value: "zhuoteqingyati", label: "卓特清雅体", fileName: "zhuoteqingyati.ttf" },
-  { value: "zihuisongkexietiw4", label: "字汇宋克斜体", fileName: "zihuisongkexietiw4.ttf" },
+  { value: "beishidajiaguwenziti1", label: "甲骨文字体", fileName: "BeiShiDaJiaGuWenZiTi-1.ttf" },
+  { value: "chengmingshouxieti", label: "承明手写体", fileName: "chengmingshouxieti.ttf" },
+  { value: "hanchanhuokaiti", label: "寒蝉活楷体", fileName: "hanchanhuokaiti.otf" },
+  { value: "lipinhuiziyouluoti", label: "礼品会自由落体", fileName: "lipinhuiziyouluoti.ttf" },
+  { value: "yishanbeizhuanti", label: "逸善碑篆体", fileName: "yishanbeizhuanti.ttf" },
+  { value: "cascadianextjianti", label: "Cascadia Next 简体", fileName: "cascadianextjianti.ttf" },
+  { value: "hanchanbanyuanti", label: "寒蝉半圆体", fileName: "hanchanbanyuanti.ttf" },
+  { value: "hongmengsansscmediumziti", label: "鸿蒙 Sans SC Medium", fileName: "hongmengsansscmediumziti.ttf" },
+  { value: "linhailishu", label: "临海隶书", fileName: "linhailishu.ttf" },
+  { value: "namidiansong", label: "纳米点宋", fileName: "namidiansong.ttf" },
+  { value: "siyuanyuanti", label: "思源圆体", fileName: "siyuanyuanti.ttf" },
+  { value: "zhouzisongti", label: "舟字宋体", fileName: "zhouzisongti.otf" },
 ];
 
 export const FONT_FILE_MAP: Record<string, string> = Object.fromEntries(


### PR DESCRIPTION
## Summary by Sourcery

在 Web、服务器和 Docker 中添加捆绑自定义字体支持，并简化字体选择的用户体验。

新功能：
- 暴露安全的 `/api/fonts/:filename` 路由，用于为帖子渲染和网页使用提供捆绑字体文件。
- 为帖子引入多种新的中文和拉丁字体选项，并在 Web 界面中提供相应的预览样式。

改进：
- 将默认无衬线字体栈切换为系统中文字体替代 Geist，并调整字体选择器按钮布局和内联预览样式。
- 在服务器上从 `FONT_OPTIONS` 派生允许使用的字体白名单，以保证字体清理与域内字体定义保持同步。

构建：
- 在 Docker 构建中克隆并捆绑 Campux-ttf 字体仓库，并配置 `CAMPUX_FONT_DIR` 以在运行时访问字体。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add bundled custom font support across web, server, and Docker, and simplify font selection UX.

New Features:
- Expose a secure /api/fonts/:filename route to serve bundled font files for post rendering and web usage.
- Introduce multiple new Chinese and Latin font options for posts with corresponding preview styles in the web UI.

Enhancements:
- Switch the default sans-serif stack to system Chinese fonts instead of Geist and adjust font picker button layout and inline preview styling.
- Derive the allowed font whitelist on the server from FONT_OPTIONS to keep sanitization in sync with domain font definitions.

Build:
- Clone and bundle the Campux-ttf font repository in the Docker build and configure CAMPUX_FONT_DIR for runtime font access.

</details>