### PR TITLE
fix(server): preserve face/image/mface segments in private-to-review-…

### DIFF
--- a/apps/server/src/lib/private-posting.ts
+++ b/apps/server/src/lib/private-posting.ts
@@ -97,6 +97,29 @@ export function extractOneBotImageSegments(message: unknown) {
   });
 }
 
+/**
+ * 提取所有消息段，过滤掉空白的纯 text 段。
+ * 用于转发场景，保留 face、image 等非文本段，以便合并转发时正确渲染表情和图片。
+ */
+export function extractOneBotMessageSegments(message: unknown): OneBotMessageSegment[] {
+  if (!Array.isArray(message)) {
+    return [];
+  }
+
+  return message.filter((segment): segment is OneBotMessageSegment => {
+    if (!segment || typeof segment !== "object") {
+      return false;
+    }
+    const seg = segment as OneBotMessageSegment;
+    // 过滤掉空白纯文本段（只有空格/换行/零宽字符），保留有实际内容的 text 和所有非 text 段
+    if (seg.type === "text") {
+      const t = String(seg.data?.text ?? "").trim();
+      return t.length > 0;
+    }
+    return true;
+  });
+}
+
 export function extractOneBotPlainText(message: unknown, rawMessage?: string) {
   if (Array.isArray(message)) {
     return message

--- a/apps/server/src/runtime/onebot.ts
+++ b/apps/server/src/runtime/onebot.ts
@@ -22,7 +22,7 @@ import { decryptJson } from "../lib/secret-json";
 import { compressImageBuffer, deleteAttachmentObjects, uploadAttachmentBytes, type PostAttachment } from "../lib/attachments";
 import { findActiveBan, hasTenantRole } from "../lib/auth";
 import { prisma } from "../lib/prisma";
-import { extractOneBotImageSegments, extractOneBotPlainText, isPrivatePostCancelText, isPrivatePostFinishText, isPrivatePostUndoText, parsePrivatePostConfirmText, parsePrivatePostModeText, parsePrivatePostStartText, type OneBotMessageSegment } from "../lib/private-posting";
+import { extractOneBotImageSegments, extractOneBotMessageSegments, extractOneBotPlainText, isPrivatePostCancelText, isPrivatePostFinishText, isPrivatePostUndoText, parsePrivatePostConfirmText, parsePrivatePostModeText, parsePrivatePostStartText, type OneBotMessageSegment } from "../lib/private-posting";
 import { analyzePrivatePostSemantics, type PrivatePostSemanticResult } from "../lib/private-posting-ai";
 import { readTenantImageCompression, readTenantPendingPostLimit, readTenantBotStylishMessagesEnabled, readTenantBotPrivatePostStylishEnabled } from "../lib/tenant-metadata";
 import { detectPostInjection, createAutoBan } from "../lib/sanitize";
@@ -85,6 +85,7 @@ import {
   formatUnbanNotFound,
   formatBanNotify,
   formatUnbanNotify,
+  escapeCqCode,
 } from "../lib/bot-messages";
 import { buildFriendRequestAutoApprovePlan, buildSetFriendAddRequestParams, type OneBotRequestEvent } from "./onebot-friend-requests";
 
@@ -162,6 +163,7 @@ type PrivatePostPendingConfirm = PrivatePostDraft;
 type PrivateForwardEntry = {
   time: number;
   text: string;
+  segments: OneBotMessageSegment[];
 };
 
 type PrivateForwardBuffer = {
@@ -1399,16 +1401,13 @@ export class OneBotRuntime {
           return;
         }
 
-        // 跳过纯 QQ 表情包（贴图/动画表情），不转发也不回复
-        if (this.isStickerOnlyMessage(event)) {
-          return;
-        }
-
         // 跳过 "我是<昵称>" 的自我介绍消息
         const senderNickname = event.sender?.card || event.sender?.nickname;
         if (senderNickname && this.isSelfIntroMessage(plainText, senderNickname)) {
           return;
         }
+
+        const isStickerOnly = this.isStickerOnlyMessage(event);
 
         // 非投稿、非命令消息：缓存到缓冲区，1 分钟无新消息后合并转发到审核群
         if (bot.reviewGroupId) {
@@ -1418,7 +1417,13 @@ export class OneBotRuntime {
             userQqUin,
             userNickname: event.sender?.card || event.sender?.nickname || userQqUin,
             text: plainText || event.raw_message || "（不支持的消息类型）",
+            segments: extractOneBotMessageSegments(event.message),
           });
+        }
+
+        // 纯表情包消息不自动回复，避免骚扰用户
+        if (isStickerOnly) {
+          return;
         }
 
         // 保留原有自动回复
@@ -2675,7 +2680,7 @@ export class OneBotRuntime {
     buffer.userNickname = userNickname;
     buffer.delayMs = delaySeconds * 1000;
     buffer.events.push(event);
-    buffer.messages.push({ time: Math.floor(Date.now() / 1000), text });
+    buffer.messages.push({ time: Math.floor(Date.now() / 1000), text, segments: extractOneBotMessageSegments(event.message) });
     this.schedulePrivatePostAggregateFlush(key, buffer);
   }
 
@@ -2762,6 +2767,7 @@ export class OneBotRuntime {
           userQqUin: buffer.userQqUin,
           userNickname: buffer.userNickname,
           text: entry.text,
+          segments: entry.segments,
         });
       }
     }
@@ -2777,12 +2783,14 @@ export class OneBotRuntime {
     userQqUin,
     userNickname,
     text,
+    segments,
   }: {
     bot: { id: string; tenantId: string; qqUin: bigint; displayName?: string | null; reviewGroupId: string | null };
     botQqUin: string;
     userQqUin: string;
     userNickname: string;
     text: string;
+    segments?: OneBotMessageSegment[];
   }) {
     // 异步递增私信接收计数
     prisma.botAccount.update({
@@ -2809,6 +2817,7 @@ export class OneBotRuntime {
     buffer.messages.push({
       time: Math.floor(Date.now() / 1000),
       text,
+      segments: segments ?? [],
     });
 
     // 重置计时器：最后一条消息后等待 1 分钟
@@ -2851,25 +2860,26 @@ export class OneBotRuntime {
           name: string;
           uin: string;
           time?: number;
-          content: Array<{ type: "text"; data: { text: string } }>;
+          content: OneBotMessageSegment[];
         };
       }> = [];
 
       for (const entry of buffer.messages) {
+        // 如果保留了原始消息段（face/image 等），直接使用；否则降级为纯文本
+        // 合并转发中不支持的段（mface/marketface/markdown）替换为文本提示
+        const rawSegments =
+          entry.segments.length > 0
+            ? entry.segments
+            : [{ type: "text", data: { text: entry.text } }];
+        const content = this.sanitizeForwardSegments(rawSegments);
+
         nodes.push({
           type: "node",
           data: {
             name: buffer.userNickname,
             uin: buffer.userQqUin,
             time: entry.time,
-            content: [
-              {
-                type: "text",
-                data: {
-                  text: entry.text,
-                },
-              },
-            ],
+            content,
           },
         });
       }
@@ -2887,7 +2897,7 @@ export class OneBotRuntime {
         this.logger.warn({ error, botQqUin: buffer.botQqUin, userQqUin: buffer.userQqUin }, "合并转发失败，降级为普通消息发送");
         const lines = [
           `📩 ${buffer.userNickname}（${buffer.userQqUin}）发来私聊消息：`,
-          ...buffer.messages.map((entry, i) => `${i + 1}. ${entry.text}`),
+          ...buffer.messages.map((entry, i) => `${i + 1}. ${escapeCqCode(entry.text)}`),
         ];
         const fallbackData = await this.callAction(buffer.botQqUin, "send_group_msg", {
           group_id: Number(bot.reviewGroupId),
@@ -2902,6 +2912,31 @@ export class OneBotRuntime {
     } catch (error) {
       this.logger.warn({ error, botQqUin: buffer.botQqUin, userQqUin: buffer.userQqUin }, "转发私聊消息到审核群失败");
     }
+  }
+
+  /**
+   * 清理合并转发节点中可能不被 QQ 支持的段。
+   * mface（商城表情/超级表情）、marketface image、markdown 等在合并转发中可能显示为
+   * "此消息不支持查看"。将这些段替换为文本提示，保留其他段不变。
+   */
+  private sanitizeForwardSegments(segments: OneBotMessageSegment[]): OneBotMessageSegment[] {
+    return segments.flatMap((seg) => {
+      // mface 类型段（商城表情/超级表情）
+      if (seg.type === "mface") {
+        const summary = String(seg.data?.summary ?? "[超级表情]");
+        return [{ type: "text", data: { text: `[${summary}]` } }];
+      }
+      // image 中的 marketface（商城表情以 image 段上报）
+      if (seg.type === "image" && String(seg.data?.file ?? "") === "marketface") {
+        const summary = String(seg.data?.summary ?? "[商城表情]");
+        return [{ type: "text", data: { text: `[${summary}]` } }];
+      }
+      // markdown 段在双层合并转发中无法发送
+      if (seg.type === "markdown") {
+        return [{ type: "text", data: { text: "[Markdown消息]" } }];
+      }
+      return [seg];
+    });
   }
 
   private async tryResolveDisplayIdFromReply(event: OneBotMessageEvent, botQqUin: string): Promise<number | null> {

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "campux-next",


### PR DESCRIPTION
…group forward

## Summary by Sourcery

在保留并转发丰富的 OneBot 私聊消息段（表情、图片等）到复审群的同时，对不支持的消息段类型进行清理和替换。

Bug Fixes:
- 在为复审群转发而缓存和聚合私聊消息时，确保保留表情/图片以及其他非文本的 OneBot 消息段，而不是退化为纯文本。
- 在合并转发消息时，避免发送不被支持的 mface/marketface/markdown 消息段，改为用可读的文本占位符替代，以防止出现“消息不支持”的错误。
- 防止对仅包含贴纸的私聊消息自动进行机器人回复，从而减少对用户的打扰。

Enhancements:
- 在回退使用的纯文本复审通知中对 CQ 码进行转义，避免在群消息中被意外解析。
- 新增工具方法，用于提取和过滤 OneBot 消息段，在保留可转发的有效内容的同时，滤除空文本消息段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve and forward rich OneBot private message segments (faces, images, etc.) to review groups while sanitizing unsupported segment types.

Bug Fixes:
- Ensure face/image and other non-text OneBot segments are retained when buffering and aggregating private messages for review group forwarding instead of degrading to plain text.
- Avoid sending unsupported mface/marketface/markdown segments in merged forwards by replacing them with readable text placeholders to prevent "message not supported" errors.
- Prevent automatic bot replies to private messages that consist only of stickers to reduce user annoyance.

Enhancements:
- Escape CQ codes in the fallback plain-text review notification to avoid unintended parsing in group messages.
- Add utilities to extract and filter OneBot message segments, omitting empty text segments while preserving meaningful content for forwarding.

</details>