### PR TITLE
fix: close tenant admin invariant follow-up gaps

### DIFF
--- a/apps/server/src/lib/audit.test.ts
+++ b/apps/server/src/lib/audit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { writeAuditLog } from "./audit";
+
+describe("writeAuditLog", () => {
+  test("uses the provided transaction client so audit and business writes can commit atomically", async () => {
+    let createdData: unknown;
+    const transactionClient = {
+      auditLog: {
+        create: async ({ data }: { data: unknown }) => {
+          createdData = data;
+          return { id: "audit-1" };
+        },
+      },
+    };
+
+    await writeAuditLog({
+      tenantId: "tenant-1",
+      actorId: "user-1",
+      action: "tenant.lifecycle.update",
+      targetType: "tenant",
+      targetId: "tenant-1",
+      detail: { status: "active" },
+    }, transactionClient as never);
+
+    expect(createdData).toEqual({
+      tenantId: "tenant-1",
+      actorId: "user-1",
+      action: "tenant.lifecycle.update",
+      targetType: "tenant",
+      targetId: "tenant-1",
+      detail: { status: "active" },
+    });
+  });
+});

--- a/apps/server/src/lib/audit.ts
+++ b/apps/server/src/lib/audit.ts
@@ -15,7 +15,7 @@ export async function writeAuditLog({
   targetType: string;
   targetId?: string | null;
   detail?: unknown;
-}) {
+}, client: Pick<Prisma.TransactionClient, "auditLog"> = prisma) {
   const data = {
     tenantId: tenantId ?? null,
     actorId: actorId ?? null,
@@ -25,7 +25,7 @@ export async function writeAuditLog({
     ...(detail === undefined ? {} : { detail: toJsonValue(detail) }),
   };
 
-  await prisma.auditLog.create({
+  await client.auditLog.create({
     data,
   });
 }

--- a/apps/server/src/lib/tenant-domain.test.ts
+++ b/apps/server/src/lib/tenant-domain.test.ts
@@ -3,9 +3,12 @@ import type { CampuxConfig } from "@campux/config";
 import {
   buildTenantDomainHost,
   hostIsUnderTenantSuffix,
+  persistAfterTenantDomainReprovision,
   provisionTenantDomain,
   reprovisionTenantDomain,
+  reprovisionTenantDomainWithCompensation,
   resolveDnsTargetHost,
+  TenantDomainCompensationError,
   TenantDomainProvisioningError,
 } from "./tenant-domain";
 
@@ -23,6 +26,50 @@ function testConfig(overrides: Partial<CampuxConfig["tenantDomains"]> = {}) {
       ...overrides,
     },
   } as CampuxConfig;
+}
+
+type TestDnsRecord = {
+  id: string;
+  name: string;
+  type: string;
+  content: string;
+  ttl: number;
+  proxied: boolean;
+  comment: string | null;
+};
+
+function statefulDnsFetch(records: Map<string, TestDnsRecord>) {
+  let nextId = 1;
+  return (async (input, init) => {
+    const url = String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    if (method === "GET") {
+      const name = new URL(url).searchParams.get("name") ?? "";
+      const record = records.get(name);
+      return Response.json({ success: true, result: record ? [record] : [] });
+    }
+
+    const body = init?.body ? JSON.parse(init.body as string) as Omit<TestDnsRecord, "id"> : null;
+    if (method === "POST" && body) {
+      const record = { id: `created-${nextId++}`, ...body };
+      records.set(record.name, record);
+      return Response.json({ success: true, result: record });
+    }
+
+    const recordId = decodeURIComponent(url.split("/").at(-1) ?? "");
+    const current = [...records.values()].find((record) => record.id === recordId);
+    if (method === "PUT" && body && current) {
+      records.delete(current.name);
+      const record = { id: current.id, ...body };
+      records.set(record.name, record);
+      return Response.json({ success: true, result: record });
+    }
+    if (method === "DELETE" && current) {
+      records.delete(current.name);
+      return Response.json({ success: true, result: { id: recordId } });
+    }
+    return Response.json({ success: false, errors: [{ message: "unexpected test request" }] });
+  }) as typeof fetch;
 }
 
 describe("buildTenantDomainHost", () => {
@@ -211,6 +258,58 @@ describe("reprovisionTenantDomain", () => {
     expect(requests.filter((r) => r.method === "DELETE")).toHaveLength(1);
   });
 
+  test("restores pre-existing records exactly when persistence needs compensation", async () => {
+    const oldRecord: TestDnsRecord = {
+      id: "old-rec",
+      name: "old.campux.top",
+      type: "CNAME",
+      content: "app.campux.top",
+      ttl: 1,
+      proxied: true,
+      comment: "Created by Campux tenant domain automation",
+    };
+    const manualRecord: TestDnsRecord = {
+      id: "manual-rec",
+      name: "new.campux.top",
+      type: "A",
+      content: "192.0.2.10",
+      ttl: 300,
+      proxied: false,
+      comment: "hand made",
+    };
+    const records = new Map([
+      [oldRecord.name, { ...oldRecord }],
+      [manualRecord.name, { ...manualRecord }],
+    ]);
+
+    const change = await reprovisionTenantDomainWithCompensation({
+      config: configWithZone(),
+      previousHost: oldRecord.name,
+      nextHost: manualRecord.name,
+      targetHost: "app.campux.top",
+      fetchImpl: statefulDnsFetch(records),
+    });
+
+    expect(records.has(oldRecord.name)).toBe(false);
+    expect(records.get(manualRecord.name)).toMatchObject({
+      type: "CNAME",
+      content: "app.campux.top",
+      comment: "Created by Campux tenant domain automation",
+    });
+
+    await change.compensate();
+    const restoredOld = records.get(oldRecord.name);
+    expect(restoredOld).toMatchObject({
+      name: oldRecord.name,
+      type: oldRecord.type,
+      content: oldRecord.content,
+      ttl: oldRecord.ttl,
+      proxied: oldRecord.proxied,
+      comment: oldRecord.comment,
+    });
+    expect(records.get(manualRecord.name)).toMatchObject(manualRecord);
+  });
+
   test("returns null and does nothing when automation disabled", async () => {
     const { requests, mockFetch } = mockCf({});
     const recordId = await reprovisionTenantDomain({
@@ -222,5 +321,58 @@ describe("reprovisionTenantDomain", () => {
     });
     expect(recordId).toBeNull();
     expect(requests).toHaveLength(0);
+  });
+});
+
+describe("persistAfterTenantDomainReprovision", () => {
+  test("does not compensate when the database write succeeds", async () => {
+    let compensated = false;
+    const result = await persistAfterTenantDomainReprovision({
+      persist: async () => "tenant",
+      compensate: async () => {
+        compensated = true;
+      },
+    });
+
+    expect(result).toBe("tenant");
+    expect(compensated).toBe(false);
+  });
+
+  test("compensates DNS and rethrows the database error when persistence fails", async () => {
+    const databaseError = new Error("database write failed");
+    let compensated = false;
+
+    await expect(persistAfterTenantDomainReprovision({
+      persist: async () => {
+        throw databaseError;
+      },
+      compensate: async () => {
+        compensated = true;
+      },
+    })).rejects.toBe(databaseError);
+    expect(compensated).toBe(true);
+  });
+
+  test("preserves both errors when DNS compensation also fails", async () => {
+    const databaseError = new Error("database write failed");
+    const compensationError = new Error("DNS compensation failed");
+    let caught: unknown;
+
+    try {
+      await persistAfterTenantDomainReprovision({
+        persist: async () => {
+          throw databaseError;
+        },
+        compensate: async () => {
+          throw compensationError;
+        },
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(TenantDomainCompensationError);
+    expect((caught as TenantDomainCompensationError).persistenceError).toBe(databaseError);
+    expect((caught as TenantDomainCompensationError).compensationError).toBe(compensationError);
   });
 });

--- a/apps/server/src/lib/tenant-domain.ts
+++ b/apps/server/src/lib/tenant-domain.ts
@@ -21,6 +21,8 @@ type CloudflareDnsRecord = {
   name: string;
   type: string;
   content: string;
+  ttl?: number;
+  proxied?: boolean;
   comment?: string | null;
 };
 
@@ -33,6 +35,37 @@ export class TenantDomainProvisioningError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "TenantDomainProvisioningError";
+  }
+}
+
+export class TenantDomainCompensationError extends Error {
+  readonly persistenceError: unknown;
+  readonly compensationError: unknown;
+
+  constructor(persistenceError: unknown, compensationError: unknown) {
+    super("主操作失败，且自动域名补偿也失败");
+    this.name = "TenantDomainCompensationError";
+    this.persistenceError = persistenceError;
+    this.compensationError = compensationError;
+  }
+}
+
+export async function persistAfterTenantDomainReprovision<T>({
+  persist,
+  compensate,
+}: {
+  persist: () => Promise<T>;
+  compensate: () => Promise<void>;
+}) {
+  try {
+    return await persist();
+  } catch (persistenceError) {
+    try {
+      await compensate();
+    } catch (compensationError) {
+      throw new TenantDomainCompensationError(persistenceError, compensationError);
+    }
+    throw persistenceError;
   }
 }
 
@@ -199,6 +232,78 @@ export async function reprovisionTenantDomain({
   return createdRecordId;
 }
 
+export async function reprovisionTenantDomainWithCompensation({
+  config,
+  previousHost,
+  nextHost,
+  targetHost,
+  fetchImpl = fetch,
+}: {
+  config: CampuxConfig;
+  previousHost: string | null | undefined;
+  nextHost: string | null | undefined;
+  targetHost: string;
+  fetchImpl?: FetchLike;
+}) {
+  const apiToken = config.tenantDomains.cloudflare.apiToken;
+  const suffix = normalizeDomainSuffix(config.tenantDomains.suffix);
+  if (!apiToken || !suffix) {
+    return { recordId: null, compensate: async () => {} };
+  }
+
+  const zoneId = await resolveZoneId({ config, apiToken, suffix, fetchImpl });
+  const managedHosts = [...new Set([previousHost, nextHost]
+    .filter((host): host is string => Boolean(host && hostIsUnderTenantSuffix(config, host))))];
+  const before = await captureDnsRecords({ apiToken, zoneId, hosts: managedHosts, fetchImpl });
+
+  try {
+    const recordId = await reprovisionTenantDomain({
+      config,
+      previousHost,
+      nextHost,
+      targetHost,
+      fetchImpl,
+    });
+    const after = await captureDnsRecords({ apiToken, zoneId, hosts: managedHosts, fetchImpl });
+    return {
+      recordId,
+      compensate: () => restoreDnsRecords({
+        config,
+        apiToken,
+        zoneId,
+        before,
+        expectedCurrent: after,
+        fetchImpl,
+      }),
+    };
+  } catch (persistenceError) {
+    try {
+      await restoreDnsRecords({ config, apiToken, zoneId, before, fetchImpl });
+    } catch (compensationError) {
+      throw new TenantDomainCompensationError(persistenceError, compensationError);
+    }
+    throw persistenceError;
+  }
+}
+
+async function captureDnsRecords({
+  apiToken,
+  zoneId,
+  hosts,
+  fetchImpl,
+}: {
+  apiToken: string;
+  zoneId: string;
+  hosts: string[];
+  fetchImpl: FetchLike;
+}) {
+  const records = new Map<string, CloudflareDnsRecord | null>();
+  for (const host of hosts) {
+    records.set(host, await findCloudflareRecordByName({ apiToken, zoneId, name: host, fetchImpl }));
+  }
+  return records;
+}
+
 async function resolveZoneId({
   config,
   apiToken,
@@ -232,6 +337,98 @@ async function findCloudflareRecordByName({
     failurePrefix: "查询 Cloudflare DNS 记录失败",
   });
   return records[0] ?? null;
+}
+
+function sameDnsRecord(left: CloudflareDnsRecord | null, right: CloudflareDnsRecord | null) {
+  if (left === null || right === null) return left === right;
+  return left.name === right.name
+    && left.type === right.type
+    && left.content === right.content
+    && (left.ttl ?? null) === (right.ttl ?? null)
+    && (left.proxied ?? null) === (right.proxied ?? null)
+    && (left.comment ?? null) === (right.comment ?? null);
+}
+
+async function restoreDnsRecords({
+  config,
+  apiToken,
+  zoneId,
+  before,
+  expectedCurrent,
+  fetchImpl,
+}: {
+  config: CampuxConfig;
+  apiToken: string;
+  zoneId: string;
+  before: Map<string, CloudflareDnsRecord | null>;
+  expectedCurrent?: Map<string, CloudflareDnsRecord | null>;
+  fetchImpl: FetchLike;
+}) {
+  for (const [host, original] of before) {
+    const current = await findCloudflareRecordByName({ apiToken, zoneId, name: host, fetchImpl });
+    const expected = expectedCurrent?.get(host) ?? null;
+    if (expectedCurrent && !sameDnsRecord(current, expected)) {
+      if (sameDnsRecord(current, original)) continue;
+      throw new TenantDomainProvisioningError(`补偿自动域名时检测到并发 DNS 变更：${host}`);
+    }
+    if (sameDnsRecord(current, original)) continue;
+
+    if (original === null) {
+      if (!current || current.comment !== automationComment) {
+        throw new TenantDomainProvisioningError(`补偿自动域名时拒绝删除非自动化 DNS 记录：${host}`);
+      }
+      await deleteCloudflareRecord({ apiToken, zoneId, recordId: current.id, fetchImpl });
+      continue;
+    }
+
+    if (!expectedCurrent && current && current.comment !== automationComment) {
+      throw new TenantDomainProvisioningError(`补偿自动域名时检测到非自动化 DNS 变更：${host}`);
+    }
+    await writeCloudflareRecordSnapshot({
+      config,
+      apiToken,
+      zoneId,
+      ...(current ? { currentRecordId: current.id } : {}),
+      record: original,
+      fetchImpl,
+    });
+  }
+}
+
+async function writeCloudflareRecordSnapshot({
+  config,
+  apiToken,
+  zoneId,
+  currentRecordId,
+  record,
+  fetchImpl,
+}: {
+  config: CampuxConfig;
+  apiToken: string;
+  zoneId: string;
+  currentRecordId?: string;
+  record: CloudflareDnsRecord;
+  fetchImpl: FetchLike;
+}) {
+  return cloudflareRequest<CloudflareDnsRecord>({
+    apiToken,
+    path: currentRecordId
+      ? `/zones/${encodeURIComponent(zoneId)}/dns_records/${encodeURIComponent(currentRecordId)}`
+      : `/zones/${encodeURIComponent(zoneId)}/dns_records`,
+    fetchImpl,
+    failurePrefix: "恢复 Cloudflare DNS 记录失败",
+    init: {
+      method: currentRecordId ? "PUT" : "POST",
+      body: JSON.stringify({
+        type: record.type,
+        name: record.name,
+        content: record.content,
+        ttl: record.ttl ?? config.tenantDomains.ttl,
+        proxied: record.proxied ?? config.tenantDomains.proxied,
+        comment: record.comment ?? null,
+      }),
+    },
+  });
 }
 
 async function updateCloudflareRecord({

--- a/apps/server/src/lib/tenant-membership-removal.test.ts
+++ b/apps/server/src/lib/tenant-membership-removal.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, test } from "bun:test";
 import {
   LastTenantAdminRemovalError,
   TenantAdminRequiredError,
+  TransactionSerializationRetriesExhaustedError,
   assertTenantActivationAllowed,
   assertTenantMembershipRemovalAllowed,
   assertTenantMembershipRoleChangeAllowed,
   buildTenantAdminUserIds,
   retryTransactionSerializationFailures,
+  tenantAdminInvariantErrorResponse,
+  updateTenantAfterAdminCheck,
 } from "./tenant-membership-removal";
 
 describe("assertTenantActivationAllowed", () => {
@@ -16,6 +19,37 @@ describe("assertTenantActivationAllowed", () => {
 
   test("allows activating a tenant with an admin", () => {
     expect(() => assertTenantActivationAllowed(1)).not.toThrow();
+  });
+});
+
+describe("updateTenantAfterAdminCheck", () => {
+  test("does not write the active status when the transaction sees no admin", async () => {
+    let updated = false;
+    await expect(updateTenantAfterAdminCheck({
+      countAdmins: async () => 0,
+      updateTenant: async () => {
+        updated = true;
+        return "active";
+      },
+    })).rejects.toBeInstanceOf(TenantAdminRequiredError);
+    expect(updated).toBe(false);
+  });
+
+  test("writes the active status after the transaction sees an admin", async () => {
+    const events: string[] = [];
+    const result = await updateTenantAfterAdminCheck({
+      countAdmins: async () => {
+        events.push("count");
+        return 1;
+      },
+      updateTenant: async () => {
+        events.push("update");
+        return "active";
+      },
+    });
+
+    expect(result).toBe("active");
+    expect(events).toEqual(["count", "update"]);
   });
 });
 
@@ -103,5 +137,29 @@ describe("retryTransactionSerializationFailures", () => {
       () => false,
     )).rejects.toThrow("permission denied");
     expect(attempts).toBe(1);
+  });
+
+  test("turns exhausted serialization retries into a 409 response contract", async () => {
+    let attempts = 0;
+    let caught: unknown;
+    try {
+      await retryTransactionSerializationFailures(
+        async () => {
+          attempts += 1;
+          throw new Error("serialization");
+        },
+        (error) => error instanceof Error && error.message === "serialization",
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(attempts).toBe(3);
+    expect(caught).toBeInstanceOf(TransactionSerializationRetriesExhaustedError);
+    expect(tenantAdminInvariantErrorResponse(caught)).toEqual({
+      statusCode: 409,
+      code: "TENANT_ADMIN_CONCURRENT_UPDATE",
+      message: "管理员状态发生并发变化，请刷新后重试",
+    });
   });
 });

--- a/apps/server/src/lib/tenant-membership-removal.ts
+++ b/apps/server/src/lib/tenant-membership-removal.ts
@@ -2,6 +2,7 @@ import { isPrismaKnownRequestError, type TenantRole } from "@campux/db";
 
 export const LAST_TENANT_ADMIN_REMOVAL_MESSAGE = "校园墙必须至少保留一名管理员，请先授权另一名管理员再移除当前管理员";
 export const TENANT_ADMIN_REQUIRED_MESSAGE = "校园墙必须至少有一名管理员，请先添加管理员再恢复运行";
+export const TENANT_ADMIN_CONCURRENT_UPDATE_MESSAGE = "管理员状态发生并发变化，请刷新后重试";
 
 export class LastTenantAdminRemovalError extends Error {
   constructor() {
@@ -17,10 +18,45 @@ export class TenantAdminRequiredError extends Error {
   }
 }
 
+export class TransactionSerializationRetriesExhaustedError extends Error {
+  readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super(TENANT_ADMIN_CONCURRENT_UPDATE_MESSAGE);
+    this.name = "TransactionSerializationRetriesExhaustedError";
+    this.cause = cause;
+  }
+}
+
+export function tenantAdminInvariantErrorResponse(error: unknown) {
+  if (error instanceof LastTenantAdminRemovalError) {
+    return { statusCode: 409 as const, code: "LAST_TENANT_ADMIN", message: error.message };
+  }
+  if (error instanceof TenantAdminRequiredError) {
+    return { statusCode: 409 as const, code: "TENANT_ADMIN_REQUIRED", message: error.message };
+  }
+  if (error instanceof TransactionSerializationRetriesExhaustedError) {
+    return { statusCode: 409 as const, code: "TENANT_ADMIN_CONCURRENT_UPDATE", message: error.message };
+  }
+  return null;
+}
+
 export function assertTenantActivationAllowed(adminCount: number) {
   if (adminCount < 1) {
     throw new TenantAdminRequiredError();
   }
+}
+
+export async function updateTenantAfterAdminCheck<T>({
+  countAdmins,
+  updateTenant,
+}: {
+  countAdmins: () => Promise<number>;
+  updateTenant: () => Promise<T>;
+}) {
+  const adminCount = await countAdmins();
+  assertTenantActivationAllowed(adminCount);
+  return updateTenant();
 }
 
 export function assertTenantMembershipRemovalAllowed(options: {
@@ -59,8 +95,11 @@ export async function retryTransactionSerializationFailures<T>(
     try {
       return await operation();
     } catch (error) {
-      if (attempt >= maxAttempts || !isSerializationFailure(error)) {
+      if (!isSerializationFailure(error)) {
         throw error;
+      }
+      if (attempt >= maxAttempts) {
+        throw new TransactionSerializationRetriesExhaustedError(error);
       }
       await new Promise((resolve) => setTimeout(resolve, attempt * 10));
     }

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -4,10 +4,10 @@ import { Prisma, TransactionIsolationLevel, type TenantRole } from "@campux/db";
 import { requireTenantRole } from "../lib/auth";
 import { prisma } from "../lib/prisma";
 import {
-  LastTenantAdminRemovalError,
   assertTenantMembershipRoleChangeAllowed,
   isTransactionSerializationFailure,
   retryTransactionSerializationFailures,
+  tenantAdminInvariantErrorResponse,
 } from "../lib/tenant-membership-removal";
 import { decryptJson, encryptJson } from "../lib/secret-json";
 import { writeAuditLog } from "../lib/audit";
@@ -400,11 +400,9 @@ export function registerAdminRoutes(app: FastifyInstance, queue: RuntimeQueue, o
         isTransactionSerializationFailure,
       );
     } catch (error) {
-      if (error instanceof LastTenantAdminRemovalError) {
-        return reply.code(409).send({
-          code: "LAST_TENANT_ADMIN",
-          message: error.message,
-        });
+      const response = tenantAdminInvariantErrorResponse(error);
+      if (response) {
+        return reply.code(response.statusCode).send({ code: response.code, message: response.message });
       }
       throw error;
     }
@@ -465,11 +463,9 @@ export function registerAdminRoutes(app: FastifyInstance, queue: RuntimeQueue, o
         isTransactionSerializationFailure,
       );
     } catch (error) {
-      if (error instanceof LastTenantAdminRemovalError) {
-        return reply.code(409).send({
-          code: "LAST_TENANT_ADMIN",
-          message: error.message,
-        });
+      const response = tenantAdminInvariantErrorResponse(error);
+      if (response) {
+        return reply.code(response.statusCode).send({ code: response.code, message: response.message });
       }
       throw error;
     }

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -1,29 +1,31 @@
 import type { FastifyInstance, FastifyReply } from "fastify";
 import type { CampuxConfig } from "@campux/config";
-import { Prisma, TransactionIsolationLevel, createManyDedup, type Tenant } from "@campux/db";
+import { Prisma, TransactionIsolationLevel, createManyDedup } from "@campux/db";
 import { z } from "zod";
 import { requirePlatformAdmin } from "../lib/auth";
 import { writeAuditLog } from "../lib/audit";
 import { prisma } from "../lib/prisma";
 import {
-  LastTenantAdminRemovalError,
-  TenantAdminRequiredError,
   assertTenantActivationAllowed,
   assertTenantMembershipRemovalAllowed,
   assertTenantMembershipRoleChangeAllowed,
   buildTenantAdminUserIds,
   isTransactionSerializationFailure,
   retryTransactionSerializationFailures,
+  tenantAdminInvariantErrorResponse,
+  updateTenantAfterAdminCheck,
 } from "../lib/tenant-membership-removal";
 import { normalizeTenantHost } from "../lib/tenant-host";
 import {
   buildTenantDomainHost,
   hostIsUnderTenantSuffix,
   normalizeDomainSuffix,
+  persistAfterTenantDomainReprovision,
   provisionTenantDomain,
-  reprovisionTenantDomain,
+  reprovisionTenantDomainWithCompensation,
   resolveDnsTargetHost,
   tenantDomainAutomationEnabled,
+  TenantDomainCompensationError,
   TenantDomainProvisioningError,
 } from "../lib/tenant-domain";
 import { buildUserContainsSearch } from "../lib/user-search";
@@ -474,28 +476,36 @@ export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, 
     }
 
     if (body.status === "active") {
-      const adminCount = await prisma.tenantMembership.count({
-        where: { tenantId: params.tenantId, role: "admin" },
-      });
       try {
-        assertTenantActivationAllowed(adminCount);
+        await retryTransactionSerializationFailures(
+          () => prisma.$transaction(async (tx) => {
+            const adminCount = await tx.tenantMembership.count({
+              where: { tenantId: params.tenantId, role: "admin" },
+            });
+            assertTenantActivationAllowed(adminCount);
+          }, { isolationLevel: TransactionIsolationLevel.Serializable }),
+          isTransactionSerializationFailure,
+        );
       } catch (error) {
-        if (error instanceof TenantAdminRequiredError) {
-          return reply.code(409).send({
-            code: "TENANT_ADMIN_REQUIRED",
-            message: error.message,
-          });
+        const response = tenantAdminInvariantErrorResponse(error);
+        if (response) {
+          return reply.code(response.statusCode).send({ code: response.code, message: response.message });
         }
         throw error;
       }
     }
 
     // When the host is changing and either the old or new host is managed by
-    // the auto-domain automation, sync Cloudflare BEFORE writing the DB so a
-    // failed DNS change leaves the tenant's stored host untouched (no drift
-    // between DB and DNS).
+    // the auto-domain automation, sync Cloudflare before the authoritative DB
+    // transaction. If that transaction fails, the DNS move is compensated in
+    // reverse below so the two systems converge on the previous host.
     const hostChanging = body.host !== undefined;
     let cloudflareDnsRecordId: string | null = null;
+    let dnsChange: {
+      previousHost: string | null;
+      nextHost: string | null;
+      compensate: () => Promise<void>;
+    } | null = null;
     if (hostChanging && tenantDomainAutomationEnabled(config)) {
       const current = await prisma.tenant.findUnique({
         where: { id: params.tenantId },
@@ -512,12 +522,15 @@ export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, 
           if (!targetHost) {
             return reply.code(500).send({ message: "自动域名已启用，但没有可用的 DNS CNAME 目标" });
           }
-          cloudflareDnsRecordId = await reprovisionTenantDomain({
+          const nextHost = normalizedHost ?? null;
+          const change = await reprovisionTenantDomainWithCompensation({
             config,
             previousHost,
-            nextHost: normalizedHost ?? null,
+            nextHost,
             targetHost,
           });
+          cloudflareDnsRecordId = change.recordId;
+          dnsChange = { previousHost, nextHost, compensate: change.compensate };
         } catch (caught) {
           request.log.error({ err: caught, tenantId: params.tenantId, host: normalizedHost }, "failed to reprovision tenant domain");
           if (caught instanceof TenantDomainProvisioningError) {
@@ -539,47 +552,80 @@ export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, 
     // scheduler does not immediately re-archive it.
     if (body.status === "active") updateData.archiveWarningAt = null;
 
-    let tenant: Tenant;
-    try {
-      tenant = body.status === "active"
-        ? await retryTransactionSerializationFailures(
-          () => prisma.$transaction(async (tx) => {
-            const adminCount = await tx.tenantMembership.count({
-              where: { tenantId: params.tenantId, role: "admin" },
-            });
-            assertTenantActivationAllowed(adminCount);
-            return tx.tenant.update({
-              where: { id: params.tenantId },
-              data: updateData,
-            });
-          }, { isolationLevel: TransactionIsolationLevel.Serializable }),
-          isTransactionSerializationFailure,
-        )
-        : await prisma.tenant.update({
-          where: { id: params.tenantId },
-          data: updateData,
-        });
-    } catch (error) {
-      if (error instanceof TenantAdminRequiredError) {
-        return reply.code(409).send({
-          code: "TENANT_ADMIN_REQUIRED",
-          message: error.message,
-        });
-      }
-      throw error;
-    }
-    await writeAuditLog({
-      tenantId: tenant.id,
+    const auditInput = {
+      tenantId: params.tenantId,
       actorId: context.user.id,
       action: "tenant.lifecycle.update",
       targetType: "tenant",
-      targetId: tenant.id,
+      targetId: params.tenantId,
       detail: {
         ...(body.status !== undefined ? { status: body.status } : {}),
         ...(body.host !== undefined ? { host: normalizedHost } : {}),
         ...(cloudflareDnsRecordId ? { cloudflareDnsRecordId } : {}),
       },
-    });
+    };
+    const persistTenant = () => body.status === "active"
+      ? retryTransactionSerializationFailures(
+        () => prisma.$transaction(
+          async (tx) => {
+            const tenant = await updateTenantAfterAdminCheck({
+              countAdmins: () => tx.tenantMembership.count({
+                where: { tenantId: params.tenantId, role: "admin" },
+              }),
+              updateTenant: () => tx.tenant.update({
+                where: { id: params.tenantId },
+                data: updateData,
+              }),
+            });
+            await writeAuditLog(auditInput, tx);
+            return tenant;
+          },
+          { isolationLevel: TransactionIsolationLevel.Serializable },
+        ),
+        isTransactionSerializationFailure,
+      )
+      : prisma.$transaction(async (tx) => {
+        const tenant = await tx.tenant.update({
+          where: { id: params.tenantId },
+          data: updateData,
+        });
+        await writeAuditLog(auditInput, tx);
+        return tenant;
+      });
+
+    const appliedDnsChange = dnsChange;
+    try {
+      await (appliedDnsChange
+        ? persistAfterTenantDomainReprovision({
+          persist: persistTenant,
+          compensate: appliedDnsChange.compensate,
+        })
+        : persistTenant());
+    } catch (error) {
+      if (error instanceof TenantDomainCompensationError) {
+        request.log.error({
+          err: error.compensationError,
+          persistenceError: error.persistenceError,
+          tenantId: params.tenantId,
+          previousHost: appliedDnsChange?.previousHost,
+          nextHost: appliedDnsChange?.nextHost,
+        }, "tenant update and tenant domain compensation both failed");
+        throw error;
+      }
+      if (appliedDnsChange) {
+        request.log.warn({
+          err: error,
+          tenantId: params.tenantId,
+          previousHost: appliedDnsChange.previousHost,
+          nextHost: appliedDnsChange.nextHost,
+        }, "tenant update failed; compensated tenant domain change");
+      }
+      const response = tenantAdminInvariantErrorResponse(error);
+      if (response) {
+        return reply.code(response.statusCode).send({ code: response.code, message: response.message });
+      }
+      throw error;
+    }
 
     return {
       tenants: await listSystemTenants(context),
@@ -796,11 +842,9 @@ export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, 
         isTransactionSerializationFailure,
       );
     } catch (error) {
-      if (error instanceof LastTenantAdminRemovalError) {
-        return reply.code(409).send({
-          code: "LAST_TENANT_ADMIN",
-          message: error.message,
-        });
+      const response = tenantAdminInvariantErrorResponse(error);
+      if (response) {
+        return reply.code(response.statusCode).send({ code: response.code, message: response.message });
       }
       throw error;
     }
@@ -868,11 +912,9 @@ export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, 
         isTransactionSerializationFailure,
       );
     } catch (error) {
-      if (error instanceof LastTenantAdminRemovalError) {
-        return reply.code(409).send({
-          code: "LAST_TENANT_ADMIN",
-          message: error.message,
-        });
+      const response = tenantAdminInvariantErrorResponse(error);
+      if (response) {
+        return reply.code(response.statusCode).send({ code: response.code, message: response.message });
       }
       throw error;
     }

--- a/apps/web/src/features/admin/AdminPage.tsx
+++ b/apps/web/src/features/admin/AdminPage.tsx
@@ -26,7 +26,10 @@ import {
 import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { roleLabels, statusLabels } from "@/lib/app-model";
-import { buildMembershipRoleChangeConfirmation } from "../ops/membership-removal-confirmation";
+import {
+  buildMembershipRoleChangeConfirmation,
+  refreshMembershipDataAfterRoleChange,
+} from "../ops/membership-removal-confirmation";
 import { readListPreferences, writeListPreferences } from "@/lib/list-preferences";
 import { hasAnyQueryParam, readQueryInt, readQueryParam, writeQueryParams } from "@/lib/url-query";
 import type { AdminBanRecord, AdminBotAccount, AdminBotEvent, AdminMember, AdminMemberDetail, AdminTab, AiRules, OAuthClientItem, OAuthClientSecretResponse, OAuthClientSettingsResponse, OAuthServerSettings, Pagination, PublishAttemptItem, PublishTargetItem, PublishTextTemplate, TenantAiSettings, TenantMetadata, TenantRole } from "@/types/app";
@@ -739,9 +742,23 @@ export function AdminPage({
         method: "PATCH",
         body: JSON.stringify({ role }),
       });
-      await refreshAdminData();
     } catch (caught) {
       toast.error(caught instanceof Error ? caught.message : "更新用户身份失败");
+      return;
+    }
+
+    try {
+      await refreshMembershipDataAfterRoleChange({
+        actorUserId: currentUserId,
+        targetUserId: member.user.id,
+        currentRole: member.role,
+        nextRole: role,
+        refreshAdminData,
+        refreshSessionData: onSaved,
+      });
+      toast.success("用户身份已更新。");
+    } catch {
+      toast.error("用户身份已更新，但权限状态刷新失败，请重新加载页面。");
     }
   }
 

--- a/apps/web/src/features/ops/membership-removal-confirmation.test.ts
+++ b/apps/web/src/features/ops/membership-removal-confirmation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildMembershipRemovalConfirmation,
   buildMembershipRoleChangeConfirmation,
+  refreshMembershipDataAfterRoleChange,
 } from "./membership-removal-confirmation";
 
 describe("buildMembershipRoleChangeConfirmation", () => {
@@ -33,6 +34,34 @@ describe("buildMembershipRoleChangeConfirmation", () => {
       currentRole: "admin",
       nextRole: "admin",
     })).toBeNull();
+  });
+});
+
+describe("refreshMembershipDataAfterRoleChange", () => {
+  test("refreshes session state instead of admin endpoints after self-demotion", async () => {
+    const calls: string[] = [];
+    await refreshMembershipDataAfterRoleChange({
+      actorUserId: "user-1",
+      targetUserId: "user-1",
+      currentRole: "admin",
+      nextRole: "reviewer",
+      refreshAdminData: async () => { calls.push("admin"); },
+      refreshSessionData: async () => { calls.push("session"); },
+    });
+    expect(calls).toEqual(["session"]);
+  });
+
+  test("keeps the normal admin refresh for changes that preserve actor access", async () => {
+    const calls: string[] = [];
+    await refreshMembershipDataAfterRoleChange({
+      actorUserId: "user-1",
+      targetUserId: "user-2",
+      currentRole: "admin",
+      nextRole: "reviewer",
+      refreshAdminData: async () => { calls.push("admin"); },
+      refreshSessionData: async () => { calls.push("session"); },
+    });
+    expect(calls).toEqual(["admin"]);
   });
 });
 

--- a/apps/web/src/features/ops/membership-removal-confirmation.ts
+++ b/apps/web/src/features/ops/membership-removal-confirmation.ts
@@ -24,6 +24,24 @@ export function buildMembershipRoleChangeConfirmation(options: {
   return `你正在将自己在「${options.tenantName}」的身份从管理员改为${membershipRoleLabels[options.nextRole]}，将失去管理员权限。确认继续？如果这是最后一名管理员，系统会阻止操作。`;
 }
 
+export async function refreshMembershipDataAfterRoleChange(options: {
+  actorUserId: string;
+  targetUserId: string;
+  currentRole: TenantRole;
+  nextRole: TenantRole;
+  refreshAdminData: () => Promise<void>;
+  refreshSessionData: () => Promise<void>;
+}) {
+  const actorLostAdminAccess = options.actorUserId === options.targetUserId
+    && options.currentRole === "admin"
+    && options.nextRole !== "admin";
+  if (actorLostAdminAccess) {
+    await options.refreshSessionData();
+    return;
+  }
+  await options.refreshAdminData();
+}
+
 export function buildMembershipRemovalConfirmation(options: {
   actorUserId: string;
   targetUserId: string;

--- a/packages/db/src/seed-membership.test.ts
+++ b/packages/db/src/seed-membership.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, test } from "bun:test";
-import { membershipRoleUpdateForSeed } from "./seed-membership";
+import { resolveMembershipRoleForSeed } from "./seed-membership";
 
-describe("membershipRoleUpdateForSeed", () => {
-  test("never demotes an existing membership during reseeding", () => {
-    expect(membershipRoleUpdateForSeed("submitter")).toEqual({});
-    expect(membershipRoleUpdateForSeed("reviewer")).toEqual({});
+describe("resolveMembershipRoleForSeed", () => {
+  test("never demotes an existing admin during reseeding", () => {
+    expect(resolveMembershipRoleForSeed("admin", "reviewer")).toBe("admin");
+    expect(resolveMembershipRoleForSeed("admin", "submitter")).toBe("admin");
   });
 
-  test("allows a safe promotion to admin during reseeding", () => {
-    expect(membershipRoleUpdateForSeed("admin")).toEqual({ role: "admin" });
+  test("restores the declared role for existing non-admin fixtures", () => {
+    expect(resolveMembershipRoleForSeed("submitter", "reviewer")).toBe("reviewer");
+    expect(resolveMembershipRoleForSeed("reviewer", "submitter")).toBe("submitter");
+  });
+
+  test("uses the declared role for a new membership and permits admin promotion", () => {
+    expect(resolveMembershipRoleForSeed(undefined, "submitter")).toBe("submitter");
+    expect(resolveMembershipRoleForSeed("reviewer", "admin")).toBe("admin");
   });
 });

--- a/packages/db/src/seed-membership.ts
+++ b/packages/db/src/seed-membership.ts
@@ -1,5 +1,11 @@
 import type { TenantRole } from "@prisma/client";
 
-export function membershipRoleUpdateForSeed(role: TenantRole): { role?: TenantRole } {
-  return role === "admin" ? { role } : {};
+export function resolveMembershipRoleForSeed(
+  currentRole: TenantRole | undefined,
+  declaredRole: TenantRole,
+): TenantRole {
+  if (currentRole === "admin" && declaredRole !== "admin") {
+    return "admin";
+  }
+  return declaredRole;
 }

--- a/packages/db/src/seed-transaction.test.ts
+++ b/packages/db/src/seed-transaction.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { runSeedInTransaction } from "./seed-transaction";
+
+describe("runSeedInTransaction", () => {
+  test("runs the complete seed callback through one transaction client", async () => {
+    const events: string[] = [];
+    const client = {
+      async $transaction<T>(operation: (tx: { write: (value: string) => void }) => Promise<T>) {
+        events.push("begin");
+        const result = await operation({ write: (value) => events.push(value) });
+        events.push("commit");
+        return result;
+      },
+    };
+
+    await runSeedInTransaction(client, async (tx) => {
+      tx.write("tenant");
+      tx.write("admin");
+    });
+
+    expect(events).toEqual(["begin", "tenant", "admin", "commit"]);
+  });
+
+  test("does not report a commit when seeding fails after creating the active tenant", async () => {
+    const events: string[] = [];
+    const client = {
+      async $transaction<T>(operation: (tx: { write: (value: string) => void }) => Promise<T>) {
+        events.push("begin");
+        const result = await operation({ write: (value) => events.push(value) });
+        events.push("commit");
+        return result;
+      },
+    };
+
+    await expect(runSeedInTransaction(client, async (tx) => {
+      tx.write("active-tenant");
+      throw new Error("admin seed failed");
+    })).rejects.toThrow("admin seed failed");
+
+    expect(events).toEqual(["begin", "active-tenant"]);
+  });
+});

--- a/packages/db/src/seed-transaction.ts
+++ b/packages/db/src/seed-transaction.ts
@@ -1,0 +1,8 @@
+export async function runSeedInTransaction<Tx>(
+  client: {
+    $transaction<T>(operation: (tx: Tx) => Promise<T>): Promise<T>;
+  },
+  operation: (tx: Tx) => Promise<void>,
+) {
+  await client.$transaction(operation);
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1,6 +1,7 @@
-import { PrismaClient } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 import { hashPassword } from "./password";
-import { membershipRoleUpdateForSeed } from "./seed-membership";
+import { resolveMembershipRoleForSeed } from "./seed-membership";
+import { runSeedInTransaction } from "./seed-transaction";
 
 // Guard: the demo seed creates well-known accounts with a shared weak password
 // ("campux123"), including a system_operator. That is fine for local dev but a
@@ -48,8 +49,8 @@ const services = [
   { title: "校园服务", description: "推荐入口" },
 ];
 
-async function seedTenant(tenant: (typeof tenants)[number]) {
-  await prisma.tenant.upsert({
+async function seedTenant(db: Prisma.TransactionClient, tenant: (typeof tenants)[number]) {
+  await db.tenant.upsert({
     where: { id: tenant.id },
     update: {
       slug: tenant.slug,
@@ -74,7 +75,7 @@ async function seedTenant(tenant: (typeof tenants)[number]) {
     { key: "pending_post_limit", value: 1 },
     { key: "services", value: services },
   ]) {
-    await prisma.tenantMetadata.upsert({
+    await db.tenantMetadata.upsert({
       where: {
         tenantId_key: {
           tenantId: tenant.id,
@@ -92,9 +93,13 @@ async function seedTenant(tenant: (typeof tenants)[number]) {
     });
   }
 
-  const botAccount = await prisma.botAccount.upsert({
+  const botQqUin = BigInt(tenant.id === "tenant-canton" ? "2854199010" : "2854199020");
+  const botAccount = await db.botAccount.upsert({
     where: {
-      qqUin: BigInt(tenant.id === "tenant-canton" ? "2854199010" : "2854199020"),
+      tenantId_qqUin: {
+        tenantId: tenant.id,
+        qqUin: botQqUin,
+      },
     },
     update: {
       displayName: `${tenant.name} 1 号墙`,
@@ -103,14 +108,14 @@ async function seedTenant(tenant: (typeof tenants)[number]) {
     },
     create: {
       tenantId: tenant.id,
-      qqUin: BigInt(tenant.id === "tenant-canton" ? "2854199010" : "2854199020"),
+      qqUin: botQqUin,
       displayName: `${tenant.name} 1 号墙`,
       enabled: true,
       reviewGroupId: tenant.id === "tenant-canton" ? "91000001" : "91000002",
     },
   });
 
-  await prisma.publishTarget.upsert({
+  await db.publishTarget.upsert({
     where: {
       id: `${tenant.id}-qzone-primary`,
     },
@@ -133,7 +138,7 @@ async function seedTenant(tenant: (typeof tenants)[number]) {
   });
 }
 
-async function seedUser({
+async function seedUser(db: Prisma.TransactionClient, {
   qqUin,
   email,
   displayName,
@@ -148,7 +153,7 @@ async function seedUser({
   memberships: Array<{ tenantId: string; role: "submitter" | "reviewer" | "admin" }>;
   isTestAccount?: boolean;
 }) {
-  const user = await prisma.user.upsert({
+  const user = await db.user.upsert({
     where: { qqUin: BigInt(qqUin) },
     update: {
       displayName,
@@ -170,14 +175,25 @@ async function seedUser({
   });
 
   for (const membership of memberships) {
-    await prisma.tenantMembership.upsert({
+    const existingMembership = await db.tenantMembership.findUnique({
       where: {
         tenantId_userId: {
           tenantId: membership.tenantId,
           userId: user.id,
         },
       },
-      update: membershipRoleUpdateForSeed(membership.role),
+      select: { role: true },
+    });
+    await db.tenantMembership.upsert({
+      where: {
+        tenantId_userId: {
+          tenantId: membership.tenantId,
+          userId: user.id,
+        },
+      },
+      update: {
+        role: resolveMembershipRoleForSeed(existingMembership?.role, membership.role),
+      },
       create: {
         tenantId: membership.tenantId,
         userId: user.id,
@@ -187,48 +203,50 @@ async function seedUser({
   }
 }
 
-for (const tenant of tenants) {
-  await seedTenant(tenant);
-}
+await runSeedInTransaction<Prisma.TransactionClient>(prisma, async (tx) => {
+  for (const tenant of tenants) {
+    await seedTenant(tx, tenant);
+  }
 
-await seedUser({
-  qqUin: "10000",
-  email: "submitter@example.com",
-  displayName: "投稿测试号",
-  memberships: [{ tenantId: "tenant-canton", role: "submitter" }],
-});
+  await seedUser(tx, {
+    qqUin: "10000",
+    email: "submitter@example.com",
+    displayName: "投稿测试号",
+    memberships: [{ tenantId: "tenant-canton", role: "submitter" }],
+  });
 
-await seedUser({
-  qqUin: "20000",
-  email: "reviewer@example.com",
-  displayName: "审核测试号",
-  memberships: [{ tenantId: "tenant-canton", role: "reviewer" }],
-});
+  await seedUser(tx, {
+    qqUin: "20000",
+    email: "reviewer@example.com",
+    displayName: "审核测试号",
+    memberships: [{ tenantId: "tenant-canton", role: "reviewer" }],
+  });
 
-await seedUser({
-  qqUin: "30000",
-  email: "admin@example.com",
-  displayName: "多墙管理员",
-  memberships: [
-    { tenantId: "tenant-canton", role: "admin" },
-    { tenantId: "tenant-riverside", role: "admin" },
-  ],
-});
+  await seedUser(tx, {
+    qqUin: "30000",
+    email: "admin@example.com",
+    displayName: "多墙管理员",
+    memberships: [
+      { tenantId: "tenant-canton", role: "admin" },
+      { tenantId: "tenant-riverside", role: "admin" },
+    ],
+  });
 
-await seedUser({
-  qqUin: "40000",
-  email: "operator@example.com",
-  displayName: "系统运维",
-  systemRole: "system_operator",
-  memberships: [{ tenantId: "tenant-canton", role: "admin" }],
-});
+  await seedUser(tx, {
+    qqUin: "40000",
+    email: "operator@example.com",
+    displayName: "系统运维",
+    systemRole: "system_operator",
+    memberships: [{ tenantId: "tenant-canton", role: "admin" }],
+  });
 
-await seedUser({
-  qqUin: "50000",
-  email: "operations@example.com",
-  displayName: "运营管理员",
-  systemRole: "operations_admin",
-  memberships: [{ tenantId: "tenant-riverside", role: "admin" }],
+  await seedUser(tx, {
+    qqUin: "50000",
+    email: "operations@example.com",
+    displayName: "运营管理员",
+    systemRole: "operations_admin",
+    memberships: [{ tenantId: "tenant-riverside", role: "admin" }],
+  });
 });
 
 console.log("Seeded CampuxNext demo tenants and accounts. Password for all accounts: campux123");


### PR DESCRIPTION
## Summary

Follow-up hardening for the tenant last-admin invariant introduced in #134.

- map exhausted Serializable/P2034 retries to a stable HTTP 409 contract across admin and system membership mutations
- keep the final admin check, tenant activation write, and audit row in one retried Serializable transaction
- snapshot Cloudflare records before tenant host reprovisioning and restore exact prior DNS state when DB/audit persistence fails
- fail visibly if DNS compensation conflicts with a concurrent manual DNS edit or compensation itself fails
- run the entire demo seed graph in one Prisma transaction while preserving existing admin memberships
- refresh session/tenant state instead of forbidden admin endpoints after an administrator demotes themself
- distinguish mutation failures from post-success refresh failures in the UI

## Verification

- `bun test`: **352 passed, 5 skipped, 0 failed**
- server TypeScript check: passed
- web TypeScript check: passed
- standalone seed TypeScript check: passed
- `git diff --cached --check`: passed
- added-line static security scan: clean
- independent fail-closed Codex review: **PASS**

## Safety notes

- DNS compensation preserves pre-existing record type, content, TTL, proxy mode, and comment rather than using a destructive reverse operation.
- The final production verification will use an isolated temporary tenant and will not modify tenant `9178`.

## Summary by Sourcery

在租户生命周期变更过程中加强租户管理员不变量和 DNS 自动化的可靠性，同时使演示数据播种和审计日志记录具备事务性。

New Features:
- 添加 DNS 补偿支持，在需要回滚租户主机重新配置时，对 Cloudflare 租户域名记录进行快照并恢复。
- 引入统一的错误响应映射机制，用于在管理和系统路由中处理租户管理员不变量违规以及序列化重试耗尽的情况。
- 在自我降级后刷新客户端会话状态，使移除自身管理员角色的管理员能够恢复一致的 UI 状态。

Bug Fixes:
- 通过在单个可串行化事务中执行管理员检查和更新并记录审计日志，确保只有在存在管理员的情况下才持久化租户激活和生命周期更新。
- 将事务序列化重试耗尽映射到稳定的 HTTP 409 协议，以清晰暴露并发的管理员成员变更。
- 在重新播种演示租户时保留已存在的租户管理员成员身份，而不是对其进行静默降级。

Enhancements:
- 将整个演示数据播种图运行在单个数据库事务中，以在播种失败时保持租户和成员关系的一致性。
- 扩展审计日志记录以接受事务客户端，使业务写入和审计条目能够原子性提交。
- 加强 Cloudflare DNS 自动化，检测并拒绝会覆盖非自动化或被并发编辑的记录的补偿操作，同时在恢复记录状态时包含 TTL 和代理模式。
- 优化播种时的成员角色解析逻辑，在允许为非管理员账户恢复预置角色的同时，避免对现有管理员进行降级。

Tests:
- 添加单元测试，覆盖 DNS 重新配置补偿行为、租户管理员不变量处理、事务化播种执行、使用事务客户端的审计日志记录，以及角色变更后成员刷新行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden tenant admin invariants and DNS automation around tenant lifecycle changes while making demo seeding and audit logging transactional.

New Features:
- Add DNS compensation support that snapshots and restores Cloudflare tenant domain records when tenant host reprovisioning must be rolled back.
- Introduce a unified error response mapping for tenant admin invariant violations and exhausted serialization retries across admin and system routes.
- Refresh client session state after self-demotion so administrators who remove their own admin role recover a consistent UI state.

Bug Fixes:
- Ensure tenant activation and lifecycle updates only persist when an admin exists by performing the admin check and update in a single Serializable transaction with audit logging.
- Map exhausted transaction serialization retries to a stable HTTP 409 contract to surface concurrent admin membership changes clearly.
- Preserve existing demo tenant admin memberships during reseeding instead of silently demoting them.

Enhancements:
- Run the entire demo seed graph inside a single database transaction to keep tenants and memberships consistent when seeding fails.
- Extend audit logging to accept a transaction client so business writes and audit entries commit atomically.
- Strengthen Cloudflare DNS automation to detect and refuse compensations that would overwrite non-automated or concurrently edited records while restoring full record state including TTL and proxy mode.
- Refine seed membership role resolution to avoid demoting existing admins while allowing fixture roles to be restored for non-admin accounts.

Tests:
- Add unit tests covering DNS reprovisioning compensation behavior, tenant admin invariant handling, transactional seed execution, audit logging with a transaction client, and membership refresh behavior after role changes.

</details>