### PR TITLE
fix: prevent removing the last tenant admin

### DIFF
--- a/apps/server/src/lib/tenant-membership-removal.test.ts
+++ b/apps/server/src/lib/tenant-membership-removal.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import {
+  LastTenantAdminRemovalError,
+  assertTenantMembershipRemovalAllowed,
+  assertTenantMembershipRoleChangeAllowed,
+  buildTenantAdminUserIds,
+  retryTransactionSerializationFailures,
+} from "./tenant-membership-removal";
+
+describe("assertTenantMembershipRemovalAllowed", () => {
+  test("rejects removing the only tenant admin", () => {
+    expect(() => assertTenantMembershipRemovalAllowed({ role: "admin", adminCount: 1 })).toThrow(LastTenantAdminRemovalError);
+  });
+
+  test("allows removing an admin when another admin remains", () => {
+    expect(() => assertTenantMembershipRemovalAllowed({ role: "admin", adminCount: 2 })).not.toThrow();
+  });
+
+  test("allows removing non-admin memberships", () => {
+    expect(() => assertTenantMembershipRemovalAllowed({ role: "reviewer", adminCount: 0 })).not.toThrow();
+  });
+});
+
+describe("assertTenantMembershipRoleChangeAllowed", () => {
+  test("rejects demoting the only admin", () => {
+    expect(() => assertTenantMembershipRoleChangeAllowed({
+      currentRole: "admin",
+      nextRole: "reviewer",
+      adminCount: 1,
+    })).toThrow(LastTenantAdminRemovalError);
+  });
+
+  test("allows demoting an admin when another admin remains", () => {
+    expect(() => assertTenantMembershipRoleChangeAllowed({
+      currentRole: "admin",
+      nextRole: "submitter",
+      adminCount: 2,
+    })).not.toThrow();
+  });
+
+  test("allows promotions and unchanged roles", () => {
+    expect(() => assertTenantMembershipRoleChangeAllowed({
+      currentRole: "reviewer",
+      nextRole: "admin",
+      adminCount: 1,
+    })).not.toThrow();
+    expect(() => assertTenantMembershipRoleChangeAllowed({
+      currentRole: "admin",
+      nextRole: "admin",
+      adminCount: 1,
+    })).not.toThrow();
+  });
+});
+
+describe("buildTenantAdminUserIds", () => {
+  test("always includes the creator even when there are no other admins", () => {
+    expect(buildTenantAdminUserIds([], "creator-1")).toEqual(["creator-1"]);
+  });
+
+  test("deduplicates the creator and other admin ids", () => {
+    expect(buildTenantAdminUserIds(["operator-1", "creator-1", "operator-1"], "creator-1"))
+      .toEqual(["operator-1", "creator-1"]);
+  });
+});
+
+describe("retryTransactionSerializationFailures", () => {
+  test("retries serialization failures before returning the transaction result", async () => {
+    let attempts = 0;
+    const value = await retryTransactionSerializationFailures(
+      async () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw new Error("serialization");
+        }
+        return "removed";
+      },
+      (error) => error instanceof Error && error.message === "serialization",
+    );
+
+    expect(value).toBe("removed");
+    expect(attempts).toBe(3);
+  });
+
+  test("does not retry non-serialization failures", async () => {
+    let attempts = 0;
+    await expect(retryTransactionSerializationFailures(
+      async () => {
+        attempts += 1;
+        throw new Error("permission denied");
+      },
+      () => false,
+    )).rejects.toThrow("permission denied");
+    expect(attempts).toBe(1);
+  });
+});

--- a/apps/server/src/lib/tenant-membership-removal.test.ts
+++ b/apps/server/src/lib/tenant-membership-removal.test.ts
@@ -1,11 +1,23 @@
 import { describe, expect, test } from "bun:test";
 import {
   LastTenantAdminRemovalError,
+  TenantAdminRequiredError,
+  assertTenantActivationAllowed,
   assertTenantMembershipRemovalAllowed,
   assertTenantMembershipRoleChangeAllowed,
   buildTenantAdminUserIds,
   retryTransactionSerializationFailures,
 } from "./tenant-membership-removal";
+
+describe("assertTenantActivationAllowed", () => {
+  test("rejects activating a tenant without an admin", () => {
+    expect(() => assertTenantActivationAllowed(0)).toThrow(TenantAdminRequiredError);
+  });
+
+  test("allows activating a tenant with an admin", () => {
+    expect(() => assertTenantActivationAllowed(1)).not.toThrow();
+  });
+});
 
 describe("assertTenantMembershipRemovalAllowed", () => {
   test("rejects removing the only tenant admin", () => {

--- a/apps/server/src/lib/tenant-membership-removal.ts
+++ b/apps/server/src/lib/tenant-membership-removal.ts
@@ -1,0 +1,47 @@
+export const LAST_TENANT_ADMIN_REMOVAL_MESSAGE = "校园墙必须至少保留一名管理员，请先授权另一名管理员再移除当前管理员";
+
+export class LastTenantAdminRemovalError extends Error {
+  constructor() {
+    super(LAST_TENANT_ADMIN_REMOVAL_MESSAGE);
+    this.name = "LastTenantAdminRemovalError";
+  }
+}
+
+export function assertTenantMembershipRemovalAllowed(options: {
+  role: "submitter" | "reviewer" | "admin";
+  adminCount: number;
+}) {
+  if (options.role === "admin" && options.adminCount <= 1) {
+    throw new LastTenantAdminRemovalError();
+  }
+}
+
+export function assertTenantMembershipRoleChangeAllowed(options: {
+  currentRole: "submitter" | "reviewer" | "admin";
+  nextRole: "submitter" | "reviewer" | "admin";
+  adminCount: number;
+}) {
+  if (options.currentRole === "admin" && options.nextRole !== "admin") {
+    assertTenantMembershipRemovalAllowed({ role: options.currentRole, adminCount: options.adminCount });
+  }
+}
+
+export function buildTenantAdminUserIds(adminUserIds: string[], creatorUserId: string) {
+  return [...new Set([...adminUserIds, creatorUserId])];
+}
+
+export async function retryTransactionSerializationFailures<T>(
+  operation: () => Promise<T>,
+  isSerializationFailure: (error: unknown) => boolean,
+  maxAttempts = 3,
+): Promise<T> {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (attempt >= maxAttempts || !isSerializationFailure(error)) {
+        throw error;
+      }
+    }
+  }
+}

--- a/apps/server/src/lib/tenant-membership-removal.ts
+++ b/apps/server/src/lib/tenant-membership-removal.ts
@@ -1,4 +1,7 @@
+import { isPrismaKnownRequestError, type TenantRole } from "@campux/db";
+
 export const LAST_TENANT_ADMIN_REMOVAL_MESSAGE = "校园墙必须至少保留一名管理员，请先授权另一名管理员再移除当前管理员";
+export const TENANT_ADMIN_REQUIRED_MESSAGE = "校园墙必须至少有一名管理员，请先添加管理员再恢复运行";
 
 export class LastTenantAdminRemovalError extends Error {
   constructor() {
@@ -7,8 +10,21 @@ export class LastTenantAdminRemovalError extends Error {
   }
 }
 
+export class TenantAdminRequiredError extends Error {
+  constructor() {
+    super(TENANT_ADMIN_REQUIRED_MESSAGE);
+    this.name = "TenantAdminRequiredError";
+  }
+}
+
+export function assertTenantActivationAllowed(adminCount: number) {
+  if (adminCount < 1) {
+    throw new TenantAdminRequiredError();
+  }
+}
+
 export function assertTenantMembershipRemovalAllowed(options: {
-  role: "submitter" | "reviewer" | "admin";
+  role: TenantRole;
   adminCount: number;
 }) {
   if (options.role === "admin" && options.adminCount <= 1) {
@@ -17,8 +33,8 @@ export function assertTenantMembershipRemovalAllowed(options: {
 }
 
 export function assertTenantMembershipRoleChangeAllowed(options: {
-  currentRole: "submitter" | "reviewer" | "admin";
-  nextRole: "submitter" | "reviewer" | "admin";
+  currentRole: TenantRole;
+  nextRole: TenantRole;
   adminCount: number;
 }) {
   if (options.currentRole === "admin" && options.nextRole !== "admin") {
@@ -28,6 +44,10 @@ export function assertTenantMembershipRoleChangeAllowed(options: {
 
 export function buildTenantAdminUserIds(adminUserIds: string[], creatorUserId: string) {
   return [...new Set([...adminUserIds, creatorUserId])];
+}
+
+export function isTransactionSerializationFailure(error: unknown) {
+  return isPrismaKnownRequestError(error) && error.code === "P2034";
 }
 
 export async function retryTransactionSerializationFailures<T>(
@@ -42,6 +62,7 @@ export async function retryTransactionSerializationFailures<T>(
       if (attempt >= maxAttempts || !isSerializationFailure(error)) {
         throw error;
       }
+      await new Promise((resolve) => setTimeout(resolve, attempt * 10));
     }
   }
 }

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -1,8 +1,13 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
-import { Prisma, type TenantRole } from "@campux/db";
+import { Prisma, TransactionIsolationLevel, isPrismaKnownRequestError, type TenantRole } from "@campux/db";
 import { requireTenantRole } from "../lib/auth";
 import { prisma } from "../lib/prisma";
+import {
+  LastTenantAdminRemovalError,
+  assertTenantMembershipRoleChangeAllowed,
+  retryTransactionSerializationFailures,
+} from "../lib/tenant-membership-removal";
 import { decryptJson, encryptJson } from "../lib/secret-json";
 import { writeAuditLog } from "../lib/audit";
 import { buildUserContainsSearch, findUserIdsByContainsSearch } from "../lib/user-search";
@@ -159,6 +164,10 @@ const memberQuerySchema = paginationQuerySchema.extend({
   role: z.enum(["all", "submitter", "reviewer", "admin"]).default("all"),
   sort: memberSortSchema.default("joined_asc"),
 });
+
+function isTransactionSerializationFailure(error: unknown) {
+  return isPrismaKnownRequestError(error) && error.code === "P2034";
+}
 
 function memberOrderBy(sort: z.infer<typeof memberSortSchema>): Prisma.TenantMembershipOrderByWithRelationInput[] {
   switch (sort) {
@@ -347,25 +356,61 @@ export function registerAdminRoutes(app: FastifyInstance, queue: RuntimeQueue, o
       return reply.code(404).send({ message: "账号不存在，请先让该账号通过 Bot 注册或由运维创建" });
     }
 
-    const member = await prisma.tenantMembership.upsert({
-      where: {
-        tenantId_userId: {
-          tenantId: context.selectedTenant.id,
-          userId: user.id,
-        },
-      },
-      update: {
-        role: body.role,
-      },
-      create: {
-        tenantId: context.selectedTenant.id,
-        userId: user.id,
-        role: body.role,
-      },
-      include: {
-        user: true,
-      },
-    });
+    let member;
+    try {
+      member = await retryTransactionSerializationFailures(
+        () => prisma.$transaction(async (tx) => {
+          const existingMembership = await tx.tenantMembership.findUnique({
+            where: {
+              tenantId_userId: {
+                tenantId: context.selectedTenant.id,
+                userId: user.id,
+              },
+            },
+          });
+
+          if (existingMembership?.role === "admin" && body.role !== "admin") {
+            const adminCount = await tx.tenantMembership.count({
+              where: { tenantId: context.selectedTenant.id, role: "admin" },
+            });
+            assertTenantMembershipRoleChangeAllowed({
+              currentRole: existingMembership.role,
+              nextRole: body.role,
+              adminCount,
+            });
+          }
+
+          return tx.tenantMembership.upsert({
+            where: {
+              tenantId_userId: {
+                tenantId: context.selectedTenant.id,
+                userId: user.id,
+              },
+            },
+            update: {
+              role: body.role,
+            },
+            create: {
+              tenantId: context.selectedTenant.id,
+              userId: user.id,
+              role: body.role,
+            },
+            include: {
+              user: true,
+            },
+          });
+        }, { isolationLevel: TransactionIsolationLevel.Serializable }),
+        isTransactionSerializationFailure,
+      );
+    } catch (error) {
+      if (error instanceof LastTenantAdminRemovalError) {
+        return reply.code(409).send({
+          code: "LAST_TENANT_ADMIN",
+          message: error.message,
+        });
+      }
+      throw error;
+    }
 
     await writeAuditLog({
       tenantId: context.selectedTenant.id,
@@ -388,28 +433,54 @@ export function registerAdminRoutes(app: FastifyInstance, queue: RuntimeQueue, o
     const context = await requireTenantRole(request, reply, "admin");
     const params = memberParamsSchema.parse(request.params);
     const body = memberPatchSchema.parse(request.body);
-    const member = await prisma.tenantMembership.findFirst({
-      where: {
-        id: params.id,
-        tenantId: context.selectedTenant.id,
-      },
-    });
+    let updateResult;
+    try {
+      updateResult = await retryTransactionSerializationFailures(
+        () => prisma.$transaction(async (tx) => {
+          const member = await tx.tenantMembership.findFirst({
+            where: {
+              id: params.id,
+              tenantId: context.selectedTenant.id,
+            },
+          });
+          if (!member) {
+            return null;
+          }
 
-    if (!member) {
-      return reply.code(404).send({ message: "成员不存在" });
+          if (member.role === "admin" && body.role !== "admin") {
+            const adminCount = await tx.tenantMembership.count({
+              where: { tenantId: context.selectedTenant.id, role: "admin" },
+            });
+            assertTenantMembershipRoleChangeAllowed({
+              currentRole: member.role,
+              nextRole: body.role,
+              adminCount,
+            });
+          }
+
+          const updated = await tx.tenantMembership.update({
+            where: { id: member.id },
+            data: { role: body.role },
+            include: { user: true },
+          });
+          return { member, updated };
+        }, { isolationLevel: TransactionIsolationLevel.Serializable }),
+        isTransactionSerializationFailure,
+      );
+    } catch (error) {
+      if (error instanceof LastTenantAdminRemovalError) {
+        return reply.code(409).send({
+          code: "LAST_TENANT_ADMIN",
+          message: error.message,
+        });
+      }
+      throw error;
     }
 
-    const updated = await prisma.tenantMembership.update({
-      where: {
-        id: member.id,
-      },
-      data: {
-        role: body.role,
-      },
-      include: {
-        user: true,
-      },
-    });
+    if (!updateResult) {
+      return reply.code(404).send({ message: "成员不存在" });
+    }
+    const { member, updated } = updateResult;
 
     await writeAuditLog({
       tenantId: context.selectedTenant.id,

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -1,11 +1,12 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
-import { Prisma, TransactionIsolationLevel, isPrismaKnownRequestError, type TenantRole } from "@campux/db";
+import { Prisma, TransactionIsolationLevel, type TenantRole } from "@campux/db";
 import { requireTenantRole } from "../lib/auth";
 import { prisma } from "../lib/prisma";
 import {
   LastTenantAdminRemovalError,
   assertTenantMembershipRoleChangeAllowed,
+  isTransactionSerializationFailure,
   retryTransactionSerializationFailures,
 } from "../lib/tenant-membership-removal";
 import { decryptJson, encryptJson } from "../lib/secret-json";
@@ -164,10 +165,6 @@ const memberQuerySchema = paginationQuerySchema.extend({
   role: z.enum(["all", "submitter", "reviewer", "admin"]).default("all"),
   sort: memberSortSchema.default("joined_asc"),
 });
-
-function isTransactionSerializationFailure(error: unknown) {
-  return isPrismaKnownRequestError(error) && error.code === "P2034";
-}
 
 function memberOrderBy(sort: z.infer<typeof memberSortSchema>): Prisma.TenantMembershipOrderByWithRelationInput[] {
   switch (sort) {

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -1,15 +1,18 @@
 import type { FastifyInstance, FastifyReply } from "fastify";
 import type { CampuxConfig } from "@campux/config";
-import { Prisma, TransactionIsolationLevel, createManyDedup, isPrismaKnownRequestError } from "@campux/db";
+import { Prisma, TransactionIsolationLevel, createManyDedup, type Tenant } from "@campux/db";
 import { z } from "zod";
 import { requirePlatformAdmin } from "../lib/auth";
 import { writeAuditLog } from "../lib/audit";
 import { prisma } from "../lib/prisma";
 import {
   LastTenantAdminRemovalError,
+  TenantAdminRequiredError,
+  assertTenantActivationAllowed,
   assertTenantMembershipRemovalAllowed,
   assertTenantMembershipRoleChangeAllowed,
   buildTenantAdminUserIds,
+  isTransactionSerializationFailure,
   retryTransactionSerializationFailures,
 } from "../lib/tenant-membership-removal";
 import { normalizeTenantHost } from "../lib/tenant-host";
@@ -165,10 +168,6 @@ function assertCanManageTenant(context: PlatformContext, tenantId: string, reply
 
   reply.code(403);
   throw new Error("只能管理自己所属的校园墙");
-}
-
-function isTransactionSerializationFailure(error: unknown) {
-  return isPrismaKnownRequestError(error) && error.code === "P2034";
 }
 
 async function getManagementHost() {
@@ -474,6 +473,23 @@ export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, 
       if (conflict) return conflict;
     }
 
+    if (body.status === "active") {
+      const adminCount = await prisma.tenantMembership.count({
+        where: { tenantId: params.tenantId, role: "admin" },
+      });
+      try {
+        assertTenantActivationAllowed(adminCount);
+      } catch (error) {
+        if (error instanceof TenantAdminRequiredError) {
+          return reply.code(409).send({
+            code: "TENANT_ADMIN_REQUIRED",
+            message: error.message,
+          });
+        }
+        throw error;
+      }
+    }
+
     // When the host is changing and either the old or new host is managed by
     // the auto-domain automation, sync Cloudflare BEFORE writing the DB so a
     // failed DNS change leaves the tenant's stored host untouched (no drift
@@ -523,10 +539,35 @@ export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, 
     // scheduler does not immediately re-archive it.
     if (body.status === "active") updateData.archiveWarningAt = null;
 
-    const tenant = await prisma.tenant.update({
-      where: { id: params.tenantId },
-      data: updateData,
-    });
+    let tenant: Tenant;
+    try {
+      tenant = body.status === "active"
+        ? await retryTransactionSerializationFailures(
+          () => prisma.$transaction(async (tx) => {
+            const adminCount = await tx.tenantMembership.count({
+              where: { tenantId: params.tenantId, role: "admin" },
+            });
+            assertTenantActivationAllowed(adminCount);
+            return tx.tenant.update({
+              where: { id: params.tenantId },
+              data: updateData,
+            });
+          }, { isolationLevel: TransactionIsolationLevel.Serializable }),
+          isTransactionSerializationFailure,
+        )
+        : await prisma.tenant.update({
+          where: { id: params.tenantId },
+          data: updateData,
+        });
+    } catch (error) {
+      if (error instanceof TenantAdminRequiredError) {
+        return reply.code(409).send({
+          code: "TENANT_ADMIN_REQUIRED",
+          message: error.message,
+        });
+      }
+      throw error;
+    }
     await writeAuditLog({
       tenantId: tenant.id,
       actorId: context.user.id,

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -703,6 +703,7 @@ export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, 
     if (!body.tenantId) {
       return reply.code(400).send({ message: "添加租户身份时必须选择校园墙" });
     }
+    const tenantRole = body.role;
     assertCanManageTenant(context, body.tenantId, reply);
 
     const tenant = await prisma.tenant.findUnique({ where: { id: body.tenantId } });
@@ -723,13 +724,13 @@ export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, 
             },
           });
 
-          if (existingMembership?.role === "admin" && body.role !== "admin") {
+          if (existingMembership?.role === "admin" && tenantRole !== "admin") {
             const adminCount = await tx.tenantMembership.count({
               where: { tenantId: tenant.id, role: "admin" },
             });
             assertTenantMembershipRoleChangeAllowed({
               currentRole: existingMembership.role,
-              nextRole: body.role,
+              nextRole: tenantRole,
               adminCount,
             });
           }
@@ -742,12 +743,12 @@ export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, 
               },
             },
             update: {
-              role: body.role,
+              role: tenantRole,
             },
             create: {
               tenantId: tenant.id,
               userId: user.id,
-              role: body.role,
+              role: tenantRole,
             },
           });
         }, { isolationLevel: TransactionIsolationLevel.Serializable }),
@@ -773,7 +774,7 @@ export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, 
         qqUin: user.qqUin.toString(),
         tenantId: tenant.id,
         tenantName: tenant.name,
-        role: body.role,
+        role: tenantRole,
       },
     });
 

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -1,10 +1,17 @@
 import type { FastifyInstance, FastifyReply } from "fastify";
 import type { CampuxConfig } from "@campux/config";
-import { Prisma, createManyDedup } from "@campux/db";
+import { Prisma, TransactionIsolationLevel, createManyDedup, isPrismaKnownRequestError } from "@campux/db";
 import { z } from "zod";
 import { requirePlatformAdmin } from "../lib/auth";
 import { writeAuditLog } from "../lib/audit";
 import { prisma } from "../lib/prisma";
+import {
+  LastTenantAdminRemovalError,
+  assertTenantMembershipRemovalAllowed,
+  assertTenantMembershipRoleChangeAllowed,
+  buildTenantAdminUserIds,
+  retryTransactionSerializationFailures,
+} from "../lib/tenant-membership-removal";
 import { normalizeTenantHost } from "../lib/tenant-host";
 import {
   buildTenantDomainHost,
@@ -158,6 +165,10 @@ function assertCanManageTenant(context: PlatformContext, tenantId: string, reply
 
   reply.code(403);
   throw new Error("只能管理自己所属的校园墙");
+}
+
+function isTransactionSerializationFailure(error: unknown) {
+  return isPrismaKnownRequestError(error) && error.code === "P2034";
 }
 
 async function getManagementHost() {
@@ -399,18 +410,16 @@ export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, 
             .then((users) => users.map((user) => user.id))
         : [context.user.id];
 
-      const uniqueAdminUserIds = [...new Set([...adminUserIds, context.user.id])];
-      if (uniqueAdminUserIds.length > 0) {
-        await createManyDedup(
-          tx.tenantMembership,
-          uniqueAdminUserIds.map((userId) => ({
-            tenantId: created.id,
-            userId,
-            role: "admin" as const,
-          })),
-          (row) => `${row.tenantId}:${row.userId}`,
-        );
-      }
+      const uniqueAdminUserIds = buildTenantAdminUserIds(adminUserIds, context.user.id);
+      await createManyDedup(
+        tx.tenantMembership,
+        uniqueAdminUserIds.map((userId) => ({
+          tenantId: created.id,
+          userId,
+          role: "admin" as const,
+        })),
+        (row) => `${row.tenantId}:${row.userId}`,
+      );
 
       if (body.botQqUin) {
         const bot = await tx.botAccount.create({
@@ -701,22 +710,58 @@ export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, 
       return reply.code(404).send({ message: "租户不存在" });
     }
 
-    const membership = await prisma.tenantMembership.upsert({
-      where: {
-        tenantId_userId: {
-          tenantId: tenant.id,
-          userId: user.id,
-        },
-      },
-      update: {
-        role: body.role,
-      },
-      create: {
-        tenantId: tenant.id,
-        userId: user.id,
-        role: body.role,
-      },
-    });
+    let membership;
+    try {
+      membership = await retryTransactionSerializationFailures(
+        () => prisma.$transaction(async (tx) => {
+          const existingMembership = await tx.tenantMembership.findUnique({
+            where: {
+              tenantId_userId: {
+                tenantId: tenant.id,
+                userId: user.id,
+              },
+            },
+          });
+
+          if (existingMembership?.role === "admin" && body.role !== "admin") {
+            const adminCount = await tx.tenantMembership.count({
+              where: { tenantId: tenant.id, role: "admin" },
+            });
+            assertTenantMembershipRoleChangeAllowed({
+              currentRole: existingMembership.role,
+              nextRole: body.role,
+              adminCount,
+            });
+          }
+
+          return tx.tenantMembership.upsert({
+            where: {
+              tenantId_userId: {
+                tenantId: tenant.id,
+                userId: user.id,
+              },
+            },
+            update: {
+              role: body.role,
+            },
+            create: {
+              tenantId: tenant.id,
+              userId: user.id,
+              role: body.role,
+            },
+          });
+        }, { isolationLevel: TransactionIsolationLevel.Serializable }),
+        isTransactionSerializationFailure,
+      );
+    } catch (error) {
+      if (error instanceof LastTenantAdminRemovalError) {
+        return reply.code(409).send({
+          code: "LAST_TENANT_ADMIN",
+          message: error.message,
+        });
+      }
+      throw error;
+    }
 
     await writeAuditLog({
       tenantId: tenant.id,
@@ -744,26 +789,55 @@ export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, 
   app.delete("/api/system/users/:userId/memberships/:membershipId", async (request, reply) => {
     const context = await requirePlatformAdmin(request, reply);
     const params = z.object({ userId: z.string().min(1), membershipId: z.string().min(1) }).parse(request.params);
-    const membership = await prisma.tenantMembership.findFirst({
-      where: {
-        id: params.membershipId,
-        userId: params.userId,
-      },
-      include: {
-        tenant: true,
-        user: true,
-      },
-    });
+    let membership;
+    try {
+      membership = await retryTransactionSerializationFailures(
+        () => prisma.$transaction(async (tx) => {
+          const existingMembership = await tx.tenantMembership.findFirst({
+            where: {
+              id: params.membershipId,
+              userId: params.userId,
+            },
+            include: {
+              tenant: true,
+              user: true,
+            },
+          });
+          if (!existingMembership) {
+            return null;
+          }
+          assertCanManageTenant(context, existingMembership.tenantId, reply);
+
+          if (existingMembership.role === "admin") {
+            const adminCount = await tx.tenantMembership.count({
+              where: { tenantId: existingMembership.tenantId, role: "admin" },
+            });
+            assertTenantMembershipRemovalAllowed({
+              role: existingMembership.role,
+              adminCount,
+            });
+          }
+
+          await tx.tenantMembership.delete({
+            where: { id: existingMembership.id },
+          });
+          return existingMembership;
+        }, { isolationLevel: TransactionIsolationLevel.Serializable }),
+        isTransactionSerializationFailure,
+      );
+    } catch (error) {
+      if (error instanceof LastTenantAdminRemovalError) {
+        return reply.code(409).send({
+          code: "LAST_TENANT_ADMIN",
+          message: error.message,
+        });
+      }
+      throw error;
+    }
+
     if (!membership) {
       return reply.code(404).send({ message: "租户身份不存在" });
     }
-    assertCanManageTenant(context, membership.tenantId, reply);
-
-    await prisma.tenantMembership.delete({
-      where: {
-        id: membership.id,
-      },
-    });
 
     await writeAuditLog({
       tenantId: membership.tenantId,

--- a/apps/web/src/features/admin/AdminPage.tsx
+++ b/apps/web/src/features/admin/AdminPage.tsx
@@ -26,6 +26,7 @@ import {
 import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { roleLabels, statusLabels } from "@/lib/app-model";
+import { buildMembershipRoleChangeConfirmation } from "../ops/membership-removal-confirmation";
 import { readListPreferences, writeListPreferences } from "@/lib/list-preferences";
 import { hasAnyQueryParam, readQueryInt, readQueryParam, writeQueryParams } from "@/lib/url-query";
 import type { AdminBanRecord, AdminBotAccount, AdminBotEvent, AdminMember, AdminMemberDetail, AdminTab, AiRules, OAuthClientItem, OAuthClientSecretResponse, OAuthClientSettingsResponse, OAuthServerSettings, Pagination, PublishAttemptItem, PublishTargetItem, PublishTextTemplate, TenantAiSettings, TenantMetadata, TenantRole } from "@/types/app";
@@ -292,6 +293,7 @@ function writeBanListPreferences(tenantId: string, preferences: BanListPreferenc
 
 export function AdminPage({
   activeTab,
+  currentUserId,
   selectedTenant,
   metadata,
   detailTarget,
@@ -301,6 +303,7 @@ export function AdminPage({
   onSaved,
 }: {
   activeTab: AdminTab;
+  currentUserId: string;
   selectedTenant: TenantSummary;
   metadata: TenantMetadata;
   detailTarget?: { userId: string; nonce: number } | null;
@@ -719,12 +722,27 @@ export function AdminPage({
     }
   }
 
-  async function updateMemberRole(id: string, role: TenantRole) {
-    await api(`/api/admin/members/${id}`, {
-      method: "PATCH",
-      body: JSON.stringify({ role }),
+  async function updateMemberRole(member: AdminMember, role: TenantRole) {
+    const confirmation = buildMembershipRoleChangeConfirmation({
+      actorUserId: currentUserId,
+      targetUserId: member.user.id,
+      tenantName: selectedTenant.name,
+      currentRole: member.role,
+      nextRole: role,
     });
-    await refreshAdminData();
+    if (confirmation && !window.confirm(confirmation)) {
+      return;
+    }
+
+    try {
+      await api(`/api/admin/members/${member.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ role }),
+      });
+      await refreshAdminData();
+    } catch (caught) {
+      toast.error(caught instanceof Error ? caught.message : "更新用户身份失败");
+    }
   }
 
   async function addMember() {
@@ -1073,7 +1091,7 @@ export function AdminPage({
                 }}
                 onFormChange={setMemberForm}
                 onAddMember={() => void addMember()}
-                onRoleChange={(id, role) => void updateMemberRole(id, role)}
+                onRoleChange={(member, role) => void updateMemberRole(member, role)}
                 onViewMember={(member) => void openMemberDetail(member.user.id)}
                 onPrepareBan={(member) => {
                   setBanForm((current) => ({ ...current, qqUin: member.user.qqUin }));
@@ -1325,7 +1343,7 @@ function UsersPanel({
   onPageChange: (page: number) => void;
   onFormChange: (form: MemberForm) => void;
   onAddMember: () => void;
-  onRoleChange: (id: string, role: TenantRole) => void;
+  onRoleChange: (member: AdminMember, role: TenantRole) => void;
   onViewMember: (member: AdminMember) => void;
   onPrepareBan: (member: AdminMember) => void;
 }) {
@@ -1417,7 +1435,7 @@ function UsersPanel({
               </div>
               <div className="flex items-center gap-2">
                 <div onClick={(event) => event.stopPropagation()} onKeyDown={(event) => event.stopPropagation()}>
-                  <Select value={member.role} onValueChange={(role) => onRoleChange(member.id, role as TenantRole)}>
+                  <Select value={member.role} onValueChange={(role) => onRoleChange(member, role as TenantRole)}>
                     <SelectTrigger className="bg-white font-bold">
                       <SelectValue />
                     </SelectTrigger>

--- a/apps/web/src/features/ops/OpsPanel.tsx
+++ b/apps/web/src/features/ops/OpsPanel.tsx
@@ -21,7 +21,10 @@ import {
 import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { readListPreferences, writeListPreferences } from "@/lib/list-preferences";
-import { buildMembershipRemovalConfirmation } from "./membership-removal-confirmation";
+import {
+  buildMembershipRemovalConfirmation,
+  buildMembershipRoleChangeConfirmation,
+} from "./membership-removal-confirmation";
 import type { AuditLogItem, Pagination, SystemQueueSnapshot, SystemRole, SystemTenant, SystemUser, TenantRole, TenantStatus } from "@/types/app";
 import { PaginationControls } from "@/components/app/utility";
 import { Badge } from "@/components/ui/badge";
@@ -575,6 +578,28 @@ export function OpsPanel({
     const assigningGlobalRole = membershipForm.role === "system_operator" || membershipForm.role === "operations_admin";
     if (!membershipDialogUser || (!assigningGlobalRole && !membershipForm.tenantId)) {
       return;
+    }
+
+    if (
+      membershipForm.role === "submitter"
+      || membershipForm.role === "reviewer"
+      || membershipForm.role === "admin"
+    ) {
+      const existingMembership = membershipDialogUser.memberships.find(
+        (membership) => membership.tenant.id === membershipForm.tenantId,
+      );
+      if (existingMembership) {
+        const confirmation = buildMembershipRoleChangeConfirmation({
+          actorUserId: currentUserId,
+          targetUserId: membershipDialogUser.id,
+          tenantName: existingMembership.tenant.name,
+          currentRole: existingMembership.role,
+          nextRole: membershipForm.role,
+        });
+        if (confirmation && !window.confirm(confirmation)) {
+          return;
+        }
+      }
     }
 
     setAssigningMembership(true);

--- a/apps/web/src/features/ops/OpsPanel.tsx
+++ b/apps/web/src/features/ops/OpsPanel.tsx
@@ -21,6 +21,7 @@ import {
 import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { readListPreferences, writeListPreferences } from "@/lib/list-preferences";
+import { buildMembershipRemovalConfirmation } from "./membership-removal-confirmation";
 import type { AuditLogItem, Pagination, SystemQueueSnapshot, SystemRole, SystemTenant, SystemUser, TenantRole, TenantStatus } from "@/types/app";
 import { PaginationControls } from "@/components/app/utility";
 import { Badge } from "@/components/ui/badge";
@@ -149,10 +150,12 @@ function createTenantFormState(existingSlugs?: ReadonlySet<string>) {
 }
 
 export function OpsPanel({
+  currentUserId,
   mode = "system",
   onTenantCreated,
   onEnterTenant,
 }: {
+  currentUserId: string;
   mode?: OpsPanelMode;
   onTenantCreated?: (() => Promise<void>) | undefined;
   onEnterTenant?: ((tenantId: string) => Promise<void>) | undefined;
@@ -624,6 +627,18 @@ export function OpsPanel({
   }
 
   async function revokeOperationsAdminTenant(user: SystemUser, membershipId: string, tenantName: string) {
+    const confirmation = buildMembershipRemovalConfirmation({
+      actorUserId: currentUserId,
+      targetUserId: user.id,
+      targetLabel: user.displayName ?? user.qqUin,
+      tenantName,
+      role: "admin",
+      roleLabel: roleLabels.admin,
+    });
+    if (!window.confirm(confirmation)) {
+      return;
+    }
+
     const busyKey = `revoke:${membershipId}`;
     setAccessBusyKey(busyKey);
     try {
@@ -640,7 +655,15 @@ export function OpsPanel({
   }
 
   async function revokeUserTenantMembership(user: SystemUser, membership: SystemUser["memberships"][number]) {
-    if (!window.confirm(`确认移除 ${user.displayName ?? user.qqUin} 在 ${membership.tenant.name} 的${roleLabels[membership.role]}身份？`)) {
+    const confirmation = buildMembershipRemovalConfirmation({
+      actorUserId: currentUserId,
+      targetUserId: user.id,
+      targetLabel: user.displayName ?? user.qqUin,
+      tenantName: membership.tenant.name,
+      role: membership.role,
+      roleLabel: roleLabels[membership.role],
+    });
+    if (!window.confirm(confirmation)) {
       return;
     }
 

--- a/apps/web/src/features/ops/OpsStandaloneScreen.tsx
+++ b/apps/web/src/features/ops/OpsStandaloneScreen.tsx
@@ -43,7 +43,7 @@ export function OpsStandaloneScreen({
       </header>
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
         <div className="mx-auto max-w-6xl">
-          <OpsPanel mode={mode} onTenantCreated={onTenantCreated} onEnterTenant={onEnterTenant} />
+          <OpsPanel currentUserId={me.user.id} mode={mode} onTenantCreated={onTenantCreated} onEnterTenant={onEnterTenant} />
         </div>
       </div>
     </main>

--- a/apps/web/src/features/ops/membership-removal-confirmation.test.ts
+++ b/apps/web/src/features/ops/membership-removal-confirmation.test.ts
@@ -1,5 +1,40 @@
 import { describe, expect, test } from "bun:test";
-import { buildMembershipRemovalConfirmation } from "./membership-removal-confirmation";
+import {
+  buildMembershipRemovalConfirmation,
+  buildMembershipRoleChangeConfirmation,
+} from "./membership-removal-confirmation";
+
+describe("buildMembershipRoleChangeConfirmation", () => {
+  test("warns before an admin demotes themselves", () => {
+    expect(buildMembershipRoleChangeConfirmation({
+      actorUserId: "user-1",
+      targetUserId: "user-1",
+      tenantName: "好难猜啊",
+      currentRole: "admin",
+      nextRole: "reviewer",
+    })).toBe("你正在将自己在「好难猜啊」的身份从管理员改为审核员，将失去管理员权限。确认继续？如果这是最后一名管理员，系统会阻止操作。");
+  });
+
+  test("does not prompt for another user's role change", () => {
+    expect(buildMembershipRoleChangeConfirmation({
+      actorUserId: "user-1",
+      targetUserId: "user-2",
+      tenantName: "好难猜啊",
+      currentRole: "admin",
+      nextRole: "reviewer",
+    })).toBeNull();
+  });
+
+  test("does not prompt when the actor keeps admin access", () => {
+    expect(buildMembershipRoleChangeConfirmation({
+      actorUserId: "user-1",
+      targetUserId: "user-1",
+      tenantName: "好难猜啊",
+      currentRole: "admin",
+      nextRole: "admin",
+    })).toBeNull();
+  });
+});
 
 describe("buildMembershipRemovalConfirmation", () => {
   test("warns clearly when an operator removes their own access", () => {

--- a/apps/web/src/features/ops/membership-removal-confirmation.test.ts
+++ b/apps/web/src/features/ops/membership-removal-confirmation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { buildMembershipRemovalConfirmation } from "./membership-removal-confirmation";
+
+describe("buildMembershipRemovalConfirmation", () => {
+  test("warns clearly when an operator removes their own access", () => {
+    expect(buildMembershipRemovalConfirmation({
+      actorUserId: "user-1",
+      targetUserId: "user-1",
+      targetLabel: "ShanFishDev",
+      tenantName: "好难猜啊",
+      role: "admin",
+      roleLabel: "管理员",
+    })).toBe("你正在移除自己在「好难猜啊」的管理员身份。确认继续？如果这是最后一名管理员，系统会阻止操作。");
+  });
+
+  test("identifies the target when removing another user's access", () => {
+    expect(buildMembershipRemovalConfirmation({
+      actorUserId: "user-1",
+      targetUserId: "user-2",
+      targetLabel: "AnotherOperator",
+      tenantName: "好难猜啊",
+      role: "admin",
+      roleLabel: "管理员",
+    })).toBe("确认移除 AnotherOperator 在「好难猜啊」的管理员身份？如果这是最后一名管理员，系统会阻止操作。");
+  });
+});

--- a/apps/web/src/features/ops/membership-removal-confirmation.ts
+++ b/apps/web/src/features/ops/membership-removal-confirmation.ts
@@ -1,9 +1,35 @@
+type TenantRole = "submitter" | "reviewer" | "admin";
+
+const membershipRoleLabels: Record<TenantRole, string> = {
+  submitter: "投稿用户",
+  reviewer: "审核员",
+  admin: "管理员",
+};
+
+export function buildMembershipRoleChangeConfirmation(options: {
+  actorUserId: string;
+  targetUserId: string;
+  tenantName: string;
+  currentRole: TenantRole;
+  nextRole: TenantRole;
+}) {
+  if (
+    options.actorUserId !== options.targetUserId
+    || options.currentRole !== "admin"
+    || options.nextRole === "admin"
+  ) {
+    return null;
+  }
+
+  return `你正在将自己在「${options.tenantName}」的身份从管理员改为${membershipRoleLabels[options.nextRole]}，将失去管理员权限。确认继续？如果这是最后一名管理员，系统会阻止操作。`;
+}
+
 export function buildMembershipRemovalConfirmation(options: {
   actorUserId: string;
   targetUserId: string;
   targetLabel: string;
   tenantName: string;
-  role: "submitter" | "reviewer" | "admin";
+  role: TenantRole;
   roleLabel: string;
 }) {
   const lastAdminWarning = options.role === "admin"

--- a/apps/web/src/features/ops/membership-removal-confirmation.ts
+++ b/apps/web/src/features/ops/membership-removal-confirmation.ts
@@ -1,0 +1,17 @@
+export function buildMembershipRemovalConfirmation(options: {
+  actorUserId: string;
+  targetUserId: string;
+  targetLabel: string;
+  tenantName: string;
+  role: "submitter" | "reviewer" | "admin";
+  roleLabel: string;
+}) {
+  const lastAdminWarning = options.role === "admin"
+    ? "如果这是最后一名管理员，系统会阻止操作。"
+    : "";
+  if (options.actorUserId === options.targetUserId) {
+    return `你正在移除自己在「${options.tenantName}」的${options.roleLabel}身份。确认继续？${lastAdminWarning}`;
+  }
+
+  return `确认移除 ${options.targetLabel} 在「${options.tenantName}」的${options.roleLabel}身份？${lastAdminWarning}`;
+}

--- a/apps/web/src/features/shell/AppShell.tsx
+++ b/apps/web/src/features/shell/AppShell.tsx
@@ -161,6 +161,7 @@ export function AppShell({
             <TabsContent value="admin" forceMount className="m-0 flex h-full min-h-0 flex-col overflow-hidden data-[state=inactive]:hidden">
               <AdminPage
                 activeTab={adminTab}
+                currentUserId={me.user.id}
                 selectedTenant={me.currentTenant}
                 metadata={metadata}
                 detailTarget={adminUserDetailTarget}

--- a/packages/db/src/seed-membership.test.ts
+++ b/packages/db/src/seed-membership.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { membershipRoleUpdateForSeed } from "./seed-membership";
+
+describe("membershipRoleUpdateForSeed", () => {
+  test("never demotes an existing membership during reseeding", () => {
+    expect(membershipRoleUpdateForSeed("submitter")).toEqual({});
+    expect(membershipRoleUpdateForSeed("reviewer")).toEqual({});
+  });
+
+  test("allows a safe promotion to admin during reseeding", () => {
+    expect(membershipRoleUpdateForSeed("admin")).toEqual({ role: "admin" });
+  });
+});

--- a/packages/db/src/seed-membership.ts
+++ b/packages/db/src/seed-membership.ts
@@ -1,0 +1,5 @@
+import type { TenantRole } from "@prisma/client";
+
+export function membershipRoleUpdateForSeed(role: TenantRole): { role?: TenantRole } {
+  return role === "admin" ? { role } : {};
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from "@prisma/client";
 import { hashPassword } from "./password";
+import { membershipRoleUpdateForSeed } from "./seed-membership";
 
 // Guard: the demo seed creates well-known accounts with a shared weak password
 // ("campux123"), including a system_operator. That is fine for local dev but a
@@ -176,9 +177,7 @@ async function seedUser({
           userId: user.id,
         },
       },
-      update: {
-        role: membership.role,
-      },
+      update: membershipRoleUpdateForSeed(membership.role),
       create: {
         tenantId: membership.tenantId,
         userId: user.id,


### PR DESCRIPTION
## Summary
- guarantee every newly-created tenant includes its creator as an administrator
- reject deleting, demoting, or upsert-demoting the last tenant admin with HTTP 409 / `LAST_TENANT_ADMIN`
- serialize admin-count checks and mutations with bounded Prisma `P2034` retries and short backoff
- reject restoring legacy zero-admin tenants to `active` with HTTP 409 / `TENANT_ADMIN_REQUIRED`
- prevent demo reseeding from demoting existing tenant memberships
- require explicit confirmation before self-demotion in both tenant admin and platform operations UIs, with visible API error feedback

## Verification
- `bun test` — 339 passed, 5 skipped, 0 failed
- `bun --cwd apps/server typecheck`
- `bun --cwd apps/web typecheck`
- `git diff --check`
- focused invariant, UI copy, seed policy, and retry tests
- branch Docker build and PR checks must pass on the final SHA before merge

## Concurrency invariant
The admin count and membership mutation run in the same `Serializable` transaction. Prisma `P2034` conflicts are retried with bounded backoff, preventing concurrent delete/demotion requests from both observing another admin and committing a zero-admin state. Tenant reactivation performs the same serialized admin-count check.

## Production verification
After GitOps deployment, use a disposable tenant only; do not modify tenant `9178`.