### PR TITLE
feat(posts): 添加按关键词搜索已发布和我的稿件功能

### DIFF
--- a/apps/server/src/routes/posts.ts
+++ b/apps/server/src/routes/posts.ts
@@ -33,6 +33,7 @@ const postParamsSchema = z.object({
 const listQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(50).default(10),
+  q: z.string().trim().max(200).optional(),
 });
 
 const publishedListQuerySchema = listQuerySchema.extend({
@@ -602,10 +603,18 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
   app.get("/api/posts/mine", async (request, reply) => {
     const context = await requireTenantContext(request, reply);
     const query = listQuerySchema.parse(request.query);
-    const where = {
+    const where: Record<string, unknown> = {
       tenantId: context.selectedTenant.id,
       authorId: context.user.id,
     };
+    const keyword = query.q?.trim();
+    if (keyword) {
+      const displayId = /^\d+$/.test(keyword) ? Number.parseInt(keyword, 10) : null;
+      where.OR = [
+        { text: { contains: keyword } },
+        ...(displayId !== null ? [{ displayId }] : []),
+      ];
+    }
     const [total, posts] = await Promise.all([
       prisma.post.count({ where }),
       prisma.post.findMany({
@@ -696,6 +705,7 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
     const query = publishedListQuerySchema.parse(request.query);
     const tenantId = context.selectedTenant.id;
     const viewerIsReviewer = hasTenantRole(context.selectedMembership.role, "reviewer");
+    const keyword = query.q?.trim();
 
     const metricInclude = {
       include: {
@@ -805,10 +815,28 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
       };
     });
 
-    const allItems = filterPublishedFeedByTag(
+    let allItems = filterPublishedFeedByTag(
       buildPublishedFeed({ singles, batches: batchInputs, viewerIsReviewer }),
       query.tag,
     );
+
+    // 按关键词过滤已发布稿件（匹配正文内容或稿件编号）
+    if (keyword) {
+      const keywordLower = keyword.toLowerCase();
+      const displayIdFilter = /^\d+$/.test(keyword) ? Number.parseInt(keyword, 10) : null;
+      allItems = allItems.filter((item) => {
+        for (const post of item.posts) {
+          if (displayIdFilter !== null && post.displayId === displayIdFilter) {
+            return true;
+          }
+          if (post.text.toLowerCase().includes(keywordLower)) {
+            return true;
+          }
+        }
+        return false;
+      });
+    }
+
     const total = allItems.length;
     const start = (query.page - 1) * query.limit;
     const items = allItems.slice(start, start + query.limit);

--- a/apps/web/src/features/posts/PostsPage.tsx
+++ b/apps/web/src/features/posts/PostsPage.tsx
@@ -293,6 +293,11 @@ export function PostsPage({
   const [publishedPagination, setPublishedPagination] = useState<Pagination>(() => defaultPagination());
   const [publishedLoading, setPublishedLoading] = useState(false);
   const [publishedPage, setPublishedPage] = useState(1);
+  const [publishedKeyword, setPublishedKeyword] = useState("");
+  const [mineKeyword, setMineKeyword] = useState("");
+  const [mineSearchPosts, setMineSearchPosts] = useState<PostItem[] | null>(null);
+  const [mineSearchPagination, setMineSearchPagination] = useState<Pagination | null>(null);
+  const [mineSearchLoading, setMineSearchLoading] = useState(false);
   const [tagMaintenanceDays, setTagMaintenanceDays] = useState("14");
   const [tagMaintenanceBusy, setTagMaintenanceBusy] = useState(false);
   const [detailPostId, setDetailPostId] = useState(() => readQueryParam("post"));
@@ -372,10 +377,16 @@ export function PostsPage({
     if (activeTab !== "published") {
       return;
     }
-    void Promise.all([refreshPublishedTags(), refreshPublishedFeed(publishedPage)]).catch((caught) => {
-      toast.error(caught instanceof Error ? caught.message : "无法读取已发布稿件");
-    });
-  }, [activeTab, publishedPage, publishedTagFilter, tenantId]);
+    if (publishedKeyword.trim()) {
+      void Promise.all([refreshPublishedTags(), searchPublishedFeed(publishedPage)]).catch((caught) => {
+        toast.error(caught instanceof Error ? caught.message : "无法搜索已发布稿件");
+      });
+    } else {
+      void Promise.all([refreshPublishedTags(), refreshPublishedFeed(publishedPage)]).catch((caught) => {
+        toast.error(caught instanceof Error ? caught.message : "无法读取已发布稿件");
+      });
+    }
+  }, [activeTab, publishedPage, publishedTagFilter, tenantId, publishedKeyword]);
 
   async function refreshAll() {
     await onRefresh();
@@ -787,6 +798,64 @@ export function PostsPage({
     writeQueryParams({ post: null });
   }
 
+  async function searchMinePosts(page = 1) {
+    const keyword = mineKeyword.trim();
+    if (!keyword) {
+      setMineSearchPosts(null);
+      setMineSearchPagination(null);
+      return;
+    }
+    setMineSearchLoading(true);
+    try {
+      const data = await api<{ posts: PostItem[]; pagination: Pagination }>(`/api/posts/mine?q=${encodeURIComponent(keyword)}&page=${page}&limit=10`);
+      setMineSearchPosts(data.posts);
+      setMineSearchPagination(data.pagination);
+    } catch (caught) {
+      toast.error(caught instanceof Error ? caught.message : "搜索失败");
+    } finally {
+      setMineSearchLoading(false);
+    }
+  }
+
+  function clearMineSearch() {
+    setMineKeyword("");
+    setMineSearchPosts(null);
+    setMineSearchPagination(null);
+  }
+
+  function searchMinePostsPage(page: number) {
+    void searchMinePosts(page);
+  }
+
+  async function searchPublishedFeed(page = 1) {
+    const keyword = publishedKeyword.trim();
+    const params = new URLSearchParams({
+      page: String(page),
+      limit: String(publishedPagination.limit),
+    });
+    if (publishedTagFilter !== "all") {
+      params.set("tag", publishedTagFilter);
+    }
+    if (keyword) {
+      params.set("q", keyword);
+    }
+    setPublishedLoading(true);
+    try {
+      const data = await api<{ items: PublishedFeedItem[]; pagination: Pagination }>(`/api/posts/published?${params}`);
+      setPublishedItems(data.items);
+      setPublishedPagination(data.pagination);
+    } catch (caught) {
+      toast.error(caught instanceof Error ? caught.message : "搜索失败");
+    } finally {
+      setPublishedLoading(false);
+    }
+  }
+
+  function clearPublishedSearch() {
+    setPublishedKeyword("");
+    void refreshPublishedFeed(1);
+  }
+
   return (
     <MarkdownContext.Provider value={Boolean(enableMarkdownRender)}>
     <ImageLightboxContext.Provider value={openImagePreview}>
@@ -818,7 +887,54 @@ export function PostsPage({
           </div>
         </div>
         <TabsContent value="mine" className="mt-3 min-h-0 flex-1 overflow-y-auto pb-24 pr-1 md:pb-6">
-          {mineLoading ? (
+          <div className="mb-3 flex items-center gap-2">
+            <input
+              value={mineKeyword}
+              className="h-9 flex-1 rounded-md border border-slate-200 bg-white px-3 text-sm font-medium outline-none focus:border-slate-400"
+              placeholder="按内容或编号搜索你的稿件"
+              onChange={(event) => setMineKeyword(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  void searchMinePosts();
+                }
+              }}
+            />
+            <Button variant="outline" size="sm" className="h-9 shrink-0 font-bold" disabled={mineSearchLoading} onClick={() => void searchMinePosts()}>
+              <SearchIcon className="mr-1 size-4" />
+              搜索
+            </Button>
+            {mineKeyword ? (
+              <Button variant="ghost" size="sm" className="h-9 shrink-0 text-slate-500" onClick={clearMineSearch}>
+                清除
+              </Button>
+            ) : null}
+          </div>
+          {mineSearchLoading ? (
+            <LoadingBlock title="正在搜索你的稿件..." />
+          ) : mineSearchPosts !== null ? (
+            <>
+              <div className="mb-2 text-xs font-semibold text-slate-500">
+                搜索 "{mineKeyword}" 的结果（共 {mineSearchPagination?.total ?? 0} 条）
+              </div>
+              <PostList
+                posts={mineSearchPosts}
+                busyCancelPostId={busyCancelPostId}
+                busyRecallPostId={busyRecallPostId}
+                busyFollowPostId={busyFollowPostId}
+                onPreview={(post) => void openRenderPreview(post)}
+                onImagePreview={(post, images, index) => openImagePreview(images, index, `稿件 ${post.displayId} 上传图片`)}
+                onCancel={(post) => void cancelPost(post.id)}
+                onRecall={(post) => {
+                  setRecallReason("");
+                  setRecallConfirm({ open: true, mode: "request", post });
+                }}
+                onToggleFollow={(post) => void toggleFollowPost(post)}
+              />
+              {mineSearchPagination ? (
+                <PaginationControls pagination={mineSearchPagination} busy={mineSearchLoading} onPageChange={searchMinePostsPage} />
+              ) : null}
+            </>
+          ) : mineLoading ? (
             <LoadingBlock title="正在加载你的稿件..." />
           ) : (
             <>
@@ -843,6 +959,28 @@ export function PostsPage({
         <TabsContent value="published" className="mt-3 min-h-0 flex-1 overflow-y-auto pb-24 pr-1 md:pb-6">
           <div className="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
             <PublishedTagFilter tags={publishedTags} value={publishedTagFilter} onChange={changePublishedTagFilter} />
+            <div className="flex items-center gap-2">
+              <input
+                value={publishedKeyword}
+                className="h-8 flex-1 rounded-md border border-slate-200 bg-white px-3 text-sm font-medium outline-none focus:border-slate-400 md:w-48"
+                placeholder="搜索已发布稿件..."
+                onChange={(event) => setPublishedKeyword(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    setPublishedPage(1);
+                    void searchPublishedFeed(1);
+                  }
+                }}
+              />
+              <Button variant="outline" size="sm" className="h-8 shrink-0 font-bold" disabled={publishedLoading} onClick={() => { setPublishedPage(1); void searchPublishedFeed(1); }}>
+                <SearchIcon className="size-4" />
+              </Button>
+              {publishedKeyword ? (
+                <Button variant="ghost" size="sm" className="h-8 shrink-0 text-xs text-slate-500" onClick={clearPublishedSearch}>
+                  清除
+                </Button>
+              ) : null}
+            </div>
             {isAdmin ? (
               <PublishedTagMaintenanceToolbar
                 value={tagMaintenanceDays}


### PR DESCRIPTION
## Summary by Sourcery

为个人帖子和已发布帖子新增基于关键词的搜索功能，并将其集成到帖子页面和后端查询处理中。

New Features:
- 支持在「我的帖子」中按内容或显示 ID 进行搜索，并提供分页和可清除的结果。
- 为已发布帖子新增关键词搜索功能，可与现有的标签过滤和分页功能组合使用。

Enhancements:
- 扩展帖子列表 API，使其接受可选的关键词参数，并根据文本内容或显示 ID 过滤结果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add keyword-based search for both personal and published posts, integrating it into the posts page and backend query handling.

New Features:
- Enable searching 'my posts' by content or display ID with pagination and clearable results.
- Add keyword search for published posts, combining with existing tag filters and pagination.

Enhancements:
- Extend posts listing APIs to accept an optional keyword query and filter results by text content or display ID.

</details>