### PR TITLE
feat: make tenant image limits configurable

### DIFF
--- a/apps/server/src/lib/image-upload-policy.test.ts
+++ b/apps/server/src/lib/image-upload-policy.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import {
+  defaultImageMaxSizeMb,
+  imageUploadSourceHardMaxSizeMb,
+  maxImageMaxSizeMb,
+  minImageMaxSizeMb,
+  normalizeImageMaxSizeMb,
+  resolveImageUploadLimits,
+  validateProcessedImageSize,
+} from "./image-upload-policy";
+
+describe("tenant image upload policy", () => {
+  test("normalizes tenant limits to a safe 1-50MB range with a 10MB default", () => {
+    expect(normalizeImageMaxSizeMb(undefined)).toBe(defaultImageMaxSizeMb);
+    expect(normalizeImageMaxSizeMb("20")).toBe(20);
+    expect(normalizeImageMaxSizeMb(0)).toBe(minImageMaxSizeMb);
+    expect(normalizeImageMaxSizeMb(999)).toBe(maxImageMaxSizeMb);
+    expect(normalizeImageMaxSizeMb(Number.NaN)).toBe(defaultImageMaxSizeMb);
+  });
+
+  test("accepts a larger source only when compression is enabled", () => {
+    expect(resolveImageUploadLimits({ maxSizeMb: 8, compressionEnabled: false })).toEqual({
+      sourceMaxBytes: 8 * 1024 * 1024,
+      processedMaxBytes: 8 * 1024 * 1024,
+    });
+    expect(resolveImageUploadLimits({ maxSizeMb: 8, compressionEnabled: true })).toEqual({
+      sourceMaxBytes: imageUploadSourceHardMaxSizeMb * 1024 * 1024,
+      processedMaxBytes: 8 * 1024 * 1024,
+    });
+  });
+
+  test("rejects an image that is still over the tenant limit after compression", () => {
+    expect(validateProcessedImageSize(8 * 1024 * 1024, 8)).toEqual({ ok: true });
+    expect(validateProcessedImageSize(8 * 1024 * 1024 + 1, 8)).toEqual({
+      ok: false,
+      status: 413,
+      message: "图片处理后仍超过 8MB 限制",
+    });
+  });
+});

--- a/apps/server/src/lib/image-upload-policy.test.ts
+++ b/apps/server/src/lib/image-upload-policy.test.ts
@@ -4,6 +4,8 @@ import {
   imageUploadSourceHardMaxSizeMb,
   maxImageMaxSizeMb,
   minImageMaxSizeMb,
+  buildImageSourceSizeErrorMessage,
+  imageStorageHardMaxBytes,
   normalizeImageMaxSizeMb,
   resolveImageUploadLimits,
   validateProcessedImageSize,
@@ -27,6 +29,14 @@ describe("tenant image upload policy", () => {
       sourceMaxBytes: imageUploadSourceHardMaxSizeMb * 1024 * 1024,
       processedMaxBytes: 8 * 1024 * 1024,
     });
+  });
+
+  test("keeps source errors and publisher safety limits aligned with the shared policy", () => {
+    expect(buildImageSourceSizeErrorMessage({ compressionEnabled: true, maxSizeMb: 5 }))
+      .toBe("图片原图不能超过 50MB，无法自动压缩");
+    expect(buildImageSourceSizeErrorMessage({ compressionEnabled: false, maxSizeMb: 5.9 }))
+      .toBe("图片不能超过 5MB");
+    expect(imageStorageHardMaxBytes).toBe(50 * 1024 * 1024);
   });
 
   test("rejects an image that is still over the tenant limit after compression", () => {

--- a/apps/server/src/lib/image-upload-policy.ts
+++ b/apps/server/src/lib/image-upload-policy.ts
@@ -12,7 +12,21 @@ export const defaultImageMaxSizeMb = DEFAULT_IMAGE_MAX_SIZE_MB;
 export const minImageMaxSizeMb = MIN_IMAGE_MAX_SIZE_MB;
 export const maxImageMaxSizeMb = MAX_IMAGE_MAX_SIZE_MB;
 export const imageUploadSourceHardMaxSizeMb = IMAGE_UPLOAD_SOURCE_HARD_MAX_SIZE_MB;
+export const imageStorageHardMaxBytes = imageUploadSourceHardMaxSizeMb * bytesPerMegabyte;
 export { normalizeImageMaxSizeMb };
+
+export function buildImageSourceSizeErrorMessage({
+  compressionEnabled,
+  maxSizeMb,
+}: {
+  compressionEnabled: boolean;
+  maxSizeMb: unknown;
+}): string {
+  if (compressionEnabled) {
+    return `图片原图不能超过 ${imageUploadSourceHardMaxSizeMb}MB，无法自动压缩`;
+  }
+  return `图片不能超过 ${normalizeImageMaxSizeMb(maxSizeMb)}MB`;
+}
 
 export function resolveImageUploadLimits({
   maxSizeMb,

--- a/apps/server/src/lib/image-upload-policy.ts
+++ b/apps/server/src/lib/image-upload-policy.ts
@@ -1,0 +1,43 @@
+import {
+  DEFAULT_IMAGE_MAX_SIZE_MB,
+  IMAGE_UPLOAD_SOURCE_HARD_MAX_SIZE_MB,
+  MAX_IMAGE_MAX_SIZE_MB,
+  MIN_IMAGE_MAX_SIZE_MB,
+  normalizeImageMaxSizeMb,
+} from "@campux/domain";
+
+const bytesPerMegabyte = 1024 * 1024;
+
+export const defaultImageMaxSizeMb = DEFAULT_IMAGE_MAX_SIZE_MB;
+export const minImageMaxSizeMb = MIN_IMAGE_MAX_SIZE_MB;
+export const maxImageMaxSizeMb = MAX_IMAGE_MAX_SIZE_MB;
+export const imageUploadSourceHardMaxSizeMb = IMAGE_UPLOAD_SOURCE_HARD_MAX_SIZE_MB;
+export { normalizeImageMaxSizeMb };
+
+export function resolveImageUploadLimits({
+  maxSizeMb,
+  compressionEnabled,
+}: {
+  maxSizeMb: unknown;
+  compressionEnabled: boolean;
+}) {
+  const normalizedMaxSizeMb = normalizeImageMaxSizeMb(maxSizeMb);
+  return {
+    sourceMaxBytes: (compressionEnabled ? imageUploadSourceHardMaxSizeMb : normalizedMaxSizeMb) * bytesPerMegabyte,
+    processedMaxBytes: normalizedMaxSizeMb * bytesPerMegabyte,
+  };
+}
+
+export function validateProcessedImageSize(sizeBytes: number, maxSizeMb: unknown):
+  | { ok: true }
+  | { ok: false; status: 413; message: string } {
+  const normalizedMaxSizeMb = normalizeImageMaxSizeMb(maxSizeMb);
+  if (sizeBytes <= normalizedMaxSizeMb * bytesPerMegabyte) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    status: 413,
+    message: `图片处理后仍超过 ${normalizedMaxSizeMb}MB 限制`,
+  };
+}

--- a/apps/server/src/lib/tenant-metadata-image-upload.test.ts
+++ b/apps/server/src/lib/tenant-metadata-image-upload.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import {
+  imageMaxSizeMetadataKey,
+  readTenantImageCompression,
+} from "./tenant-metadata";
+
+function metadataClient(entries: Array<{ key: string; value: unknown }>) {
+  return {
+    tenantMetadata: {
+      findMany: async () => entries,
+    },
+  } as never;
+}
+
+describe("tenant image upload metadata", () => {
+  test("defaults legacy tenants to a 10MB image limit with compression enabled", async () => {
+    await expect(readTenantImageCompression(metadataClient([]), "tenant-1")).resolves.toEqual({
+      enabled: true,
+      quality: 80,
+      maxDimension: 2048,
+      maxSizeMb: 10,
+    });
+  });
+
+  test("reads the tenant-specific image size limit together with compression settings", async () => {
+    await expect(readTenantImageCompression(metadataClient([
+      { key: "image_compression_enabled", value: false },
+      { key: "image_compression_quality", value: 70 },
+      { key: "image_compression_max_dimension", value: 1600 },
+      { key: imageMaxSizeMetadataKey, value: 25 },
+    ]), "tenant-1")).resolves.toEqual({
+      enabled: false,
+      quality: 70,
+      maxDimension: 1600,
+      maxSizeMb: 25,
+    });
+  });
+});

--- a/apps/server/src/lib/tenant-metadata.ts
+++ b/apps/server/src/lib/tenant-metadata.ts
@@ -1,5 +1,6 @@
 import { Prisma } from "@campux/db";
 import { prisma } from "./prisma";
+import { normalizeImageMaxSizeMb } from "./image-upload-policy";
 
 type MetadataClient = typeof prisma | Prisma.TransactionClient;
 
@@ -10,6 +11,7 @@ export const pendingPostLimitMetadataKey = "pending_post_limit";
 export const imageCompressionEnabledKey = "image_compression_enabled";
 export const imageCompressionQualityKey = "image_compression_quality";
 export const imageCompressionMaxDimensionKey = "image_compression_max_dimension";
+export const imageMaxSizeMetadataKey = "image_max_size_mb";
 
 export const imageCompressionDefaults = {
   enabled: true,
@@ -118,7 +120,7 @@ export async function readTenantImageCompression(client: MetadataClient, tenantI
     where: {
       tenantId,
       key: {
-        in: [imageCompressionEnabledKey, imageCompressionQualityKey, imageCompressionMaxDimensionKey],
+        in: [imageCompressionEnabledKey, imageCompressionQualityKey, imageCompressionMaxDimensionKey, imageMaxSizeMetadataKey],
       },
     },
     select: {
@@ -133,6 +135,7 @@ export async function readTenantImageCompression(client: MetadataClient, tenantI
     enabled: normalizeImageCompressionEnabled(record[imageCompressionEnabledKey]),
     quality: normalizeImageCompressionQuality(record[imageCompressionQualityKey]),
     maxDimension: normalizeImageCompressionMaxDimension(record[imageCompressionMaxDimensionKey]),
+    maxSizeMb: normalizeImageMaxSizeMb(record[imageMaxSizeMetadataKey]),
   };
 }
 

--- a/apps/server/src/routes/metadata.ts
+++ b/apps/server/src/routes/metadata.ts
@@ -16,6 +16,7 @@ import {
   imageCompressionEnabledKey,
   imageCompressionQualityKey,
   imageCompressionMaxDimensionKey,
+  imageMaxSizeMetadataKey,
   botStylishMessagesEnabledKey,
   normalizeBotStylishMessagesEnabled,
   botPrivatePostStylishEnabledKey,
@@ -41,6 +42,7 @@ import {
   enableAnonymousAvatarSelectionKey,
   normalizeEnableAnonymousAvatarSelection,
 } from "../lib/tenant-metadata";
+import { maxImageMaxSizeMb, minImageMaxSizeMb, normalizeImageMaxSizeMb } from "../lib/image-upload-policy";
 
 const publicMetadataKeys = [
   "brand",
@@ -52,6 +54,7 @@ const publicMetadataKeys = [
   imageCompressionEnabledKey,
   imageCompressionQualityKey,
   imageCompressionMaxDimensionKey,
+  imageMaxSizeMetadataKey,
   botStylishMessagesEnabledKey,
   botPrivatePostStylishEnabledKey,
   publishModeKey,
@@ -84,6 +87,7 @@ const patchMetadataSchema = z.object({
   imageCompressionEnabled: z.boolean().optional(),
   imageCompressionQuality: z.number().int().min(40).max(95).optional(),
   imageCompressionMaxDimension: z.number().int().min(512).max(4096).optional(),
+  imageMaxSizeMb: z.number().int().min(minImageMaxSizeMb).max(maxImageMaxSizeMb).optional(),
   botStylishMessagesEnabled: z.boolean().optional(),
   botPrivatePostStylishEnabled: z.boolean().optional(),
   publishMode: z.enum(["single", "accumulate"]).optional(),
@@ -122,6 +126,7 @@ function normalizeMetadata(entries: Array<{ key: string; value: unknown }>) {
       quality: normalizeQuality(record[imageCompressionQualityKey]),
       maxDimension: normalizeMaxDimension(record[imageCompressionMaxDimensionKey]),
     },
+    imageMaxSizeMb: normalizeImageMaxSizeMb(record[imageMaxSizeMetadataKey]),
     botStylishMessagesEnabled: normalizeBotStylishMessagesEnabled(record[botStylishMessagesEnabledKey]),
     botPrivatePostStylishEnabled: normalizeBotPrivatePostStylishEnabled(record[botPrivatePostStylishEnabledKey]),
     publishMode: normalizePublishMode(record[publishModeKey]),
@@ -351,6 +356,9 @@ export function registerMetadataRoutes(app: FastifyInstance, config: CampuxConfi
     }
     if (body.imageCompressionMaxDimension !== undefined) {
       updates.push({ key: imageCompressionMaxDimensionKey, value: body.imageCompressionMaxDimension });
+    }
+    if (body.imageMaxSizeMb !== undefined) {
+      updates.push({ key: imageMaxSizeMetadataKey, value: normalizeImageMaxSizeMb(body.imageMaxSizeMb) });
     }
     if (body.botStylishMessagesEnabled !== undefined) {
       updates.push({ key: botStylishMessagesEnabledKey, value: body.botStylishMessagesEnabled });

--- a/apps/server/src/routes/posts.ts
+++ b/apps/server/src/routes/posts.ts
@@ -13,6 +13,7 @@ import { buildPublishedFeed, filterPublishedFeedByTag, type BatchFeedInput, type
 import { serializeAssignedPostTags } from "../lib/post-tags";
 import { prisma } from "../lib/prisma";
 import { readTenantPendingPostLimit, readTenantImageCompression } from "../lib/tenant-metadata";
+import { imageUploadSourceHardMaxSizeMb, resolveImageUploadLimits, validateProcessedImageSize } from "../lib/image-upload-policy";
 import { writeAuditLog } from "../lib/audit";
 import { compressImageBuffer, uploadAttachmentBytes, deleteAttachmentObjects, type PostAttachment } from "../lib/attachments";
 import { detectPostInjection, validateRemoteGifUrls, createAutoBan } from "../lib/sanitize";
@@ -96,7 +97,6 @@ function isConvertibleVideoType(contentType: string): boolean {
   return VIDEO_CONVERT_MIME_TYPES.has(contentType);
 }
 
-const IMAGE_SIZE_CAP = 10 * 1024 * 1024; // 10MB
 const VIDEO_SIZE_CAP = 100 * 1024 * 1024; // 100MB
 const MAX_VIDEO_DURATION_SEC = 60;
 
@@ -242,6 +242,10 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
   app.post("/api/posts", async (request, reply) => {
     const context = await requireReadyTenant(request, reply, "submitter");
     const compression = await readTenantImageCompression(prisma, context.selectedTenant.id);
+    const imageUploadLimits = resolveImageUploadLimits({
+      maxSizeMb: compression.maxSizeMb,
+      compressionEnabled: compression.enabled,
+    });
 
     // Check ban first
     const activeBan = await prisma.banRecord.findFirst({
@@ -327,10 +331,15 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
         }
 
         const isVideo = isConvertibleVideoType(mime);
-        const cap = isVideo ? VIDEO_SIZE_CAP : IMAGE_SIZE_CAP;
+        const cap = isVideo ? VIDEO_SIZE_CAP : imageUploadLimits.sourceMaxBytes;
+        const sizeErrorMessage = isVideo
+          ? "视频原文件不能超过 100MB"
+          : compression.enabled
+            ? `图片原图不能超过 ${imageUploadSourceHardMaxSizeMb}MB，无法自动压缩`
+            : `图片不能超过 ${compression.maxSizeMb}MB`;
 
         // Read file with size cap using Transform
-        const buf = await readPartCapped(part.file, cap, fileIndex);
+        const buf = await readPartCapped(part.file, cap, fileIndex, sizeErrorMessage);
 
         let finalBuf: Buffer;
         let finalMime: string;
@@ -354,6 +363,15 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
           finalBuf = await compressImageBuffer(buf, mime, compression);
           finalMime = mime;
           finalFileName = part.filename || "attachment.jpg";
+        }
+
+        const sizeValidation = validateProcessedImageSize(finalBuf.byteLength, compression.maxSizeMb);
+        if (!sizeValidation.ok) {
+          throw {
+            status: sizeValidation.status,
+            message: sizeValidation.message,
+            fileIndex,
+          };
         }
 
         // Upload to S3
@@ -392,6 +410,14 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
           }
           const arrayBuffer = await response.arrayBuffer();
           const buf = Buffer.from(arrayBuffer);
+          const sizeValidation = validateProcessedImageSize(buf.byteLength, compression.maxSizeMb);
+          if (!sizeValidation.ok) {
+            throw {
+              status: sizeValidation.status,
+              message: sizeValidation.message,
+              fileIndex: staged.length,
+            };
+          }
 
           const att = await uploadAttachmentBytes({
             config,
@@ -404,6 +430,9 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
           uploadedKeys.push(att.key);
           staged.push(att);
         } catch (fetchErr) {
+          if (fetchErr && typeof fetchErr === "object" && "status" in fetchErr && "message" in fetchErr) {
+            throw fetchErr;
+          }
           app.log.warn({ error: fetchErr, url: gifUrl }, "failed to process remote GIF");
           // Skip failed URLs rather than failing the entire post
         }
@@ -592,6 +621,7 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
     sourceStream: NodeJS.ReadableStream,
     cap: number,
     fileIndex: number,
+    sizeErrorMessage: string,
   ): Promise<Buffer> {
     let transferredBytes = 0;
     const chunks: Buffer[] = [];
@@ -618,7 +648,7 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
       if (error instanceof Error && (error.message === "size limit exceeded" || error.message.includes("size limit exceeded"))) {
         throw {
           status: 413,
-          message: "文件过大，请检查文件大小限制",
+          message: sizeErrorMessage,
           fileIndex,
         };
       }

--- a/apps/server/src/routes/posts.ts
+++ b/apps/server/src/routes/posts.ts
@@ -13,7 +13,11 @@ import { buildPublishedFeed, filterPublishedFeedByTag, type BatchFeedInput, type
 import { serializeAssignedPostTags } from "../lib/post-tags";
 import { prisma } from "../lib/prisma";
 import { readTenantPendingPostLimit, readTenantImageCompression } from "../lib/tenant-metadata";
-import { imageUploadSourceHardMaxSizeMb, resolveImageUploadLimits, validateProcessedImageSize } from "../lib/image-upload-policy";
+import {
+  buildImageSourceSizeErrorMessage,
+  resolveImageUploadLimits,
+  validateProcessedImageSize,
+} from "../lib/image-upload-policy";
 import { writeAuditLog } from "../lib/audit";
 import { compressImageBuffer, uploadAttachmentBytes, deleteAttachmentObjects, type PostAttachment } from "../lib/attachments";
 import { detectPostInjection, validateRemoteGifUrls, createAutoBan } from "../lib/sanitize";
@@ -334,9 +338,10 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
         const cap = isVideo ? VIDEO_SIZE_CAP : imageUploadLimits.sourceMaxBytes;
         const sizeErrorMessage = isVideo
           ? "视频原文件不能超过 100MB"
-          : compression.enabled
-            ? `图片原图不能超过 ${imageUploadSourceHardMaxSizeMb}MB，无法自动压缩`
-            : `图片不能超过 ${compression.maxSizeMb}MB`;
+          : buildImageSourceSizeErrorMessage({
+              compressionEnabled: compression.enabled,
+              maxSizeMb: compression.maxSizeMb,
+            });
 
         // Read file with size cap using Transform
         const buf = await readPartCapped(part.file, cap, fileIndex, sizeErrorMessage);

--- a/apps/server/src/runtime/onebot.ts
+++ b/apps/server/src/runtime/onebot.ts
@@ -26,7 +26,11 @@ import { prisma } from "../lib/prisma";
 import { extractOneBotImageSegments, extractOneBotMessageSegments, extractOneBotPlainText, isPrivatePostCancelText, isPrivatePostFinishText, isPrivatePostUndoText, parsePrivatePostConfirmText, parsePrivatePostModeText, parsePrivatePostStartText, type OneBotMessageSegment } from "../lib/private-posting";
 import { analyzePrivatePostSemantics, type PrivatePostSemanticResult } from "../lib/private-posting-ai";
 import { readTenantImageCompression, readTenantPendingPostLimit, readTenantBotStylishMessagesEnabled, readTenantBotPrivatePostStylishEnabled } from "../lib/tenant-metadata";
-import { imageUploadSourceHardMaxSizeMb, resolveImageUploadLimits, validateProcessedImageSize } from "../lib/image-upload-policy";
+import {
+  buildImageSourceSizeErrorMessage,
+  resolveImageUploadLimits,
+  validateProcessedImageSize,
+} from "../lib/image-upload-policy";
 import { detectPostInjection, createAutoBan } from "../lib/sanitize";
 import { readTenantAiSettings } from "./ai-settings";
 import type { RuntimeQueue } from "./queue";
@@ -1875,10 +1879,13 @@ export class OneBotRuntime {
       for (const segment of imageSegments) {
         const source = await this.resolvePrivatePostImageSource(bot.qqUin.toString(), segment);
         if (source.bytes.length > imageUploadLimits.sourceMaxBytes) {
-          const message = compression.enabled
-            ? `图片原图不能超过 ${imageUploadSourceHardMaxSizeMb}MB，无法自动压缩`
-            : `图片不能超过 ${compression.maxSizeMb}MB`;
-          throw new BotWorkflowError(message, 413);
+          throw new BotWorkflowError(
+            buildImageSourceSizeErrorMessage({
+              compressionEnabled: compression.enabled,
+              maxSizeMb: compression.maxSizeMb,
+            }),
+            413,
+          );
         }
         const fileName = source.fileName || normalizeImageFileName(source.url) || "attachment.jpg";
         const compressed = await compressImageBuffer(source.bytes, source.contentType, compression);

--- a/apps/server/src/runtime/onebot.ts
+++ b/apps/server/src/runtime/onebot.ts
@@ -26,6 +26,7 @@ import { prisma } from "../lib/prisma";
 import { extractOneBotImageSegments, extractOneBotMessageSegments, extractOneBotPlainText, isPrivatePostCancelText, isPrivatePostFinishText, isPrivatePostUndoText, parsePrivatePostConfirmText, parsePrivatePostModeText, parsePrivatePostStartText, type OneBotMessageSegment } from "../lib/private-posting";
 import { analyzePrivatePostSemantics, type PrivatePostSemanticResult } from "../lib/private-posting-ai";
 import { readTenantImageCompression, readTenantPendingPostLimit, readTenantBotStylishMessagesEnabled, readTenantBotPrivatePostStylishEnabled } from "../lib/tenant-metadata";
+import { imageUploadSourceHardMaxSizeMb, resolveImageUploadLimits, validateProcessedImageSize } from "../lib/image-upload-policy";
 import { detectPostInjection, createAutoBan } from "../lib/sanitize";
 import { readTenantAiSettings } from "./ai-settings";
 import type { RuntimeQueue } from "./queue";
@@ -1863,17 +1864,28 @@ export class OneBotRuntime {
     }
 
     const compression = await readTenantImageCompression(prisma, bot.tenantId);
+    const imageUploadLimits = resolveImageUploadLimits({
+      maxSizeMb: compression.maxSizeMb,
+      compressionEnabled: compression.enabled,
+    });
     const attachments: PostAttachment[] = [];
     const uploadedKeys: string[] = [];
 
     try {
       for (const segment of imageSegments) {
         const source = await this.resolvePrivatePostImageSource(bot.qqUin.toString(), segment);
-        if (source.bytes.length > 10 * 1024 * 1024) {
-          throw new BotWorkflowError("图片最大 10MB，请重新发送更小的图片", 400);
+        if (source.bytes.length > imageUploadLimits.sourceMaxBytes) {
+          const message = compression.enabled
+            ? `图片原图不能超过 ${imageUploadSourceHardMaxSizeMb}MB，无法自动压缩`
+            : `图片不能超过 ${compression.maxSizeMb}MB`;
+          throw new BotWorkflowError(message, 413);
         }
         const fileName = source.fileName || normalizeImageFileName(source.url) || "attachment.jpg";
         const compressed = await compressImageBuffer(source.bytes, source.contentType, compression);
+        const sizeValidation = validateProcessedImageSize(compressed.byteLength, compression.maxSizeMb);
+        if (!sizeValidation.ok) {
+          throw new BotWorkflowError(sizeValidation.message, sizeValidation.status);
+        }
         const attachment = await uploadAttachmentBytes({
           config: this.config,
           tenantId: bot.tenantId,

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -12,7 +12,8 @@ import { checkAndUpdateQZoneSession } from "../lib/qzone-cookies";
 import { isQZoneProtocolAutoRefreshCooldownError } from "../lib/qzone-auto-refresh";
 import { joinBatchCaptions } from "./publish-batching";
 import { generatePublishSummary } from "./publish-summary";
-import { readTenantPublishLlmSummaryEnabled } from "../lib/tenant-metadata";
+import { readTenantImageCompression, readTenantPublishLlmSummaryEnabled } from "../lib/tenant-metadata";
+import { resolveImageUploadLimits } from "../lib/image-upload-policy";
 import { readSvgAvatarDataUrl } from "../lib/svg-avatars";
 import { createOfficialQqForumThread } from "./official-qq";
 import { buildPublicForumMediaUrl } from "../lib/public-forum-media";
@@ -1542,8 +1543,6 @@ function getImageUrls(attachments: unknown) {
   });
 }
 
-const IMAGE_READ_SIZE_LIMIT = 10 * 1024 * 1024;
-
 function assertValidImageKey(key: string, tenantId: string): void {
   const allowedPrefixes = [
     `tenants/${tenantId}/uploads/`,
@@ -1559,6 +1558,11 @@ async function loadPostImages(config: CampuxConfig, tenantId: string, attachment
     throw new Error("稿件图片数据格式错误：attachments 不是数组");
   }
   const storage = getStorageDriver(config);
+  const imageSettings = await readTenantImageCompression(prisma, tenantId);
+  const { processedMaxBytes } = resolveImageUploadLimits({
+    maxSizeMb: imageSettings.maxSizeMb,
+    compressionEnabled: imageSettings.enabled,
+  });
   const result = [];
   for (const attachment of attachments) {
     const candidate = attachment as any;
@@ -1568,8 +1572,8 @@ async function loadPostImages(config: CampuxConfig, tenantId: string, attachment
     assertValidImageKey(candidate.key, tenantId);
 
     const head = await storage.head(candidate.key);
-    if (head && head.size > IMAGE_READ_SIZE_LIMIT) {
-      throw new Error(`图片 ${candidate.key} 超过 10MB 限制（${Math.round(head.size / 1024 / 1024)}MB）`);
+    if (head && head.size > processedMaxBytes) {
+      throw new Error(`图片 ${candidate.key} 超过租户 ${imageSettings.maxSizeMb}MB 限制（${Math.round(head.size / 1024 / 1024)}MB）`);
     }
 
     const object = await storage.getBytes(candidate.key);
@@ -1580,6 +1584,9 @@ async function loadPostImages(config: CampuxConfig, tenantId: string, attachment
 
     if (bytes.byteLength === 0) {
       throw new Error(`图片 ${candidate.key} 读取结果为空`);
+    }
+    if (bytes.byteLength > processedMaxBytes) {
+      throw new Error(`图片 ${candidate.key} 超过租户 ${imageSettings.maxSizeMb}MB 限制（${Math.round(bytes.byteLength / 1024 / 1024)}MB）`);
     }
 
     result.push({

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -12,8 +12,8 @@ import { checkAndUpdateQZoneSession } from "../lib/qzone-cookies";
 import { isQZoneProtocolAutoRefreshCooldownError } from "../lib/qzone-auto-refresh";
 import { joinBatchCaptions } from "./publish-batching";
 import { generatePublishSummary } from "./publish-summary";
-import { readTenantImageCompression, readTenantPublishLlmSummaryEnabled } from "../lib/tenant-metadata";
-import { resolveImageUploadLimits } from "../lib/image-upload-policy";
+import { readTenantPublishLlmSummaryEnabled } from "../lib/tenant-metadata";
+import { imageStorageHardMaxBytes } from "../lib/image-upload-policy";
 import { readSvgAvatarDataUrl } from "../lib/svg-avatars";
 import { createOfficialQqForumThread } from "./official-qq";
 import { buildPublicForumMediaUrl } from "../lib/public-forum-media";
@@ -1558,11 +1558,8 @@ async function loadPostImages(config: CampuxConfig, tenantId: string, attachment
     throw new Error("稿件图片数据格式错误：attachments 不是数组");
   }
   const storage = getStorageDriver(config);
-  const imageSettings = await readTenantImageCompression(prisma, tenantId);
-  const { processedMaxBytes } = resolveImageUploadLimits({
-    maxSizeMb: imageSettings.maxSizeMb,
-    compressionEnabled: imageSettings.enabled,
-  });
+  // Existing attachments keep the policy that accepted them. The global hard cap
+  // prevents unbounded reads without retroactively applying a newly lowered tenant limit.
   const result = [];
   for (const attachment of attachments) {
     const candidate = attachment as any;
@@ -1572,8 +1569,8 @@ async function loadPostImages(config: CampuxConfig, tenantId: string, attachment
     assertValidImageKey(candidate.key, tenantId);
 
     const head = await storage.head(candidate.key);
-    if (head && head.size > processedMaxBytes) {
-      throw new Error(`图片 ${candidate.key} 超过租户 ${imageSettings.maxSizeMb}MB 限制（${Math.round(head.size / 1024 / 1024)}MB）`);
+    if (head && head.size > imageStorageHardMaxBytes) {
+      throw new Error(`图片 ${candidate.key} 超过 50MB 存储安全限制`);
     }
 
     const object = await storage.getBytes(candidate.key);
@@ -1585,8 +1582,8 @@ async function loadPostImages(config: CampuxConfig, tenantId: string, attachment
     if (bytes.byteLength === 0) {
       throw new Error(`图片 ${candidate.key} 读取结果为空`);
     }
-    if (bytes.byteLength > processedMaxBytes) {
-      throw new Error(`图片 ${candidate.key} 超过租户 ${imageSettings.maxSizeMb}MB 限制（${Math.round(bytes.byteLength / 1024 / 1024)}MB）`);
+    if (bytes.byteLength > imageStorageHardMaxBytes) {
+      throw new Error(`图片 ${candidate.key} 超过 50MB 存储安全限制`);
     }
 
     result.push({

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -99,7 +99,10 @@ export function App() {
   const [adminUserDetailTarget, setAdminUserDetailTarget] = useState<{ userId: string; nonce: number } | null>(null);
   const [error, setError] = useState("");
   const [busy, setBusy] = useState(false);
-  const { pending: pendingAttachments, add: addAttachments, remove: removeAttachment, markUploading, setProgress, markFailed, clearAll: clearAttachments } = usePendingAttachments();
+  const { pending: pendingAttachments, add: addAttachments, remove: removeAttachment, markUploading, setProgress, markFailed, clearAll: clearAttachments } = usePendingAttachments({
+    maxSizeMb: metadata.imageMaxSizeMb,
+    compressionEnabled: metadata.imageCompression.enabled,
+  });
 
   const hostTenant = authContext.currentTenant;
   // In single-wall deployments tenant mechanics are hidden: no ops-panel entry,

--- a/apps/web/src/features/admin/AdminPage.tsx
+++ b/apps/web/src/features/admin/AdminPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { PRIVATE_POST_PROMPT_MAX_LENGTH, type TenantSummary } from "@campux/domain";
+import { MAX_IMAGE_MAX_SIZE_MB, MIN_IMAGE_MAX_SIZE_MB, PRIVATE_POST_PROMPT_MAX_LENGTH, type TenantSummary } from "@campux/domain";
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import {
@@ -57,6 +57,7 @@ type TenantSettingsForm = {
   imageCompressionEnabled: boolean;
   imageCompressionQuality: number;
   imageCompressionMaxDimension: number;
+  imageMaxSizeMb: number;
   botStylishMessagesEnabled: boolean;
   publishMode: "single" | "accumulate";
   publishAccumulateMinImages: number;
@@ -364,7 +365,7 @@ export function AdminPage({
 
   useEffect(() => {
     setForm(toForm(selectedTenant, metadata));
-  }, [selectedTenant.id, selectedTenant.slug, selectedTenant.name, selectedTenant.themeColor, metadata.brand, metadata.banner, metadata.logoUrl, metadata.pendingPostLimit, metadata.postRules, metadata.services, metadata.imageCompression.enabled, metadata.imageCompression.quality, metadata.imageCompression.maxDimension, metadata.publishMode, metadata.publishAccumulate.minImages, metadata.publishAccumulate.maxImages, metadata.publishAccumulate.staleMinutes, metadata.publishLlmSummaryEnabled, metadata.enableAnonymousAvatarSelection]);
+  }, [selectedTenant.id, selectedTenant.slug, selectedTenant.name, selectedTenant.themeColor, metadata.brand, metadata.banner, metadata.logoUrl, metadata.pendingPostLimit, metadata.postRules, metadata.services, metadata.imageCompression.enabled, metadata.imageCompression.quality, metadata.imageCompression.maxDimension, metadata.imageMaxSizeMb, metadata.publishMode, metadata.publishAccumulate.minImages, metadata.publishAccumulate.maxImages, metadata.publishAccumulate.staleMinutes, metadata.publishLlmSummaryEnabled, metadata.enableAnonymousAvatarSelection]);
 
   useEffect(() => {
     if (activeTab === "users") {
@@ -538,6 +539,7 @@ export function AdminPage({
           imageCompressionEnabled: form.imageCompressionEnabled,
           imageCompressionQuality: form.imageCompressionQuality,
           imageCompressionMaxDimension: form.imageCompressionMaxDimension,
+          imageMaxSizeMb: form.imageMaxSizeMb,
           botStylishMessagesEnabled: form.botStylishMessagesEnabled,
           botPrivatePostStylishEnabled: form.botStylishMessagesEnabled,
           publishMode: form.publishMode,
@@ -1814,11 +1816,23 @@ function MetadataPanel({
             />
             <span className="text-xs font-normal text-slate-500">0 表示不限制，默认建议 1 条。</span>
           </label>
-          <div className="grid gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-3 md:col-span-2">
-            <div className="flex items-center justify-between gap-3">
+          <div className="grid gap-3 rounded-md border border-slate-200 bg-slate-50 px-3 py-3 md:col-span-2">
+            <label className="grid gap-1 text-sm font-medium md:max-w-xs">
+              单张投稿图片上限 (MB)
+              <Input
+                type="number"
+                min={MIN_IMAGE_MAX_SIZE_MB}
+                max={MAX_IMAGE_MAX_SIZE_MB}
+                value={form.imageMaxSizeMb}
+                disabled={busy}
+                onChange={(event) => onFormChange({ ...form, imageMaxSizeMb: Number(event.target.value) })}
+              />
+              <span className="text-xs font-normal text-slate-500">允许 {MIN_IMAGE_MAX_SIZE_MB}-{MAX_IMAGE_MAX_SIZE_MB}MB；自动压缩后仍须小于该上限，默认 10MB。</span>
+            </label>
+            <div className="flex items-center justify-between gap-3 border-t border-slate-200 pt-3">
               <div>
-                <p className="text-sm font-medium text-slate-900">图片压缩</p>
-                <p className="text-xs text-slate-500">投稿图片会自动压缩，关闭后按原图存储。</p>
+                <p className="text-sm font-medium text-slate-900">自动压缩投稿图片</p>
+                <p className="text-xs text-slate-500">默认开启；上传原图后立即压缩，关闭后按原图存储并直接校验大小。</p>
               </div>
               <Switch
                 checked={form.imageCompressionEnabled}
@@ -3860,6 +3874,7 @@ function toForm(selectedTenant: TenantSummary, metadata: TenantMetadata): Tenant
     imageCompressionEnabled: metadata.imageCompression.enabled,
     imageCompressionQuality: metadata.imageCompression.quality,
     imageCompressionMaxDimension: metadata.imageCompression.maxDimension,
+    imageMaxSizeMb: metadata.imageMaxSizeMb,
     botStylishMessagesEnabled: metadata.botStylishMessagesEnabled,
     publishMode: metadata.publishMode,
     publishAccumulateMinImages: metadata.publishAccumulate.minImages,

--- a/apps/web/src/features/admin/AdminPage.tsx
+++ b/apps/web/src/features/admin/AdminPage.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from "react";
-import { MAX_IMAGE_MAX_SIZE_MB, MIN_IMAGE_MAX_SIZE_MB, PRIVATE_POST_PROMPT_MAX_LENGTH, type TenantSummary } from "@campux/domain";
+import {
+  MAX_IMAGE_MAX_SIZE_MB,
+  MIN_IMAGE_MAX_SIZE_MB,
+  PRIVATE_POST_PROMPT_MAX_LENGTH,
+  normalizeImageMaxSizeMb,
+  type TenantSummary,
+} from "@campux/domain";
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import {
@@ -1821,11 +1827,15 @@ function MetadataPanel({
               单张投稿图片上限 (MB)
               <Input
                 type="number"
+                step={1}
                 min={MIN_IMAGE_MAX_SIZE_MB}
                 max={MAX_IMAGE_MAX_SIZE_MB}
                 value={form.imageMaxSizeMb}
                 disabled={busy}
-                onChange={(event) => onFormChange({ ...form, imageMaxSizeMb: Number(event.target.value) })}
+                onChange={(event) => onFormChange({
+                  ...form,
+                  imageMaxSizeMb: normalizeImageMaxSizeMb(event.target.value),
+                })}
               />
               <span className="text-xs font-normal text-slate-500">允许 {MIN_IMAGE_MAX_SIZE_MB}-{MAX_IMAGE_MAX_SIZE_MB}MB；自动压缩后仍须小于该上限，默认 10MB。</span>
             </label>

--- a/apps/web/src/features/posts/PostPage.tsx
+++ b/apps/web/src/features/posts/PostPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { ClipboardEvent } from "react";
 import type { TenantSummary } from "@campux/domain";
-import { FONT_OPTIONS, isDefaultFont } from "@campux/domain";
+import { FONT_OPTIONS, IMAGE_UPLOAD_SOURCE_HARD_MAX_SIZE_MB, isDefaultFont } from "@campux/domain";
 import { ChevronDownIcon, ImagePlusIcon, LoaderIcon, MegaphoneIcon, SendIcon } from "lucide-react";
 import { defaultMetadata } from "@/lib/app-model";
 import { builtInSvgAvatarFilenames } from "@/lib/built-in-svg-avatars";
@@ -198,7 +198,11 @@ export function PostPage({
           <input ref={inputRef} hidden multiple accept="image/*,video/*" type="file" onChange={(event) => onFilesSelected(event.target.files)} />
         </div>
         <p className="mt-2 text-xs leading-5 text-slate-500">
-          最多 9 个文件。图片 ≤ 10MB，视频 ≤ 15MB（上传后自动转为 GIF）。
+          最多 9 个文件。
+          {metadata.imageCompression.enabled
+            ? `图片原图 ≤ ${IMAGE_UPLOAD_SOURCE_HARD_MAX_SIZE_MB}MB，上传时自动压缩至 ≤ ${metadata.imageMaxSizeMb}MB。`
+            : `图片 ≤ ${metadata.imageMaxSizeMb}MB，自动压缩已关闭。`}
+          视频 ≤ 15MB（上传后自动转为 GIF）。
           {hasConverting ? (
             <span className="ml-1 text-amber-600">视频转换中，请稍候…</span>
           ) : null}

--- a/apps/web/src/hooks/useUploadImages.ts
+++ b/apps/web/src/hooks/useUploadImages.ts
@@ -2,15 +2,20 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { PendingAttachment } from "@/types/app";
 import { uploadVideoToGif, ScdnApiError, SCDN_MAX_VIDEO_SIZE } from "@/lib/scdn-api";
-
-const MAX_IMAGE_SIZE = 10 * 1024 * 1024;
+import { getSelectedImageRejection } from "@/lib/image-upload-policy";
 
 type ConversionJob = {
   attachmentId: string;
   file: File;
 };
 
-export function usePendingAttachments() {
+export function usePendingAttachments({
+  maxSizeMb,
+  compressionEnabled,
+}: {
+  maxSizeMb: number;
+  compressionEnabled: boolean;
+}) {
   const [pending, setPending] = useState<PendingAttachment[]>([]);
   const blobUrlsRef = useRef<string[]>([]);
   const conversionQueueRef = useRef<ConversionJob[]>([]);
@@ -127,9 +132,17 @@ export function usePendingAttachments() {
             toast.error(`${file.name || "视频"} 超过 15MB 限制`);
             continue;
           }
-          if (!isVideo && file.size > MAX_IMAGE_SIZE) {
-            toast.error(`${file.name || "图片"} 超过 10MB 限制`);
-            continue;
+          if (!isVideo) {
+            const rejection = getSelectedImageRejection({
+              fileName: file.name,
+              sizeBytes: file.size,
+              maxSizeMb,
+              compressionEnabled,
+            });
+            if (rejection) {
+              toast.error(rejection);
+              continue;
+            }
           }
 
           const id = crypto.randomUUID();
@@ -164,7 +177,7 @@ export function usePendingAttachments() {
         return [...current, ...accepted];
       });
     },
-    [processNextConversion],
+    [compressionEnabled, maxSizeMb, processNextConversion],
   );
 
   const remove = useCallback((id: string) => {

--- a/apps/web/src/lib/app-model.ts
+++ b/apps/web/src/lib/app-model.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_IMAGE_MAX_SIZE_MB } from "@campux/domain";
 import type { LucideIcon } from "lucide-react";
 import { BarChart3Icon, ClipboardListIcon, HomeIcon, ShieldCheckIcon, WrenchIcon } from "lucide-react";
 import type { MainTab, TenantMetadata, TenantRole } from "@/types/app";
@@ -18,7 +19,7 @@ export const defaultMetadata: TenantMetadata = {
   postRules: [
     "不发布隐私信息、辱骂、人身攻击和未经确认的指控。",
     "寻物招领请写清地点、时间和联系方式。",
-    "图片最多 9 张，单张 ≤ 10MB；审核通过后会同步到本校启用的墙号。",
+    "图片最多 9 张，单张大小以当前墙面设置为准；审核通过后会同步到本校启用的墙号。",
   ],
   pendingPostLimit: 1,
   services: [
@@ -32,6 +33,7 @@ export const defaultMetadata: TenantMetadata = {
     quality: 80,
     maxDimension: 2048,
   },
+  imageMaxSizeMb: DEFAULT_IMAGE_MAX_SIZE_MB,
   botStylishMessagesEnabled: false,
   botPrivatePostStylishEnabled: false,
   publishMode: "single",

--- a/apps/web/src/lib/image-upload-policy.test.ts
+++ b/apps/web/src/lib/image-upload-policy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { getSelectedImageRejection } from "./image-upload-policy";
+
+describe("getSelectedImageRejection", () => {
+  test("uses the tenant limit immediately when automatic compression is disabled", () => {
+    expect(getSelectedImageRejection({
+      fileName: "poster.png",
+      sizeBytes: 6 * 1024 * 1024,
+      maxSizeMb: 5,
+      compressionEnabled: false,
+    })).toBe("poster.png 超过 5MB 限制");
+  });
+
+  test("allows an oversized original to reach server-side compression", () => {
+    expect(getSelectedImageRejection({
+      fileName: "camera.jpg",
+      sizeBytes: 30 * 1024 * 1024,
+      maxSizeMb: 5,
+      compressionEnabled: true,
+    })).toBeNull();
+  });
+
+  test("still protects the service from originals above the hard upload cap", () => {
+    expect(getSelectedImageRejection({
+      fileName: "huge.jpg",
+      sizeBytes: 50 * 1024 * 1024 + 1,
+      maxSizeMb: 10,
+      compressionEnabled: true,
+    })).toBe("huge.jpg 原图超过 50MB，无法自动压缩");
+  });
+});

--- a/apps/web/src/lib/image-upload-policy.ts
+++ b/apps/web/src/lib/image-upload-policy.ts
@@ -1,0 +1,29 @@
+import { IMAGE_UPLOAD_SOURCE_HARD_MAX_SIZE_MB } from "@campux/domain";
+
+const bytesPerMegabyte = 1024 * 1024;
+export const imageUploadSourceHardMaxSizeMb = IMAGE_UPLOAD_SOURCE_HARD_MAX_SIZE_MB;
+
+export function getSelectedImageRejection({
+  fileName,
+  sizeBytes,
+  maxSizeMb,
+  compressionEnabled,
+}: {
+  fileName: string;
+  sizeBytes: number;
+  maxSizeMb: number;
+  compressionEnabled: boolean;
+}): string | null {
+  const displayName = fileName || "图片";
+  if (compressionEnabled) {
+    if (sizeBytes > imageUploadSourceHardMaxSizeMb * bytesPerMegabyte) {
+      return `${displayName} 原图超过 ${imageUploadSourceHardMaxSizeMb}MB，无法自动压缩`;
+    }
+    return null;
+  }
+
+  if (sizeBytes > maxSizeMb * bytesPerMegabyte) {
+    return `${displayName} 超过 ${maxSizeMb}MB 限制`;
+  }
+  return null;
+}

--- a/apps/web/src/types/app.ts
+++ b/apps/web/src/types/app.ts
@@ -115,6 +115,7 @@ export type TenantMetadata = {
     quality: number;
     maxDimension: number;
   };
+  imageMaxSizeMb: number;
   botStylishMessagesEnabled: boolean;
   botPrivatePostStylishEnabled: boolean;
   publishMode: "single" | "accumulate";

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -2,6 +2,23 @@ import { z } from "zod";
 
 export * from "./fonts";
 
+export const DEFAULT_IMAGE_MAX_SIZE_MB = 10;
+export const MIN_IMAGE_MAX_SIZE_MB = 1;
+export const MAX_IMAGE_MAX_SIZE_MB = 50;
+export const IMAGE_UPLOAD_SOURCE_HARD_MAX_SIZE_MB = 50;
+
+export function normalizeImageMaxSizeMb(value: unknown): number {
+  const numeric = typeof value === "number"
+    ? value
+    : typeof value === "string"
+      ? Number(value)
+      : DEFAULT_IMAGE_MAX_SIZE_MB;
+  if (!Number.isFinite(numeric)) {
+    return DEFAULT_IMAGE_MAX_SIZE_MB;
+  }
+  return Math.max(MIN_IMAGE_MAX_SIZE_MB, Math.min(MAX_IMAGE_MAX_SIZE_MB, Math.floor(numeric)));
+}
+
 export const PRIVATE_POST_PROMPT_MAX_LENGTH = 4_000;
 export const DEFAULT_PRIVATE_POST_PROMPT = [
   "你是校园墙 QQ 私聊投稿语义解析器。只返回 JSON，不要 Markdown。",


### PR DESCRIPTION
## Summary
- add a tenant wall setting for the per-image size limit (1-50 MB, default 10 MB)
- keep automatic image compression enabled by default and allow tenant admins to disable it
- apply the same policy to web uploads, OneBot private submissions, converted GIFs, and publisher reads
- allow up to 50 MB source images when compression is enabled, then enforce the tenant limit after processing

## Validation
- `bun test` — 360 pass, 5 skip, 0 fail
- `git diff --cached --check`
- production verification script prepared; will run against a temporary tenant after deployment (tenant 9178 excluded)

## Summary by Sourcery

使图片上传大小限制可按租户进行配置，并在网页、机器人和发布流程中统一执行。

新功能：
- 为每个租户引入最大图片大小配置，提供安全默认值，并限定在 1–50MB 范围内。
- 在管理后台界面中暴露图片大小限制和压缩开关，并将其应用于网页图片上传和提示（prompts）。
- 在启用自动压缩时允许更大的源图片，同时在处理后图片上严格执行租户的大小限制。

增强：
- 在服务器端和网页端集中管理图片上传策略逻辑，包括限制归一化和错误信息提示。
- 在发布和 GIF 处理过程中读取已存储的帖子图片时，应用租户特定的图片大小检查。

测试：
- 为服务器端图片上传策略以及针对旧版和已配置租户的租户元数据默认值添加单元测试。
- 为网页端图片选择拒绝逻辑添加单元测试，以确保遵守租户限制和硬性上限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make image upload size limits tenant-configurable and consistently enforced across web, bot, and publishing flows.

New Features:
- Introduce per-tenant configuration for maximum image size with safe defaults and 1-50MB bounds.
- Expose the image size limit and compression toggle in the admin UI and apply it to web image uploads and prompts.
- Allow larger source images when automatic compression is enabled while enforcing the tenant limit on processed images.

Enhancements:
- Centralize image upload policy logic on server and web, including limit normalization and error messaging.
- Apply tenant-specific image size checks when reading stored post images during publishing and GIF processing.

Tests:
- Add unit tests for server-side image upload policy and tenant metadata defaults for legacy and configured tenants.
- Add unit tests for web-side image selection rejection logic respecting tenant limits and hard caps.

</details>