### PR TITLE
fix(server): strip zero-width chars in extractOneBotMessageSegments

### DIFF
--- a/apps/server/src/lib/private-posting.ts
+++ b/apps/server/src/lib/private-posting.ts
@@ -113,7 +113,9 @@ export function extractOneBotMessageSegments(message: unknown): OneBotMessageSeg
     const seg = segment as OneBotMessageSegment;
     // 过滤掉空白纯文本段（只有空格/换行/零宽字符），保留有实际内容的 text 和所有非 text 段
     if (seg.type === "text") {
-      const t = String(seg.data?.text ?? "").trim();
+      const t = String(seg.data?.text ?? "")
+        .replace(/[\u200B\u200C\u200D\uFEFF]/g, "")
+        .trim();
       return t.length > 0;
     }
     return true;

--- a/apps/server/src/lib/private-posting.ts
+++ b/apps/server/src/lib/private-posting.ts
@@ -3,6 +3,8 @@ export type OneBotMessageSegment = {
   data?: Record<string, unknown>;
 };
 
+import { stripZeroWidthChars } from "./sanitize";
+
 /**
  * 检查 input 是否以指定的关键词开头（支持半角 # 和全角 ＃ 前缀）。
  * 关键词本身不应包含 # 前缀。
@@ -113,9 +115,7 @@ export function extractOneBotMessageSegments(message: unknown): OneBotMessageSeg
     const seg = segment as OneBotMessageSegment;
     // 过滤掉空白纯文本段（只有空格/换行/零宽字符），保留有实际内容的 text 和所有非 text 段
     if (seg.type === "text") {
-      const t = String(seg.data?.text ?? "")
-        .replace(/[\u200B\u200C\u200D\uFEFF]/g, "")
-        .trim();
+      const t = stripZeroWidthChars(String(seg.data?.text ?? "")).trim();
       return t.length > 0;
     }
     return true;

--- a/apps/server/src/lib/sanitize.ts
+++ b/apps/server/src/lib/sanitize.ts
@@ -363,6 +363,15 @@ export function sanitizeTextForStorage(text: string): string {
     .replace(/javascript\s*:/gi, "");
 }
 
+/**
+ * 移除 Unicode 格式控制字符（Cf 类别），包括零宽空格、零宽连字、
+ * 零宽非连字、字节顺序标记等不可见字符。
+ * 使用 Unicode property escape `\p{Cf}` 覆盖整个类别，避免硬编码码点列表。
+ */
+export function stripZeroWidthChars(text: string): string {
+  return text.replace(/\p{Cf}/gu, "");
+}
+
 // ── 自动封禁 ──────────────────────────────────────────
 
 const BAN_DURATION_MS = 24 * 60 * 60 * 1000; // 1 天


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 确保仅包含零宽字符的纯文本 OneBot 消息片段被视为空内容并被过滤掉。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure text-only OneBot message segments containing only zero-width characters are treated as empty and filtered out.

</details>