### PR TITLE
feat(publishing): 添加失败发布尝试重新排队功能及相关测试

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -15,7 +15,7 @@ import fastifyStatic from "@fastify/static";
 import { loadConfig } from "@campux/config";
 import { createRuntimeQueue } from "./runtime/queue";
 import { OneBotRuntime } from "./runtime/onebot";
-import { recoverPublishAttempts, registerPublishingWorker } from "./runtime/publishing";
+import { recoverPublishAttempts, registerFailedPublishAttemptRepublisher, registerPublishingWorker } from "./runtime/publishing";
 import { registerQZonePostMetricScheduler, registerQZonePostMetricWorker } from "./runtime/qzone-post-metrics";
 import { registerBotFriendSnapshotScheduler } from "./runtime/bot-friend-snapshots";
 import { registerFollowedPostCommentScheduler } from "./runtime/followed-post-comments";
@@ -126,6 +126,7 @@ const stopBotFriendSnapshotScheduler = registerBotFriendSnapshotScheduler({ call
 const stopFollowedPostCommentScheduler = registerFollowedPostCommentScheduler({ caller: oneBot, logger: app.log });
 const stopPostTagMaintenanceScheduler = registerPostTagMaintenanceScheduler({ logger: app.log });
 const stopTelemetryReporter = registerTelemetryReporter({ logger: app.log, config });
+const stopFailedPublishAttemptRepublisher = registerFailedPublishAttemptRepublisher(queue, app.log);
 registerBatchFlushSweeper(queue, app.log);
 
 app.addHook("onClose", async () => {
@@ -136,6 +137,7 @@ app.addHook("onClose", async () => {
   stopFollowedPostCommentScheduler();
   stopPostTagMaintenanceScheduler();
   stopTelemetryReporter();
+  stopFailedPublishAttemptRepublisher();
   stopBatchFlushSweeper();
 });
 

--- a/apps/server/src/runtime/publishing.test.ts
+++ b/apps/server/src/runtime/publishing.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { deriveAggregateStatus, republishFailureRetryDelayMs } from "./publishing";
+
+describe("republish failure timeout", () => {
+  it("uses a 12 hour retry delay", () => {
+    expect(republishFailureRetryDelayMs).toBe(12 * 60 * 60 * 1000);
+  });
+});
+
+describe("deriveAggregateStatus", () => {
+  it("keeps publishing while a failed attempt still has a scheduled retry", () => {
+    const result = deriveAggregateStatus([
+      {
+        status: "failed",
+        nextRunAt: new Date("2026-07-10T12:00:00.000Z"),
+        publishTarget: { required: true },
+      },
+    ]);
+
+    expect(result).toEqual({
+      status: "publishing",
+      comment: "发布任务仍在进行",
+    });
+  });
+
+  it("marks failed when the required attempt has no retry scheduled", () => {
+    const result = deriveAggregateStatus([
+      {
+        status: "failed",
+        nextRunAt: null,
+        publishTarget: { required: true },
+      },
+    ]);
+
+    expect(result).toEqual({
+      status: "failed",
+      comment: "发布目标失败，请在管理页查看详情",
+    });
+  });
+});

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -18,6 +18,8 @@ import type { RuntimeJob, RuntimeQueue } from "./queue";
 
 const maxPublishAttempts = 3;
 export const defaultPublishIntervalSeconds = 10;
+export const republishFailureRetryDelayMs = 12 * 60 * 60 * 1000;
+export const republishFailureSweepIntervalMs = 15 * 60 * 1000;
 
 const duplicateBlockingPublishAttemptStatuses = new Set(["queued", "running", "succeeded"]);
 
@@ -128,6 +130,89 @@ export async function recoverPublishAttempts(queue: RuntimeQueue, logger: Fastif
   }
 
   logger.info({ count: attempts.length, postsChecked: posts.length }, "publish attempts recovered");
+}
+
+export async function requeueExpiredFailedPublishAttempts(queue: RuntimeQueue, logger: FastifyBaseLogger, now = new Date()) {
+  const attempts = await prisma.publishAttempt.findMany({
+    where: {
+      status: "failed",
+      nextRunAt: null,
+      updatedAt: {
+        lte: new Date(now.getTime() - republishFailureRetryDelayMs),
+      },
+      post: {
+        status: {
+          in: ["partially_failed", "failed"],
+        },
+      },
+      publishTarget: {
+        enabled: true,
+        botAccount: {
+          enabled: true,
+        },
+      },
+    },
+    include: {
+      publishTarget: true,
+    },
+    orderBy: {
+      updatedAt: "asc",
+    },
+  });
+
+  for (const attempt of attempts) {
+    const { attempt: updated, nextRunAt } = await schedulePublishAttempt({
+      tenantId: attempt.tenantId,
+      postId: attempt.postId,
+      publishTargetId: attempt.publishTargetId,
+      botAccountId: attempt.publishTarget.botAccountId,
+      batchId: attempt.batchId,
+      intervalSeconds: attempt.publishTarget.publishDelaySeconds,
+      excludeAttemptId: attempt.id,
+      resetAttempt: true,
+    });
+    enqueueAttempt(queue, updated.tenantId, updated.id, nextRunAt);
+    await prisma.postLog.create({
+      data: {
+        tenantId: attempt.tenantId,
+        postId: attempt.postId,
+        newStatus: "publishing",
+        comment: `${attempt.publishTarget.displayName} 发表失败超过 12 小时未手动重发，系统已自动重新排队`,
+      },
+    });
+    await refreshAttemptPostStatuses(attempt);
+  }
+
+  if (attempts.length > 0) {
+    logger.info({ count: attempts.length }, "failed publish attempts requeued after 12 hour timeout");
+  }
+
+  return attempts.length;
+}
+
+export function registerFailedPublishAttemptRepublisher(queue: RuntimeQueue, logger: FastifyBaseLogger) {
+  let running = false;
+
+  const run = async () => {
+    if (running) {
+      return;
+    }
+    running = true;
+    try {
+      await requeueExpiredFailedPublishAttempts(queue, logger);
+    } catch (error) {
+      logger.warn({ error }, "failed publish attempt republisher sweep failed");
+    } finally {
+      running = false;
+    }
+  };
+
+  void run();
+  const timer = setInterval(() => {
+    void run();
+  }, republishFailureSweepIntervalMs);
+
+  return () => clearInterval(timer);
 }
 
 export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string, postId: string, actorId?: string | null) {

--- a/bun.lock
+++ b/bun.lock
@@ -114,6 +114,7 @@
     "packages/render": {
       "name": "@campux/render",
       "dependencies": {
+        "@campux/domain": "workspace:*",
         "marked": "^15.0.0",
         "playwright-core": "^1.60.0",
       },


### PR DESCRIPTION
## Summary by Sourcery

在 12 小时超时时间后，自动重新排队符合条件的发布失败尝试，并将周期性重新发布器集成到服务器运行时中。

New Features:
- 添加一个调度器，用于扫描空闲达 12 小时的发布失败尝试，并将其重新排队以自动重试。
- 在服务器启动生命周期中注册一个后台重新发布器，并确保在服务器关闭时将其停止。

Tests:
- 添加单元测试，用于验证 12 小时重试延迟常量，以及针对有/无计划重试的失败尝试的聚合状态行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automatically requeue eligible failed publish attempts after a 12-hour timeout and integrate a periodic republisher into the server runtime.

New Features:
- Add a scheduler that scans for failed publish attempts that have been idle for 12 hours and requeues them for automatic retry.
- Register a background republisher in the server startup lifecycle and ensure it is stopped on server shutdown.

Tests:
- Add unit tests validating the 12-hour retry delay constant and aggregate status behavior for failed attempts with and without scheduled retries.

</details>