### PR TITLE
fix(server): preserve face/image/mface segments in private-to-review-group forward

### DIFF
--- a/apps/server/src/lib/private-posting.ts
+++ b/apps/server/src/lib/private-posting.ts
@@ -97,6 +97,29 @@ export function extractOneBotImageSegments(message: unknown) {
   });
 }
 
+/**
+ * 提取所有消息段，过滤掉空白的纯 text 段。
+ * 用于转发场景，保留 face、image 等非文本段，以便合并转发时正确渲染表情和图片。
+ */
+export function extractOneBotMessageSegments(message: unknown): OneBotMessageSegment[] {
+  if (!Array.isArray(message)) {
+    return [];
+  }
+
+  return message.filter((segment): segment is OneBotMessageSegment => {
+    if (!segment || typeof segment !== "object") {
+      return false;
+    }
+    const seg = segment as OneBotMessageSegment;
+    // 过滤掉空白纯文本段（只有空格/换行/零宽字符），保留有实际内容的 text 和所有非 text 段
+    if (seg.type === "text") {
+      const t = String(seg.data?.text ?? "").trim();
+      return t.length > 0;
+    }
+    return true;
+  });
+}
+
 export function extractOneBotPlainText(message: unknown, rawMessage?: string) {
   if (Array.isArray(message)) {
     return message

--- a/apps/server/src/runtime/onebot.ts
+++ b/apps/server/src/runtime/onebot.ts
@@ -23,7 +23,7 @@ import { compressImageBuffer, deleteAttachmentObjects, uploadAttachmentBytes, ty
 import { findActiveBan, hasTenantRole } from "../lib/auth";
 import { buildCampuxLoginUrl } from "../lib/campux-login-url";
 import { prisma } from "../lib/prisma";
-import { extractOneBotImageSegments, extractOneBotPlainText, isPrivatePostCancelText, isPrivatePostFinishText, isPrivatePostUndoText, parsePrivatePostConfirmText, parsePrivatePostModeText, parsePrivatePostStartText, type OneBotMessageSegment } from "../lib/private-posting";
+import { extractOneBotImageSegments, extractOneBotMessageSegments, extractOneBotPlainText, isPrivatePostCancelText, isPrivatePostFinishText, isPrivatePostUndoText, parsePrivatePostConfirmText, parsePrivatePostModeText, parsePrivatePostStartText, type OneBotMessageSegment } from "../lib/private-posting";
 import { analyzePrivatePostSemantics, type PrivatePostSemanticResult } from "../lib/private-posting-ai";
 import { readTenantImageCompression, readTenantPendingPostLimit, readTenantBotStylishMessagesEnabled, readTenantBotPrivatePostStylishEnabled } from "../lib/tenant-metadata";
 import { detectPostInjection, createAutoBan } from "../lib/sanitize";
@@ -86,6 +86,7 @@ import {
   formatUnbanNotFound,
   formatBanNotify,
   formatUnbanNotify,
+  escapeCqCode,
 } from "../lib/bot-messages";
 import { buildFriendRequestAutoApprovePlan, buildSetFriendAddRequestParams, type OneBotRequestEvent } from "./onebot-friend-requests";
 import { collectOverdueReviewReminders, listPendingReviewQueue, reviewQueueReminderIntervalMs } from "./review-queue";
@@ -165,6 +166,7 @@ type PrivatePostPendingConfirm = PrivatePostDraft;
 type PrivateForwardEntry = {
   time: number;
   text: string;
+  segments: OneBotMessageSegment[];
 };
 
 type PrivateForwardBuffer = {
@@ -1425,8 +1427,8 @@ export class OneBotRuntime {
           }
         }
 
-        // 跳过纯 QQ 表情包（贴图/动画表情），不转发也不回复
-        if (this.isStickerOnlyMessage(event)) {
+// 跳过好友请求等系统消息，不转发
+        if (this.isSkippablePrivateMessage(plainText || event.raw_message || "")) {
           return;
         }
 
@@ -1436,6 +1438,8 @@ export class OneBotRuntime {
           return;
         }
 
+        const isStickerOnly = this.isStickerOnlyMessage(event);
+
         // 非投稿、非命令消息：缓存到缓冲区，1 分钟无新消息后合并转发到审核群
         if (bot.reviewGroupId) {
           this.bufferPrivateForwardMessage({
@@ -1444,7 +1448,13 @@ export class OneBotRuntime {
             userQqUin,
             userNickname: event.sender?.card || event.sender?.nickname || userQqUin,
             text: plainText || event.raw_message || "（不支持的消息类型）",
+            segments: extractOneBotMessageSegments(event.message),
           });
+        }
+
+        // 纯表情包消息不自动回复，避免骚扰用户
+        if (isStickerOnly) {
+          return;
         }
 
         // 保留原有自动回复
@@ -2725,7 +2735,7 @@ export class OneBotRuntime {
     buffer.userNickname = userNickname;
     buffer.delayMs = delaySeconds * 1000;
     buffer.events.push(event);
-    buffer.messages.push({ time: Math.floor(Date.now() / 1000), text });
+    buffer.messages.push({ time: Math.floor(Date.now() / 1000), text, segments: extractOneBotMessageSegments(event.message) });
     this.schedulePrivatePostAggregateFlush(key, buffer);
   }
 
@@ -2812,6 +2822,7 @@ export class OneBotRuntime {
           userQqUin: buffer.userQqUin,
           userNickname: buffer.userNickname,
           text: entry.text,
+          segments: entry.segments,
         });
       }
     }
@@ -2827,12 +2838,14 @@ export class OneBotRuntime {
     userQqUin,
     userNickname,
     text,
+    segments,
   }: {
     bot: { id: string; tenantId: string; qqUin: bigint; displayName?: string | null; reviewGroupId: string | null };
     botQqUin: string;
     userQqUin: string;
     userNickname: string;
     text: string;
+    segments?: OneBotMessageSegment[];
   }) {
     // 异步递增私信接收计数
     prisma.botAccount.update({
@@ -2859,6 +2872,7 @@ export class OneBotRuntime {
     buffer.messages.push({
       time: Math.floor(Date.now() / 1000),
       text,
+      segments: segments ?? [],
     });
 
     // 重置计时器：最后一条消息后等待 1 分钟
@@ -2901,25 +2915,26 @@ export class OneBotRuntime {
           name: string;
           uin: string;
           time?: number;
-          content: Array<{ type: "text"; data: { text: string } }>;
+          content: OneBotMessageSegment[];
         };
       }> = [];
 
       for (const entry of buffer.messages) {
+        // 如果保留了原始消息段（face/image 等），直接使用；否则降级为纯文本
+        // 合并转发中不支持的段（mface/marketface/markdown）替换为文本提示
+        const rawSegments =
+          entry.segments.length > 0
+            ? entry.segments
+            : [{ type: "text", data: { text: entry.text } }];
+        const content = this.sanitizeForwardSegments(rawSegments);
+
         nodes.push({
           type: "node",
           data: {
             name: buffer.userNickname,
             uin: buffer.userQqUin,
             time: entry.time,
-            content: [
-              {
-                type: "text",
-                data: {
-                  text: entry.text,
-                },
-              },
-            ],
+            content,
           },
         });
       }
@@ -2937,7 +2952,7 @@ export class OneBotRuntime {
         this.logger.warn({ error, botQqUin: buffer.botQqUin, userQqUin: buffer.userQqUin }, "合并转发失败，降级为普通消息发送");
         const lines = [
           `📩 ${buffer.userNickname}（${buffer.userQqUin}）发来私聊消息：`,
-          ...buffer.messages.map((entry, i) => `${i + 1}. ${entry.text}`),
+          ...buffer.messages.map((entry, i) => `${i + 1}. ${escapeCqCode(entry.text)}`),
         ];
         const fallbackData = await this.callAction(buffer.botQqUin, "send_group_msg", {
           group_id: Number(bot.reviewGroupId),
@@ -2952,6 +2967,31 @@ export class OneBotRuntime {
     } catch (error) {
       this.logger.warn({ error, botQqUin: buffer.botQqUin, userQqUin: buffer.userQqUin }, "转发私聊消息到审核群失败");
     }
+  }
+
+  /**
+   * 清理合并转发节点中可能不被 QQ 支持的段。
+   * mface（商城表情/超级表情）、marketface image、markdown 等在合并转发中可能显示为
+   * "此消息不支持查看"。将这些段替换为文本提示，保留其他段不变。
+   */
+  private sanitizeForwardSegments(segments: OneBotMessageSegment[]): OneBotMessageSegment[] {
+    return segments.flatMap((seg) => {
+      // mface 类型段（商城表情/超级表情）
+      if (seg.type === "mface") {
+        const summary = String(seg.data?.summary ?? "[超级表情]");
+        return [{ type: "text", data: { text: `[${summary}]` } }];
+      }
+      // image 中的 marketface（商城表情以 image 段上报）
+      if (seg.type === "image" && String(seg.data?.file ?? "") === "marketface") {
+        const summary = String(seg.data?.summary ?? "[商城表情]");
+        return [{ type: "text", data: { text: `[${summary}]` } }];
+      }
+      // markdown 段在双层合并转发中无法发送
+      if (seg.type === "markdown") {
+        return [{ type: "text", data: { text: "[Markdown消息]" } }];
+      }
+      return [seg];
+    });
   }
 
   private async tryResolveDisplayIdFromReply(event: OneBotMessageEvent, botQqUin: string): Promise<number | null> {

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "campux-next",


### PR DESCRIPTION
## 问题

用户私聊机器人时发送的表情包（QQ 黄脸表情 `CQ:face`）、图片（`CQ:image`）和超级表情在转发到审核群时出现以下问题：

1. **表情/图片丢失**：`extractOneBotPlainText` 只提取 `type="text"` 的消息段，face/image 等被丢弃，转发到审核群的消息只剩下纯文本，CQ 码变成乱码
2. **纯表情包不转发**：`isStickerOnlyMessage` 直接跳过纯表情包消息，审核员看不到用户发了什么
3. **超级表情显示异常**：mface/marketface 段在 QQ 合并转发中不被支持，显示为"此消息不支持查看"

## 修复

### 1. 保留原始消息段 (`private-posting.ts`)
新增 `extractOneBotMessageSegments` 函数，提取所有消息段（过滤空白 text，保留 face/image/at 等非文本段），供转发使用。

### 2. 合并转发使用原始段 (`onebot.ts`)
- `PrivateForwardEntry` 新增 `segments` 字段存储原始消息段
- `flushPrivateForwardBuffer` 合并转发节点 `content` 直接使用原始消息段，不再只填充纯文本
- 降级路径使用 `escapeCqCode` 转义 CQ 码，防止显示乱码

### 3. 纯表情包仍然转发
将 `isStickerOnlyMessage` 判断后移到转发之后，纯表情包消息先转发到审核群，再跳过自动回复（避免骚扰用户）。

### 4. 合并转发不支持的段替换为文本
新增 `sanitizeForwardSegments` 方法，将 mface/marketface/markdown 段替换为文本提示（如 `[超级表情]`），避免合并转发中显示"不支持查看"。

## 修改文件

| 文件 | 变更 |
|------|------|
| `apps/server/src/lib/private-posting.ts` | +23 行，新增 `extractOneBotMessageSegments` |
| `apps/server/src/runtime/onebot.ts` | +55/-14 行，核心转发逻辑修改 |

## Summary by Sourcery

在将私聊消息转发到审查群组时保留完整的 OneBot 富文本消息段，确保表情、图片和不支持的消息段都能被优雅地处理。

New Features:
- 使用原始 OneBot 消息段将私聊消息转发到审查群组，以确保 QQ 表情和图片能够正确渲染。
- 允许纯表情包/表情消息被转发到审查群组，同时对这类消息抑制自动回复。

Bug Fixes:
- 修复私聊转发到审查群组过程中丢失 face/image/mface 消息段的问题，使转发内容与用户原始消息保持一致。

Enhancements:
- 新增对所有非空 OneBot 消息段的提取，用于在转发流程中复用，而不再仅依赖纯文本。
- 对不支持转发的消息段（例如 mface、marketface 图片和 markdown）进行清洗，转换为可读的文本占位符，以避免出现“消息不支持”的提示。
- 调整私聊消息跳过逻辑，仅忽略类似系统消息的内容，同时仍然转发用户的表情包内容。
- 在备用纯文本群消息中对 CQ 码进行转义，以防在合并转发失败时出现乱码显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve rich OneBot message segments when forwarding private messages to the review group, ensuring emojis, images, and unsupported segments are handled gracefully.

New Features:
- Forward private messages to the review group using original OneBot segments so that QQ emojis and images render correctly.
- Allow pure sticker/emoticon messages to be forwarded to the review group while suppressing automatic replies for them.

Bug Fixes:
- Fix loss of face/image/mface segments in private-to-review-group forwarding so forwarded content matches the original user message.

Enhancements:
- Add extraction of all non-empty OneBot message segments for reuse in forwarding flows instead of relying solely on plain text.
- Sanitize unsupported forward segments such as mface, marketface images, and markdown into readable text placeholders to avoid "message not supported" displays.
- Adjust private message skipping logic to ignore only system-like messages while still forwarding user sticker content.
- Escape CQ codes in fallback plain-text group messages to prevent garbled display when merged forwarding fails.

</details>