### PR TITLE
feat(posts): 添加关键词过滤功能和调整我的稿件分页限制

### DIFF
--- a/apps/server/src/routes/posts.ts
+++ b/apps/server/src/routes/posts.ts
@@ -729,6 +729,27 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
 
     const authorSelect = { select: { displayName: true, qqUin: true } } as const;
 
+    // Build keyword filter for Prisma queries
+    let keywordSingleFilter: Record<string, unknown> = {};
+    let keywordBatchFilter: Record<string, unknown> = {};
+    if (keyword) {
+      const displayIdFilter = /^\d+$/.test(keyword) ? Number.parseInt(keyword, 10) : null;
+      const orClauses: Record<string, unknown>[] = [{ text: { contains: keyword } }];
+      if (displayIdFilter !== null) {
+        orClauses.push({ displayId: displayIdFilter });
+      }
+      keywordSingleFilter = { OR: orClauses };
+      keywordBatchFilter = {
+        items: {
+          some: {
+            post: {
+              OR: orClauses,
+            },
+          },
+        },
+      };
+    }
+
     const [singlePosts, batches] = await Promise.all([
       // A) 独立发布稿件：已发布且不属于任何批次
       prisma.post.findMany({
@@ -736,6 +757,7 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
           tenantId,
           status: "published",
           batchItem: { is: null },
+          ...keywordSingleFilter,
         },
         include: {
           author: authorSelect,
@@ -749,7 +771,11 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
       }),
       // B) 已发布批次（批量）
       prisma.publishBatch.findMany({
-        where: { tenantId, status: "published" },
+        where: {
+          tenantId,
+          status: "published",
+          ...(keyword ? keywordBatchFilter : {}),
+        },
         include: {
           items: {
             orderBy: { position: "asc" },

--- a/apps/web/src/features/posts/PostsPage.tsx
+++ b/apps/web/src/features/posts/PostsPage.tsx
@@ -807,7 +807,7 @@ export function PostsPage({
     }
     setMineSearchLoading(true);
     try {
-      const data = await api<{ posts: PostItem[]; pagination: Pagination }>(`/api/posts/mine?q=${encodeURIComponent(keyword)}&page=${page}&limit=10`);
+      const data = await api<{ posts: PostItem[]; pagination: Pagination }>(`/api/posts/mine?q=${encodeURIComponent(keyword)}&page=${page}&limit=${minePagination.limit}`);
       setMineSearchPosts(data.posts);
       setMineSearchPagination(data.pagination);
     } catch (caught) {
@@ -853,6 +853,7 @@ export function PostsPage({
 
   function clearPublishedSearch() {
     setPublishedKeyword("");
+    setPublishedPage(1);
     void refreshPublishedFeed(1);
   }
 


### PR DESCRIPTION
## Summary by Sourcery

为已发布帖子添加基于关键词的筛选，并使“我的帖子”的分页与可配置的限制保持一致。

新功能：
- 支持对单个已发布帖子和已发布批次进行关键词和展示 ID 的筛选。

改进：
- 对“我的帖子”列表使用可配置的分页限制，而不是硬编码的数值。
- 在清空搜索关键词时，将已发布帖子的页面重置为第一页。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add keyword-based filtering for published posts and align 'my posts' pagination with configurable limits.

New Features:
- Support keyword and display ID filtering for single published posts and published batches.

Enhancements:
- Use the configurable pagination limit for the 'my posts' list instead of a hard-coded value.
- Reset the published posts page to the first page when clearing the search keyword.

</details>