### PR TITLE
fix: harden tenant image upload limits

### DIFF
--- a/apps/server/src/lib/image-upload-policy.test.ts
+++ b/apps/server/src/lib/image-upload-policy.test.ts
@@ -7,7 +7,10 @@ import {
   buildImageSourceSizeErrorMessage,
   imageStorageHardMaxBytes,
   normalizeImageMaxSizeMb,
+  readResponseBufferWithLimit,
   resolveImageUploadLimits,
+  ResponseBodyTooLargeError,
+  validateConvertedVideoGifSize,
   validateProcessedImageSize,
 } from "./image-upload-policy";
 
@@ -46,5 +49,45 @@ describe("tenant image upload policy", () => {
       status: 413,
       message: "图片处理后仍超过 8MB 限制",
     });
+  });
+
+  test("keeps converted video GIFs on the stable storage cap instead of the tenant image limit", () => {
+    expect(validateConvertedVideoGifSize(12 * 1024 * 1024)).toEqual({ ok: true });
+    expect(validateConvertedVideoGifSize(imageStorageHardMaxBytes + 1)).toEqual({
+      ok: false,
+      status: 413,
+      message: "视频转换后的 GIF 不能超过 50MB",
+    });
+  });
+
+  test("reads remote bodies without crossing the configured memory cap", async () => {
+    const response = new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2]));
+        controller.enqueue(new Uint8Array([3, 4]));
+        controller.close();
+      },
+    }));
+    expect([...await readResponseBufferWithLimit(response, 4)]).toEqual([1, 2, 3, 4]);
+  });
+
+  test("rejects remote bodies from content-length or streamed bytes before full buffering", async () => {
+    let declaredBodyCancelled = false;
+    const declared = new Response(new ReadableStream<Uint8Array>({
+      cancel() {
+        declaredBodyCancelled = true;
+      },
+    }), { headers: { "content-length": "6" } });
+    await expect(readResponseBufferWithLimit(declared, 5)).rejects.toBeInstanceOf(ResponseBodyTooLargeError);
+    expect(declaredBodyCancelled).toBe(true);
+
+    const streamed = new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        controller.enqueue(new Uint8Array([4, 5, 6]));
+        controller.close();
+      },
+    }));
+    await expect(readResponseBufferWithLimit(streamed, 5)).rejects.toBeInstanceOf(ResponseBodyTooLargeError);
   });
 });

--- a/apps/server/src/lib/image-upload-policy.ts
+++ b/apps/server/src/lib/image-upload-policy.ts
@@ -42,6 +42,66 @@ export function resolveImageUploadLimits({
   };
 }
 
+export const convertedVideoGifSizeErrorMessage = `视频转换后的 GIF 不能超过 ${imageUploadSourceHardMaxSizeMb}MB`;
+
+export function validateConvertedVideoGifSize(sizeBytes: number):
+  | { ok: true }
+  | { ok: false; status: 413; message: string } {
+  if (sizeBytes <= imageStorageHardMaxBytes) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    status: 413,
+    message: convertedVideoGifSizeErrorMessage,
+  };
+}
+
+export class ResponseBodyTooLargeError extends Error {
+  constructor(public readonly maxBytes: number) {
+    super(`response body exceeds ${maxBytes} bytes`);
+    this.name = "ResponseBodyTooLargeError";
+  }
+}
+
+export async function readResponseBufferWithLimit(response: Response, maxBytes: number): Promise<Buffer> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    throw new TypeError("maxBytes must be a non-negative safe integer");
+  }
+
+  const contentLength = response.headers.get("content-length")?.trim();
+  if (contentLength && /^\d+$/.test(contentLength) && BigInt(contentLength) > BigInt(maxBytes)) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new ResponseBodyTooLargeError(maxBytes);
+  }
+
+  if (!response.body) {
+    return Buffer.alloc(0);
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw new ResponseBodyTooLargeError(maxBytes);
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return Buffer.concat(chunks, totalBytes);
+}
+
 export function validateProcessedImageSize(sizeBytes: number, maxSizeMb: unknown):
   | { ok: true }
   | { ok: false; status: 413; message: string } {

--- a/apps/server/src/routes/posts.ts
+++ b/apps/server/src/routes/posts.ts
@@ -15,7 +15,12 @@ import { prisma } from "../lib/prisma";
 import { readTenantPendingPostLimit, readTenantImageCompression } from "../lib/tenant-metadata";
 import {
   buildImageSourceSizeErrorMessage,
+  convertedVideoGifSizeErrorMessage,
+  imageStorageHardMaxBytes,
+  readResponseBufferWithLimit,
   resolveImageUploadLimits,
+  ResponseBodyTooLargeError,
+  validateConvertedVideoGifSize,
   validateProcessedImageSize,
 } from "../lib/image-upload-policy";
 import { writeAuditLog } from "../lib/audit";
@@ -370,7 +375,9 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
           finalFileName = part.filename || "attachment.jpg";
         }
 
-        const sizeValidation = validateProcessedImageSize(finalBuf.byteLength, compression.maxSizeMb);
+        const sizeValidation = isVideo
+          ? validateConvertedVideoGifSize(finalBuf.byteLength)
+          : validateProcessedImageSize(finalBuf.byteLength, compression.maxSizeMb);
         if (!sizeValidation.ok) {
           throw {
             status: sizeValidation.status,
@@ -413,9 +420,20 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
             app.log.warn({ url: gifUrl, status: response.status }, "failed to fetch remote GIF");
             continue;
           }
-          const arrayBuffer = await response.arrayBuffer();
-          const buf = Buffer.from(arrayBuffer);
-          const sizeValidation = validateProcessedImageSize(buf.byteLength, compression.maxSizeMb);
+          let buf: Buffer;
+          try {
+            buf = await readResponseBufferWithLimit(response, imageStorageHardMaxBytes);
+          } catch (error) {
+            if (error instanceof ResponseBodyTooLargeError) {
+              throw {
+                status: 413,
+                message: convertedVideoGifSizeErrorMessage,
+                fileIndex: staged.length,
+              };
+            }
+            throw error;
+          }
+          const sizeValidation = validateConvertedVideoGifSize(buf.byteLength);
           if (!sizeValidation.ok) {
             throw {
               status: sizeValidation.status,

--- a/apps/server/src/runtime/onebot.ts
+++ b/apps/server/src/runtime/onebot.ts
@@ -28,7 +28,11 @@ import { analyzePrivatePostSemantics, type PrivatePostSemanticResult } from "../
 import { readTenantImageCompression, readTenantPendingPostLimit, readTenantBotStylishMessagesEnabled, readTenantBotPrivatePostStylishEnabled } from "../lib/tenant-metadata";
 import {
   buildImageSourceSizeErrorMessage,
+  imageStorageHardMaxBytes,
+  imageUploadSourceHardMaxSizeMb,
+  readResponseBufferWithLimit,
   resolveImageUploadLimits,
+  ResponseBodyTooLargeError,
   validateProcessedImageSize,
 } from "../lib/image-upload-policy";
 import { detectPostInjection, createAutoBan } from "../lib/sanitize";
@@ -1872,12 +1876,23 @@ export class OneBotRuntime {
       maxSizeMb: compression.maxSizeMb,
       compressionEnabled: compression.enabled,
     });
+    const sourceFetchLimits = {
+      maxBytes: imageUploadLimits.sourceMaxBytes,
+      sizeErrorMessage: buildImageSourceSizeErrorMessage({
+        compressionEnabled: compression.enabled,
+        maxSizeMb: compression.maxSizeMb,
+      }),
+    };
     const attachments: PostAttachment[] = [];
     const uploadedKeys: string[] = [];
 
     try {
       for (const segment of imageSegments) {
-        const source = await this.resolvePrivatePostImageSource(bot.qqUin.toString(), segment);
+        const source = await this.resolvePrivatePostImageSource(
+          bot.qqUin.toString(),
+          segment,
+          sourceFetchLimits,
+        );
         if (source.bytes.length > imageUploadLimits.sourceMaxBytes) {
           throw new BotWorkflowError(
             buildImageSourceSizeErrorMessage({
@@ -1915,17 +1930,21 @@ export class OneBotRuntime {
     }
   }
 
-  private async resolvePrivatePostImageSource(botQqUin: string, segment: { data?: Record<string, unknown> }) {
+  private async resolvePrivatePostImageSource(
+    botQqUin: string,
+    segment: { data?: Record<string, unknown> },
+    limits: PrivatePostImageFetchLimits,
+  ) {
     const data = segment.data ?? {};
     const fileName = normalizeImageFileName(data.file_name ?? data.filename ?? data.name ?? data.file ?? data.url);
     const directSource = typeof (data.url ?? data.file) === "string" ? String(data.url ?? data.file).trim() : null;
     if (directSource?.startsWith("base64://")) {
-      return await fetchPrivatePostImage(directSource, fileName);
+      return await fetchPrivatePostImage(directSource, fileName, limits);
     }
 
     const directUrl = readImageUrlCandidate(data.url ?? data.file);
     if (directUrl) {
-      return await fetchPrivatePostImage(directUrl, fileName);
+      return await fetchPrivatePostImage(directUrl, fileName, limits);
     }
 
     const fileToken = readImageTokenCandidate(data.file);
@@ -1934,9 +1953,12 @@ export class OneBotRuntime {
         const response = await this.callAction(botQqUin, "get_image", { file: fileToken });
         const resolvedUrl = extractImageUrlFromOneBotResponse(response);
         if (resolvedUrl) {
-          return await fetchPrivatePostImage(resolvedUrl, fileName);
+          return await fetchPrivatePostImage(resolvedUrl, fileName, limits);
         }
       } catch (error) {
+        if (error instanceof BotWorkflowError && error.statusCode === 413) {
+          throw error;
+        }
         this.logger.debug({ error, botQqUin }, "onebot get_image fallback failed");
       }
     }
@@ -3874,9 +3896,32 @@ function extractImageUrlFromOneBotResponse(data: unknown) {
   return null;
 }
 
-async function fetchPrivatePostImage(source: string, fileName?: string) {
+type PrivatePostImageFetchLimits = {
+  maxBytes: number;
+  sizeErrorMessage: string;
+};
+
+const defaultPrivatePostImageFetchLimits: PrivatePostImageFetchLimits = {
+  maxBytes: imageStorageHardMaxBytes,
+  sizeErrorMessage: `图片不能超过 ${imageUploadSourceHardMaxSizeMb}MB`,
+};
+
+async function fetchPrivatePostImage(
+  source: string,
+  fileName?: string,
+  limits: PrivatePostImageFetchLimits = defaultPrivatePostImageFetchLimits,
+) {
   if (source.startsWith("base64://")) {
-    const bytes = Buffer.from(source.slice("base64://".length), "base64");
+    const encoded = source.slice("base64://".length);
+    const paddingBytes = encoded.endsWith("==") ? 2 : encoded.endsWith("=") ? 1 : 0;
+    const estimatedBytes = Math.max(0, Math.floor(encoded.length * 3 / 4) - paddingBytes);
+    if (estimatedBytes > limits.maxBytes) {
+      throw new BotWorkflowError(limits.sizeErrorMessage, 413);
+    }
+    const bytes = Buffer.from(encoded, "base64");
+    if (bytes.byteLength > limits.maxBytes) {
+      throw new BotWorkflowError(limits.sizeErrorMessage, 413);
+    }
     return {
       bytes,
       contentType: inferImageContentType(fileName || "attachment.jpg"),
@@ -3890,8 +3935,15 @@ async function fetchPrivatePostImage(source: string, fileName?: string) {
     throw new BotWorkflowError(`图片下载失败：${response.status}`, 502);
   }
 
-  const arrayBuffer = await response.arrayBuffer();
-  const bytes = Buffer.from(arrayBuffer);
+  let bytes: Buffer;
+  try {
+    bytes = await readResponseBufferWithLimit(response, limits.maxBytes);
+  } catch (error) {
+    if (error instanceof ResponseBodyTooLargeError) {
+      throw new BotWorkflowError(limits.sizeErrorMessage, 413);
+    }
+    throw error;
+  }
   const headerContentType = response.headers.get("content-type")?.split(";")[0]?.trim() || null;
   const contentType = headerContentType && headerContentType.startsWith("image/")
     ? headerContentType

--- a/apps/server/src/runtime/onebot.ts
+++ b/apps/server/src/runtime/onebot.ts
@@ -1893,15 +1893,6 @@ export class OneBotRuntime {
           segment,
           sourceFetchLimits,
         );
-        if (source.bytes.length > imageUploadLimits.sourceMaxBytes) {
-          throw new BotWorkflowError(
-            buildImageSourceSizeErrorMessage({
-              compressionEnabled: compression.enabled,
-              maxSizeMb: compression.maxSizeMb,
-            }),
-            413,
-          );
-        }
         const fileName = source.fileName || normalizeImageFileName(source.url) || "attachment.jpg";
         const compressed = await compressImageBuffer(source.bytes, source.contentType, compression);
         const sizeValidation = validateProcessedImageSize(compressed.byteLength, compression.maxSizeMb);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -99,7 +99,7 @@ export function App() {
   const [adminUserDetailTarget, setAdminUserDetailTarget] = useState<{ userId: string; nonce: number } | null>(null);
   const [error, setError] = useState("");
   const [busy, setBusy] = useState(false);
-  const { pending: pendingAttachments, add: addAttachments, remove: removeAttachment, markUploading, setProgress, markFailed, clearAll: clearAttachments } = usePendingAttachments({
+  const { pending: pendingAttachments, add: addAttachments, remove: removeAttachment, validateBeforeUpload, markUploading, setProgress, markFailed, clearAll: clearAttachments } = usePendingAttachments({
     maxSizeMb: metadata.imageMaxSizeMb,
     compressionEnabled: metadata.imageCompression.enabled,
   });
@@ -454,6 +454,9 @@ export function App() {
     }
     if (postText.trim().length === 0) {
       toast.error("正文不能为空");
+      return;
+    }
+    if (!validateBeforeUpload()) {
       return;
     }
     setBusy(true);

--- a/apps/web/src/features/admin/AdminPage.tsx
+++ b/apps/web/src/features/admin/AdminPage.tsx
@@ -3,7 +3,6 @@ import {
   MAX_IMAGE_MAX_SIZE_MB,
   MIN_IMAGE_MAX_SIZE_MB,
   PRIVATE_POST_PROMPT_MAX_LENGTH,
-  normalizeImageMaxSizeMb,
   type TenantSummary,
 } from "@campux/domain";
 import type { LucideIcon } from "lucide-react";
@@ -31,6 +30,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@/lib/api";
+import { normalizeImageMaxSizeDraft } from "@/lib/image-upload-policy";
 import { roleLabels, statusLabels } from "@/lib/app-model";
 import {
   buildMembershipRoleChangeConfirmation,
@@ -323,6 +323,7 @@ export function AdminPage({
   onSaved: () => Promise<void>;
 }) {
   const [form, setForm] = useState<TenantSettingsForm>(() => toForm(selectedTenant, metadata));
+  const [imageMaxSizeDraft, setImageMaxSizeDraft] = useState(() => String(metadata.imageMaxSizeMb));
   const [aiSettings, setAiSettings] = useState<TenantAiSettings | null>(null);
   const [aiForm, setAiForm] = useState<AiSettingsForm | null>(null);
   const [aiTesting, setAiTesting] = useState(false);
@@ -370,7 +371,9 @@ export function AdminPage({
   const [memberDetailLoading, setMemberDetailLoading] = useState(false);
 
   useEffect(() => {
-    setForm(toForm(selectedTenant, metadata));
+    const nextForm = toForm(selectedTenant, metadata);
+    setForm(nextForm);
+    setImageMaxSizeDraft(String(nextForm.imageMaxSizeMb));
   }, [selectedTenant.id, selectedTenant.slug, selectedTenant.name, selectedTenant.themeColor, metadata.brand, metadata.banner, metadata.logoUrl, metadata.pendingPostLimit, metadata.postRules, metadata.services, metadata.imageCompression.enabled, metadata.imageCompression.quality, metadata.imageCompression.maxDimension, metadata.imageMaxSizeMb, metadata.publishMode, metadata.publishAccumulate.minImages, metadata.publishAccumulate.maxImages, metadata.publishAccumulate.staleMinutes, metadata.publishLlmSummaryEnabled, metadata.enableAnonymousAvatarSelection]);
 
   useEffect(() => {
@@ -529,6 +532,8 @@ export function AdminPage({
   }
 
   async function saveSettings() {
+    const imageMaxSizeMb = normalizeImageMaxSizeDraft(imageMaxSizeDraft, form.imageMaxSizeMb);
+    setImageMaxSizeDraft(String(imageMaxSizeMb));
     setBusy(true);
     try {
       await api("/api/admin/tenant/metadata", {
@@ -545,7 +550,7 @@ export function AdminPage({
           imageCompressionEnabled: form.imageCompressionEnabled,
           imageCompressionQuality: form.imageCompressionQuality,
           imageCompressionMaxDimension: form.imageCompressionMaxDimension,
-          imageMaxSizeMb: form.imageMaxSizeMb,
+          imageMaxSizeMb,
           botStylishMessagesEnabled: form.botStylishMessagesEnabled,
           botPrivatePostStylishEnabled: form.botStylishMessagesEnabled,
           publishMode: form.publishMode,
@@ -1159,7 +1164,20 @@ export function AdminPage({
 
             <TabsContent value="metadata" className="mt-4 min-h-0 flex-1 overflow-y-auto pb-24 pr-1 md:pb-6">
               <div className="flex flex-col gap-4">
-                <MetadataPanel form={form} busy={busy} onFormChange={setForm} onSave={() => void saveSettings()} onUploaded={onSaved} />
+                <MetadataPanel
+                  form={form}
+                  imageMaxSizeDraft={imageMaxSizeDraft}
+                  busy={busy}
+                  onFormChange={setForm}
+                  onImageMaxSizeDraftChange={setImageMaxSizeDraft}
+                  onImageMaxSizeDraftCommit={() => {
+                    const normalized = normalizeImageMaxSizeDraft(imageMaxSizeDraft, form.imageMaxSizeMb);
+                    setImageMaxSizeDraft(String(normalized));
+                    setForm((current) => ({ ...current, imageMaxSizeMb: normalized }));
+                  }}
+                  onSave={() => void saveSettings()}
+                  onUploaded={onSaved}
+                />
                 {aiSettings && aiForm ? (
                   <div className="product-surface overflow-hidden">
                     <button
@@ -1713,14 +1731,20 @@ function BansPanel({
 
 function MetadataPanel({
   form,
+  imageMaxSizeDraft,
   busy,
   onFormChange,
+  onImageMaxSizeDraftChange,
+  onImageMaxSizeDraftCommit,
   onSave,
   onUploaded,
 }: {
   form: TenantSettingsForm;
+  imageMaxSizeDraft: string;
   busy: boolean;
   onFormChange: (form: TenantSettingsForm) => void;
+  onImageMaxSizeDraftChange: (value: string) => void;
+  onImageMaxSizeDraftCommit: () => void;
   onSave: () => void;
   onUploaded: () => Promise<void>;
 }) {
@@ -1830,12 +1854,10 @@ function MetadataPanel({
                 step={1}
                 min={MIN_IMAGE_MAX_SIZE_MB}
                 max={MAX_IMAGE_MAX_SIZE_MB}
-                value={form.imageMaxSizeMb}
+                value={imageMaxSizeDraft}
                 disabled={busy}
-                onChange={(event) => onFormChange({
-                  ...form,
-                  imageMaxSizeMb: normalizeImageMaxSizeMb(event.target.value),
-                })}
+                onChange={(event) => onImageMaxSizeDraftChange(event.target.value)}
+                onBlur={onImageMaxSizeDraftCommit}
               />
               <span className="text-xs font-normal text-slate-500">允许 {MIN_IMAGE_MAX_SIZE_MB}-{MAX_IMAGE_MAX_SIZE_MB}MB；自动压缩后仍须小于该上限，默认 10MB。</span>
             </label>

--- a/apps/web/src/hooks/useUploadImages.ts
+++ b/apps/web/src/hooks/useUploadImages.ts
@@ -197,6 +197,37 @@ export function usePendingAttachments({
     );
   }, []);
 
+  const validateBeforeUpload = useCallback(() => {
+    const rejected = pending.find((item) => {
+      if (item.status !== "ready" || item.originalVideo || item.remoteGifUrl) {
+        return false;
+      }
+      return Boolean(getSelectedImageRejection({
+        fileName: item.file.name,
+        sizeBytes: item.file.size,
+        maxSizeMb,
+        compressionEnabled,
+      }));
+    });
+    if (!rejected) {
+      return true;
+    }
+
+    const message = getSelectedImageRejection({
+      fileName: rejected.file.name,
+      sizeBytes: rejected.file.size,
+      maxSizeMb,
+      compressionEnabled,
+    })!;
+    setPending((current) => current.map((item) =>
+      item.id === rejected.id
+        ? { ...item, status: "failed" as const, errorMessage: message, progress: 0 }
+        : item,
+    ));
+    toast.error(message);
+    return false;
+  }, [compressionEnabled, maxSizeMb, pending]);
+
   const markUploading = useCallback(() => {
     setPending((current) =>
       current.map((p) => ({
@@ -247,6 +278,7 @@ export function usePendingAttachments({
     pending,
     add,
     remove,
+    validateBeforeUpload,
     markUploading,
     setProgress,
     markFailed,

--- a/apps/web/src/hooks/useUploadImages.ts
+++ b/apps/web/src/hooks/useUploadImages.ts
@@ -198,29 +198,29 @@ export function usePendingAttachments({
   }, []);
 
   const validateBeforeUpload = useCallback(() => {
-    const rejected = pending.find((item) => {
+    let rejected: { item: PendingAttachment; message: string } | null = null;
+    for (const item of pending) {
       if (item.status !== "ready" || item.originalVideo || item.remoteGifUrl) {
-        return false;
+        continue;
       }
-      return Boolean(getSelectedImageRejection({
+      const message = getSelectedImageRejection({
         fileName: item.file.name,
         sizeBytes: item.file.size,
         maxSizeMb,
         compressionEnabled,
-      }));
-    });
+      });
+      if (message) {
+        rejected = { item, message };
+        break;
+      }
+    }
     if (!rejected) {
       return true;
     }
 
-    const message = getSelectedImageRejection({
-      fileName: rejected.file.name,
-      sizeBytes: rejected.file.size,
-      maxSizeMb,
-      compressionEnabled,
-    })!;
+    const { item: rejectedItem, message } = rejected;
     setPending((current) => current.map((item) =>
-      item.id === rejected.id
+      item.id === rejectedItem.id
         ? { ...item, status: "failed" as const, errorMessage: message, progress: 0 }
         : item,
     ));

--- a/apps/web/src/lib/image-upload-policy.test.ts
+++ b/apps/web/src/lib/image-upload-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getSelectedImageRejection } from "./image-upload-policy";
+import { getSelectedImageRejection, normalizeImageMaxSizeDraft } from "./image-upload-policy";
 
 describe("getSelectedImageRejection", () => {
   test("uses the tenant limit immediately when automatic compression is disabled", () => {
@@ -27,5 +27,18 @@ describe("getSelectedImageRejection", () => {
       maxSizeMb: 10,
       compressionEnabled: true,
     })).toBe("huge.jpg 原图超过 50MB，无法自动压缩");
+  });
+});
+
+describe("normalizeImageMaxSizeDraft", () => {
+  test("keeps the previous setting while the input is temporarily blank", () => {
+    expect(normalizeImageMaxSizeDraft("", 10)).toBe(10);
+    expect(normalizeImageMaxSizeDraft("   ", 20)).toBe(20);
+    expect(normalizeImageMaxSizeDraft("not-a-number", 20)).toBe(20);
+  });
+
+  test("normalizes a completed draft to an integer in the shared range", () => {
+    expect(normalizeImageMaxSizeDraft("5.9", 10)).toBe(5);
+    expect(normalizeImageMaxSizeDraft("999", 10)).toBe(50);
   });
 });

--- a/apps/web/src/lib/image-upload-policy.ts
+++ b/apps/web/src/lib/image-upload-policy.ts
@@ -1,7 +1,14 @@
-import { IMAGE_UPLOAD_SOURCE_HARD_MAX_SIZE_MB } from "@campux/domain";
+import { IMAGE_UPLOAD_SOURCE_HARD_MAX_SIZE_MB, normalizeImageMaxSizeMb } from "@campux/domain";
 
 const bytesPerMegabyte = 1024 * 1024;
 export const imageUploadSourceHardMaxSizeMb = IMAGE_UPLOAD_SOURCE_HARD_MAX_SIZE_MB;
+
+export function normalizeImageMaxSizeDraft(draft: string, fallback: number): number {
+  const parsed = Number(draft);
+  return draft.trim() === "" || !Number.isFinite(parsed)
+    ? normalizeImageMaxSizeMb(fallback)
+    : normalizeImageMaxSizeMb(parsed);
+}
 
 export function getSelectedImageRejection({
   fileName,


### PR DESCRIPTION
## Summary
- stream remote GIF and OneBot image bodies through a capped reader, including early Content-Length cancellation
- keep video-to-GIF output on the stable 50MB storage safety cap instead of the tenant image setting
- revalidate selected web images against the latest tenant policy at submit time
- keep the admin image-size number input editable via a draft value and normalize on blur/save

## Verification
- `bun test`: 366 pass, 5 skip, 0 fail
- `bun run typecheck`: web/server/dash pass
- `git diff --check`

Follow-up to #136 based on late independent review findings.

## Summary by Sourcery

通过在服务端和 Web 端强制对远程和转换后的 GIF 图像施加全局存储上限、收紧 base64 处理方式，并改进管理员配置界面体验，从而加强租户图像上传限制。

Bug 修复：
- 通过使用带有大小上限且支持提前取消的流式读取器来处理 OneBot 和远程 GIF 下载，防止其突破全局图像存储上限。
- 在分配内存前预估并校验解码后的大小，从而拒绝超大体积的 base64 编码图像，避免其绕过硬性存储限制。
- 确保视频转 GIF 的转换受固定的全局存储上限约束，而不是租户级图像限制，并提供一致的错误响应。
- 在 Web 客户端提交时，按照当前租户策略重新校验已选择的图像，对不再满足大小规则的附件进行上传失败处理。

增强功能：
- 引入可复用的带上限响应体读取器以及专用错误类型，用于在图像相关流程中安全处理大型远程负载。
- 允许管理员通过草稿值自由编辑图像大小输入，并在失焦/保存时进行归一化，在保留有效限制的同时提升表单可用性。

测试：
- 扩展服务端图像上传策略测试，覆盖转换后 GIF 大小校验以及带上限响应读取行为，包括提前拒绝的情况。
- 扩展 Web 端上传策略测试，覆盖图像大小草稿值归一化，以及上传前对已选图像进行客户端校验的逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden tenant image upload limits across server and web by enforcing a global storage cap for remote and converted GIF images, tightening base64 handling, and improving admin configuration UX.

Bug Fixes:
- Prevent OneBot and remote GIF downloads from exceeding the global image storage cap by streaming responses through a size‑limited reader with early cancellation.
- Reject oversized base64-encoded images by estimating and validating decoded size before allocation so they cannot bypass hard storage limits.
- Ensure video-to-GIF conversions are constrained by a fixed global storage cap rather than tenant image limits, with consistent error responses.
- Revalidate selected images on the web client against current tenant policies at submit time and fail attachments that no longer meet size rules.

Enhancements:
- Introduce a reusable capped response-body reader and dedicated error type for safely handling large remote payloads across image workflows.
- Allow admins to freely edit the image size input via a draft value and normalize it on blur/save, preserving valid limits while improving form usability.

Tests:
- Extend server-side image upload policy tests to cover converted GIF size validation and capped response reading behavior, including early rejections.
- Extend web-side upload policy tests to cover image size draft normalization and client-side validation of selected images before upload.

</details>

Bug Fixes（错误修复）:
- 通过使用带上限的读取器对响应进行流式读取，并及早拒绝超大响应体，防止 OneBot 和远程 GIF 下载突破全局图片存储上限。
- 在分配内存前预估并校验解码后的大小，拒绝过大的 base64 图片，确保其无法突破硬性存储上限。
- 确保视频转 GIF 的转换受稳定的全局存储上限约束，而不是租户配置的图片限制，并提供一致的错误信息。
- 在提交上传之前，基于当前租户策略重新验证已选图片，对不再符合大小规则的附件进行失败处理。

Enhancements（增强功能）:
- 引入可复用的“带上限响应体读取器”以及专用错误类型，以安全处理大型远程负载。
- 允许管理员通过“草稿值”自由编辑图片尺寸输入，并在失焦/保存时进行规范化，既保证限制合法，又改善临时无效值下的用户体验。

Tests（测试）:
- 扩展服务器与 Web 端的图片上传策略测试，覆盖视频转 GIF 的大小约束、带上限响应体读取，以及管理员图片尺寸草稿值规范化行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在服务端和 Web 端强制对远程和转换后的 GIF 图像施加全局存储上限、收紧 base64 处理方式，并改进管理员配置界面体验，从而加强租户图像上传限制。

Bug 修复：
- 通过使用带有大小上限且支持提前取消的流式读取器来处理 OneBot 和远程 GIF 下载，防止其突破全局图像存储上限。
- 在分配内存前预估并校验解码后的大小，从而拒绝超大体积的 base64 编码图像，避免其绕过硬性存储限制。
- 确保视频转 GIF 的转换受固定的全局存储上限约束，而不是租户级图像限制，并提供一致的错误响应。
- 在 Web 客户端提交时，按照当前租户策略重新校验已选择的图像，对不再满足大小规则的附件进行上传失败处理。

增强功能：
- 引入可复用的带上限响应体读取器以及专用错误类型，用于在图像相关流程中安全处理大型远程负载。
- 允许管理员通过草稿值自由编辑图像大小输入，并在失焦/保存时进行归一化，在保留有效限制的同时提升表单可用性。

测试：
- 扩展服务端图像上传策略测试，覆盖转换后 GIF 大小校验以及带上限响应读取行为，包括提前拒绝的情况。
- 扩展 Web 端上传策略测试，覆盖图像大小草稿值归一化，以及上传前对已选图像进行客户端校验的逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden tenant image upload limits across server and web by enforcing a global storage cap for remote and converted GIF images, tightening base64 handling, and improving admin configuration UX.

Bug Fixes:
- Prevent OneBot and remote GIF downloads from exceeding the global image storage cap by streaming responses through a size‑limited reader with early cancellation.
- Reject oversized base64-encoded images by estimating and validating decoded size before allocation so they cannot bypass hard storage limits.
- Ensure video-to-GIF conversions are constrained by a fixed global storage cap rather than tenant image limits, with consistent error responses.
- Revalidate selected images on the web client against current tenant policies at submit time and fail attachments that no longer meet size rules.

Enhancements:
- Introduce a reusable capped response-body reader and dedicated error type for safely handling large remote payloads across image workflows.
- Allow admins to freely edit the image size input via a draft value and normalize it on blur/save, preserving valid limits while improving form usability.

Tests:
- Extend server-side image upload policy tests to cover converted GIF size validation and capped response reading behavior, including early rejections.
- Extend web-side upload policy tests to cover image size draft normalization and client-side validation of selected images before upload.

</details>

</details>

Bug Fixes（错误修复）:
- 通过使用带有字节上限的流式读取器，并基于 `content-length` 和字节数限制进行提前取消，防止下载超大尺寸的 OneBot 和远程 GIF 图片。
- 在分配内存之前，先预估并校验解码后的大小，避免接受超过存储上限的 base64 编码图片。
- 确保视频转 GIF 的转换受固定存储上限约束，而不是依赖租户配置的图片大小限制。
- 在提交时根据当前租户策略重新校验待上传的图片附件，避免上传现在已不再符合策略的图片。

Enhancements（增强功能）:
- 新增可复用的响应体读取器，支持字节数上限和专用错误类型，以安全处理大型远程负载。
- 通过可编辑的草稿值保持后台图片大小输入框可编辑，并在失焦/保存时进行规范化，从而在保证限制合法性的同时改善用户体验。

Tests（测试）:
- 扩展服务端和 Web 端的图片上传策略测试，覆盖转换 GIF 的限制、带上限的响应读取，以及图片大小草稿值规范化行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在服务端和 Web 端强制对远程和转换后的 GIF 图像施加全局存储上限、收紧 base64 处理方式，并改进管理员配置界面体验，从而加强租户图像上传限制。

Bug 修复：
- 通过使用带有大小上限且支持提前取消的流式读取器来处理 OneBot 和远程 GIF 下载，防止其突破全局图像存储上限。
- 在分配内存前预估并校验解码后的大小，从而拒绝超大体积的 base64 编码图像，避免其绕过硬性存储限制。
- 确保视频转 GIF 的转换受固定的全局存储上限约束，而不是租户级图像限制，并提供一致的错误响应。
- 在 Web 客户端提交时，按照当前租户策略重新校验已选择的图像，对不再满足大小规则的附件进行上传失败处理。

增强功能：
- 引入可复用的带上限响应体读取器以及专用错误类型，用于在图像相关流程中安全处理大型远程负载。
- 允许管理员通过草稿值自由编辑图像大小输入，并在失焦/保存时进行归一化，在保留有效限制的同时提升表单可用性。

测试：
- 扩展服务端图像上传策略测试，覆盖转换后 GIF 大小校验以及带上限响应读取行为，包括提前拒绝的情况。
- 扩展 Web 端上传策略测试，覆盖图像大小草稿值归一化，以及上传前对已选图像进行客户端校验的逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden tenant image upload limits across server and web by enforcing a global storage cap for remote and converted GIF images, tightening base64 handling, and improving admin configuration UX.

Bug Fixes:
- Prevent OneBot and remote GIF downloads from exceeding the global image storage cap by streaming responses through a size‑limited reader with early cancellation.
- Reject oversized base64-encoded images by estimating and validating decoded size before allocation so they cannot bypass hard storage limits.
- Ensure video-to-GIF conversions are constrained by a fixed global storage cap rather than tenant image limits, with consistent error responses.
- Revalidate selected images on the web client against current tenant policies at submit time and fail attachments that no longer meet size rules.

Enhancements:
- Introduce a reusable capped response-body reader and dedicated error type for safely handling large remote payloads across image workflows.
- Allow admins to freely edit the image size input via a draft value and normalize it on blur/save, preserving valid limits while improving form usability.

Tests:
- Extend server-side image upload policy tests to cover converted GIF size validation and capped response reading behavior, including early rejections.
- Extend web-side upload policy tests to cover image size draft normalization and client-side validation of selected images before upload.

</details>

Bug Fixes（错误修复）:
- 通过使用带上限的读取器对响应进行流式读取，并及早拒绝超大响应体，防止 OneBot 和远程 GIF 下载突破全局图片存储上限。
- 在分配内存前预估并校验解码后的大小，拒绝过大的 base64 图片，确保其无法突破硬性存储上限。
- 确保视频转 GIF 的转换受稳定的全局存储上限约束，而不是租户配置的图片限制，并提供一致的错误信息。
- 在提交上传之前，基于当前租户策略重新验证已选图片，对不再符合大小规则的附件进行失败处理。

Enhancements（增强功能）:
- 引入可复用的“带上限响应体读取器”以及专用错误类型，以安全处理大型远程负载。
- 允许管理员通过“草稿值”自由编辑图片尺寸输入，并在失焦/保存时进行规范化，既保证限制合法，又改善临时无效值下的用户体验。

Tests（测试）:
- 扩展服务器与 Web 端的图片上传策略测试，覆盖视频转 GIF 的大小约束、带上限响应体读取，以及管理员图片尺寸草稿值规范化行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在服务端和 Web 端强制对远程和转换后的 GIF 图像施加全局存储上限、收紧 base64 处理方式，并改进管理员配置界面体验，从而加强租户图像上传限制。

Bug 修复：
- 通过使用带有大小上限且支持提前取消的流式读取器来处理 OneBot 和远程 GIF 下载，防止其突破全局图像存储上限。
- 在分配内存前预估并校验解码后的大小，从而拒绝超大体积的 base64 编码图像，避免其绕过硬性存储限制。
- 确保视频转 GIF 的转换受固定的全局存储上限约束，而不是租户级图像限制，并提供一致的错误响应。
- 在 Web 客户端提交时，按照当前租户策略重新校验已选择的图像，对不再满足大小规则的附件进行上传失败处理。

增强功能：
- 引入可复用的带上限响应体读取器以及专用错误类型，用于在图像相关流程中安全处理大型远程负载。
- 允许管理员通过草稿值自由编辑图像大小输入，并在失焦/保存时进行归一化，在保留有效限制的同时提升表单可用性。

测试：
- 扩展服务端图像上传策略测试，覆盖转换后 GIF 大小校验以及带上限响应读取行为，包括提前拒绝的情况。
- 扩展 Web 端上传策略测试，覆盖图像大小草稿值归一化，以及上传前对已选图像进行客户端校验的逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden tenant image upload limits across server and web by enforcing a global storage cap for remote and converted GIF images, tightening base64 handling, and improving admin configuration UX.

Bug Fixes:
- Prevent OneBot and remote GIF downloads from exceeding the global image storage cap by streaming responses through a size‑limited reader with early cancellation.
- Reject oversized base64-encoded images by estimating and validating decoded size before allocation so they cannot bypass hard storage limits.
- Ensure video-to-GIF conversions are constrained by a fixed global storage cap rather than tenant image limits, with consistent error responses.
- Revalidate selected images on the web client against current tenant policies at submit time and fail attachments that no longer meet size rules.

Enhancements:
- Introduce a reusable capped response-body reader and dedicated error type for safely handling large remote payloads across image workflows.
- Allow admins to freely edit the image size input via a draft value and normalize it on blur/save, preserving valid limits while improving form usability.

Tests:
- Extend server-side image upload policy tests to cover converted GIF size validation and capped response reading behavior, including early rejections.
- Extend web-side upload policy tests to cover image size draft normalization and client-side validation of selected images before upload.

</details>

</details>

</details>