### PR TITLE
fix: harden image upload and video conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN bun run build
 FROM oven/bun:${BUN_VERSION}-alpine AS runtime
 WORKDIR /app
 
-RUN apk add --no-cache ca-certificates chromium font-noto-cjk font-noto-emoji openssl tzdata
+RUN apk add --no-cache ca-certificates chromium ffmpeg font-noto-cjk font-noto-emoji openssl tzdata
 
 # Release identifier baked in by CI (branch-shortsha); surfaces in /api/health
 # style diagnostics and the anonymous telemetry version distribution.

--- a/apps/server/src/lib/converted-gif-claim-store.test.ts
+++ b/apps/server/src/lib/converted-gif-claim-store.test.ts
@@ -7,25 +7,34 @@ import {
 
 function createMemoryStore() {
   const records = new Map<string, ConvertedGifClaimSetting>();
+  const posts = new Set<string>();
+  const transaction = async <T>(callback: (tx: {
+    findExistingKeys(keys: string[]): Promise<string[]>;
+    deleteByKeys(keys: string[]): Promise<number>;
+  }) => Promise<T>): Promise<T> => {
+    const recordSnapshot = new Map(records);
+    const postSnapshot = new Set(posts);
+    try {
+      return await callback({
+        findExistingKeys: async (keys) => keys.filter((key) => records.has(key)),
+        deleteByKeys: async (keys) => {
+          let count = 0;
+          for (const key of keys) {
+            if (records.delete(key)) count += 1;
+          }
+          return count;
+        },
+      });
+    } catch (error) {
+      records.clear();
+      for (const [key, setting] of recordSnapshot) records.set(key, setting);
+      posts.clear();
+      for (const postId of postSnapshot) posts.add(postId);
+      throw error;
+    }
+  };
   const store = new ConvertedGifClaimStore({
-    transaction: async (callback) => {
-      const snapshot = new Map(records);
-      try {
-        return await callback({
-          deleteByKeys: async (keys) => {
-            let count = 0;
-            for (const key of keys) {
-              if (records.delete(key)) count += 1;
-            }
-            return count;
-          },
-        });
-      } catch (error) {
-        records.clear();
-        for (const [key, setting] of snapshot) records.set(key, setting);
-        throw error;
-      }
-    },
+    transaction,
     pruneAndCreate: async (cutoff, setting) => {
       for (const [key, record] of records) {
         if (new Date(record.value.expiresAt).getTime() <= cutoff.getTime()) {
@@ -34,25 +43,32 @@ function createMemoryStore() {
       }
       records.set(setting.key, setting);
     },
-    restore: async (settings) => {
-      for (const setting of settings) records.set(setting.key, setting);
-    },
   });
-  return { records, store };
+  return { posts, records, store, transaction };
 }
 
 const now = new Date("2026-07-17T12:00:00.000Z").getTime();
 const proof = `${now + 15 * 60 * 1000}.deterministic_nonce_123.signature`;
 
 describe("ConvertedGifClaimStore", () => {
-  test("consumes a claim once and permits an explicit retry rollback", async () => {
+  test("consumes a claim exactly once", async () => {
     const { store } = createMemoryStore();
     await store.issue(proof, now);
 
-    const consumed = await store.consume([proof]);
+    expect(await store.consume([proof])).toHaveLength(1);
     await expect(store.consume([proof])).rejects.toBeInstanceOf(ConvertedGifClaimUnavailableError);
+  });
 
-    await store.restore(consumed);
+  test("rejects a replay during preflight without consuming other available claims", async () => {
+    const { store } = createMemoryStore();
+    const replayed = `${now + 15 * 60 * 1000}.replayed_nonce_value_123.signature`;
+    await store.issue(proof, now);
+    await store.issue(replayed, now);
+    await store.consume([replayed]);
+
+    await expect(store.assertAvailable([proof, replayed])).rejects.toMatchObject({
+      unavailableIndexes: [1],
+    });
     expect(await store.consume([proof])).toHaveLength(1);
   });
 
@@ -69,7 +85,50 @@ describe("ConvertedGifClaimStore", () => {
     await store.issue(proof, now);
     const unavailable = `${now + 15 * 60 * 1000}.another_nonce_value_123.signature`;
 
-    await expect(store.consume([proof, unavailable])).rejects.toBeInstanceOf(ConvertedGifClaimUnavailableError);
+    await expect(store.consume([proof, unavailable])).rejects.toMatchObject({
+      unavailableIndexes: [1],
+    });
     expect(await store.consume([proof])).toHaveLength(1);
+  });
+
+  test("rolls claim consumption back when the later post write fails", async () => {
+    const { posts, store, transaction } = createMemoryStore();
+    await store.issue(proof, now);
+
+    await expect(transaction(async (tx) => {
+      await store.consumeUsing([proof], tx);
+      posts.add("candidate-post");
+      throw new Error("post write failed");
+    })).rejects.toThrow("post write failed");
+
+    expect(posts.size).toBe(0);
+    expect(await store.consume([proof])).toHaveLength(1);
+  });
+
+  test("consumes through a caller-provided transaction without opening a nested transaction", async () => {
+    const records = new Map<string, ConvertedGifClaimSetting>();
+    const store = new ConvertedGifClaimStore({
+      transaction: async () => {
+        throw new Error("nested transaction must not be opened");
+      },
+      pruneAndCreate: async (_cutoff, setting) => {
+        records.set(setting.key, setting);
+      },
+    });
+    await store.issue(proof, now);
+
+    const consumed = await store.consumeUsing([proof], {
+      findExistingKeys: async (keys) => keys.filter((key) => records.has(key)),
+      deleteByKeys: async (keys) => {
+        let count = 0;
+        for (const key of keys) {
+          if (records.delete(key)) count += 1;
+        }
+        return count;
+      },
+    });
+
+    expect(consumed).toHaveLength(1);
+    expect(records.size).toBe(0);
   });
 });

--- a/apps/server/src/lib/converted-gif-claim-store.test.ts
+++ b/apps/server/src/lib/converted-gif-claim-store.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ConvertedGifClaimStore,
+  ConvertedGifClaimUnavailableError,
+  type ConvertedGifClaimSetting,
+} from "./converted-gif-claim-store";
+
+function createMemoryStore() {
+  const records = new Map<string, ConvertedGifClaimSetting>();
+  const store = new ConvertedGifClaimStore({
+    transaction: async (callback) => {
+      const snapshot = new Map(records);
+      try {
+        return await callback({
+          deleteByKeys: async (keys) => {
+            let count = 0;
+            for (const key of keys) {
+              if (records.delete(key)) count += 1;
+            }
+            return count;
+          },
+        });
+      } catch (error) {
+        records.clear();
+        for (const [key, setting] of snapshot) records.set(key, setting);
+        throw error;
+      }
+    },
+    pruneAndCreate: async (cutoff, setting) => {
+      for (const [key, record] of records) {
+        if (new Date(record.value.expiresAt).getTime() <= cutoff.getTime()) {
+          records.delete(key);
+        }
+      }
+      records.set(setting.key, setting);
+    },
+    restore: async (settings) => {
+      for (const setting of settings) records.set(setting.key, setting);
+    },
+  });
+  return { records, store };
+}
+
+const now = new Date("2026-07-17T12:00:00.000Z").getTime();
+const proof = `${now + 15 * 60 * 1000}.deterministic_nonce_123.signature`;
+
+describe("ConvertedGifClaimStore", () => {
+  test("consumes a claim once and permits an explicit retry rollback", async () => {
+    const { store } = createMemoryStore();
+    await store.issue(proof, now);
+
+    const consumed = await store.consume([proof]);
+    await expect(store.consume([proof])).rejects.toBeInstanceOf(ConvertedGifClaimUnavailableError);
+
+    await store.restore(consumed);
+    expect(await store.consume([proof])).toHaveLength(1);
+  });
+
+  test("rejects duplicate proofs without consuming the valid record", async () => {
+    const { store } = createMemoryStore();
+    await store.issue(proof, now);
+
+    await expect(store.consume([proof, proof])).rejects.toBeInstanceOf(ConvertedGifClaimUnavailableError);
+    expect(await store.consume([proof])).toHaveLength(1);
+  });
+
+  test("rolls back partial deletion when any claim is unavailable", async () => {
+    const { store } = createMemoryStore();
+    await store.issue(proof, now);
+    const unavailable = `${now + 15 * 60 * 1000}.another_nonce_value_123.signature`;
+
+    await expect(store.consume([proof, unavailable])).rejects.toBeInstanceOf(ConvertedGifClaimUnavailableError);
+    expect(await store.consume([proof])).toHaveLength(1);
+  });
+});

--- a/apps/server/src/lib/converted-gif-claim-store.ts
+++ b/apps/server/src/lib/converted-gif-claim-store.ts
@@ -12,17 +12,17 @@ export type ConvertedGifClaimSetting = {
 };
 
 type ClaimStoreTransaction = {
-  deleteByKeys: (keys: string[]) => Promise<number>;
+  findExistingKeys(keys: string[]): Promise<string[]>;
+  deleteByKeys(keys: string[]): Promise<number>;
 };
 
 type ClaimStorePersistence = {
-  transaction: <T>(callback: (tx: ClaimStoreTransaction) => Promise<T>) => Promise<T>;
-  pruneAndCreate: (cutoff: Date, setting: ConvertedGifClaimSetting) => Promise<void>;
-  restore: (settings: ConvertedGifClaimSetting[]) => Promise<void>;
+  transaction<T>(callback: (tx: ClaimStoreTransaction) => Promise<T>): Promise<T>;
+  pruneAndCreate(cutoff: Date, setting: ConvertedGifClaimSetting): Promise<void>;
 };
 
 export class ConvertedGifClaimUnavailableError extends Error {
-  constructor() {
+  constructor(readonly unavailableIndexes: number[] = []) {
     super("converted GIF claim is unavailable");
     this.name = "ConvertedGifClaimUnavailableError";
   }
@@ -52,31 +52,63 @@ export class ConvertedGifClaimStore {
     );
   }
 
+  async assertAvailable(proofs: string[]): Promise<void> {
+    if (proofs.length === 0) return;
+    await this.persistence.transaction(async (tx) => {
+      await this.availableSettingsUsing(proofs, tx);
+    });
+  }
+
   async consume(proofs: string[]): Promise<ConvertedGifClaimSetting[]> {
     if (proofs.length === 0) return [];
-    const settings = proofs.map((proof) => {
+    return this.persistence.transaction((tx) => this.consumeUsing(proofs, tx));
+  }
+
+  async consumeUsing(
+    proofs: string[],
+    transaction: ClaimStoreTransaction,
+  ): Promise<ConvertedGifClaimSetting[]> {
+    if (proofs.length === 0) return [];
+    const settings = await this.availableSettingsUsing(proofs, transaction);
+    const keys = settings.map((setting) => setting.key);
+    const deletedCount = await transaction.deleteByKeys(keys);
+    if (deletedCount !== keys.length) {
+      throw new ConvertedGifClaimUnavailableError(keys.map((_, index) => index));
+    }
+    return settings;
+  }
+
+  private async availableSettingsUsing(
+    proofs: string[],
+    transaction: ClaimStoreTransaction,
+  ): Promise<ConvertedGifClaimSetting[]> {
+    const settings = proofs.map((proof, index) => {
       const expiresAt = Number(proof.split(".", 1)[0]);
       if (!Number.isSafeInteger(expiresAt)) {
-        throw new ConvertedGifClaimUnavailableError();
+        throw new ConvertedGifClaimUnavailableError([index]);
       }
       return buildConvertedGifClaimSetting(proof, expiresAt);
     });
     const keys = settings.map((setting) => setting.key);
-    if (new Set(keys).size !== keys.length) {
-      throw new ConvertedGifClaimUnavailableError();
+    const keyCounts = new Map<string, number>();
+    for (const key of keys) {
+      keyCounts.set(key, (keyCounts.get(key) ?? 0) + 1);
+    }
+    const duplicateIndexes = keys.flatMap((key, index) => (
+      (keyCounts.get(key) ?? 0) > 1 ? [index] : []
+    ));
+    if (duplicateIndexes.length > 0) {
+      throw new ConvertedGifClaimUnavailableError(duplicateIndexes);
     }
 
-    await this.persistence.transaction(async (tx) => {
-      const deletedCount = await tx.deleteByKeys(keys);
-      if (deletedCount !== keys.length) {
-        throw new ConvertedGifClaimUnavailableError();
-      }
-    });
-    return settings;
-  }
+    const existingKeys = new Set(await transaction.findExistingKeys(keys));
+    const unavailableIndexes = keys.flatMap((key, index) => (
+      existingKeys.has(key) ? [] : [index]
+    ));
+    if (unavailableIndexes.length > 0) {
+      throw new ConvertedGifClaimUnavailableError(unavailableIndexes);
+    }
 
-  async restore(settings: ConvertedGifClaimSetting[]): Promise<void> {
-    if (settings.length === 0) return;
-    await this.persistence.restore(settings);
+    return settings;
   }
 }

--- a/apps/server/src/lib/converted-gif-claim-store.ts
+++ b/apps/server/src/lib/converted-gif-claim-store.ts
@@ -1,0 +1,82 @@
+import { createHash } from "node:crypto";
+import { convertedGifClaimTtlMs } from "./image-upload-policy";
+
+export const convertedGifClaimSettingPrefix = "converted-gif-claim:v1:";
+
+export type ConvertedGifClaimSetting = {
+  key: string;
+  value: {
+    kind: "converted-gif-claim-v1";
+    expiresAt: string;
+  };
+};
+
+type ClaimStoreTransaction = {
+  deleteByKeys: (keys: string[]) => Promise<number>;
+};
+
+type ClaimStorePersistence = {
+  transaction: <T>(callback: (tx: ClaimStoreTransaction) => Promise<T>) => Promise<T>;
+  pruneAndCreate: (cutoff: Date, setting: ConvertedGifClaimSetting) => Promise<void>;
+  restore: (settings: ConvertedGifClaimSetting[]) => Promise<void>;
+};
+
+export class ConvertedGifClaimUnavailableError extends Error {
+  constructor() {
+    super("converted GIF claim is unavailable");
+    this.name = "ConvertedGifClaimUnavailableError";
+  }
+}
+
+export function buildConvertedGifClaimSetting(
+  proof: string,
+  expiresAt: number,
+): ConvertedGifClaimSetting {
+  return {
+    key: `${convertedGifClaimSettingPrefix}${createHash("sha256").update(proof).digest("hex")}`,
+    value: {
+      kind: "converted-gif-claim-v1",
+      expiresAt: new Date(expiresAt).toISOString(),
+    },
+  };
+}
+
+export class ConvertedGifClaimStore {
+  constructor(private readonly persistence: ClaimStorePersistence) {}
+
+  async issue(proof: string, now = Date.now()): Promise<void> {
+    const setting = buildConvertedGifClaimSetting(proof, now + convertedGifClaimTtlMs);
+    await this.persistence.pruneAndCreate(
+      new Date(now - convertedGifClaimTtlMs),
+      setting,
+    );
+  }
+
+  async consume(proofs: string[]): Promise<ConvertedGifClaimSetting[]> {
+    if (proofs.length === 0) return [];
+    const settings = proofs.map((proof) => {
+      const expiresAt = Number(proof.split(".", 1)[0]);
+      if (!Number.isSafeInteger(expiresAt)) {
+        throw new ConvertedGifClaimUnavailableError();
+      }
+      return buildConvertedGifClaimSetting(proof, expiresAt);
+    });
+    const keys = settings.map((setting) => setting.key);
+    if (new Set(keys).size !== keys.length) {
+      throw new ConvertedGifClaimUnavailableError();
+    }
+
+    await this.persistence.transaction(async (tx) => {
+      const deletedCount = await tx.deleteByKeys(keys);
+      if (deletedCount !== keys.length) {
+        throw new ConvertedGifClaimUnavailableError();
+      }
+    });
+    return settings;
+  }
+
+  async restore(settings: ConvertedGifClaimSetting[]): Promise<void> {
+    if (settings.length === 0) return;
+    await this.persistence.restore(settings);
+  }
+}

--- a/apps/server/src/lib/image-upload-policy.test.ts
+++ b/apps/server/src/lib/image-upload-policy.test.ts
@@ -127,11 +127,10 @@ describe("tenant image upload policy", () => {
     )).toBeNull();
   });
 
-  test("keeps permanent converted-GIF errors attachment-specific after claim rollback", () => {
-    expect(shouldExposeRemoteGifIndexes(false, undefined)).toBe(true);
-    expect(shouldExposeRemoteGifIndexes(true, undefined)).toBe(false);
-    expect(shouldExposeRemoteGifIndexes(true, false)).toBe(false);
-    expect(shouldExposeRemoteGifIndexes(true, true)).toBe(true);
+  test("exposes converted-GIF indexes only for permanent failures", () => {
+    expect(shouldExposeRemoteGifIndexes(undefined)).toBe(false);
+    expect(shouldExposeRemoteGifIndexes(false)).toBe(false);
+    expect(shouldExposeRemoteGifIndexes(true)).toBe(true);
   });
 
   test("reads remote bodies without crossing the configured memory cap", async () => {

--- a/apps/server/src/lib/image-upload-policy.test.ts
+++ b/apps/server/src/lib/image-upload-policy.test.ts
@@ -1,16 +1,23 @@
 import { describe, expect, test } from "bun:test";
 import {
+  buildVideoGifFfmpegArgs,
+  createConvertedGifClaim,
   defaultImageMaxSizeMb,
+  hasGifSignature,
   imageUploadSourceHardMaxSizeMb,
   maxImageMaxSizeMb,
   minImageMaxSizeMb,
   buildImageSourceSizeErrorMessage,
   imageStorageHardMaxBytes,
+  isTrustedConvertedGifUrl,
   normalizeImageMaxSizeMb,
   readResponseBufferWithLimit,
+  restoreAttachmentOrder,
   resolveImageUploadLimits,
   ResponseBodyTooLargeError,
+  shouldExposeRemoteGifIndexes,
   validateConvertedVideoGifSize,
+  validateConvertedGifClaim,
   validateProcessedImageSize,
 } from "./image-upload-policy";
 
@@ -58,6 +65,73 @@ describe("tenant image upload policy", () => {
       status: 413,
       message: "视频转换后的 GIF 不能超过 50MB",
     });
+  });
+
+  test("only grants converted-video semantics to the trusted HTTPS converter origin", () => {
+    expect(isTrustedConvertedGifUrl("https://cloudflarecnimg.scdn.io/path/video.gif")).toBe(true);
+    expect(isTrustedConvertedGifUrl("http://cloudflarecnimg.scdn.io/path/video.gif")).toBe(false);
+    expect(isTrustedConvertedGifUrl("https://cloudflarecnimg.scdn.io.evil.example/video.gif")).toBe(false);
+    expect(isTrustedConvertedGifUrl("https://user:pass@cloudflarecnimg.scdn.io/video.gif")).toBe(false);
+    expect(isTrustedConvertedGifUrl("https://example.com/video.gif")).toBe(false);
+  });
+
+  test("binds converted GIF claims to server secret, URL, tenant, user, session, and expiry", () => {
+    const now = new Date("2026-07-17T12:00:00.000Z").getTime();
+    const input = {
+      url: "https://cloudflarecnimg.scdn.io/i/video.gif",
+      tenantId: "tenant-a",
+      userId: "user-a",
+      sessionTokenHash: "session-hash-a",
+      signingSecret: "server-only-signing-secret",
+    };
+    const proof = createConvertedGifClaim({ ...input, now, nonce: "deterministic_nonce_123" });
+
+    expect(validateConvertedGifClaim({ ...input, proof, now: now + 1 })).toBe(true);
+    expect(createConvertedGifClaim({ ...input, now })).not.toBe(createConvertedGifClaim({ ...input, now }));
+    expect(validateConvertedGifClaim({
+      ...input,
+      proof: proof.replace("deterministic_nonce_123", "tampered_nonce_value_12"),
+      now: now + 1,
+    })).toBe(false);
+    expect(validateConvertedGifClaim({ ...input, signingSecret: "attacker-derived-session-hash", proof, now: now + 1 })).toBe(false);
+    expect(validateConvertedGifClaim({ ...input, url: `${input.url}?other=1`, proof, now: now + 1 })).toBe(false);
+    expect(validateConvertedGifClaim({ ...input, tenantId: "tenant-b", proof, now: now + 1 })).toBe(false);
+    expect(validateConvertedGifClaim({ ...input, userId: "user-b", proof, now: now + 1 })).toBe(false);
+    expect(validateConvertedGifClaim({ ...input, sessionTokenHash: "session-hash-b", proof, now: now + 1 })).toBe(false);
+    expect(validateConvertedGifClaim({ ...input, proof, now: now + 15 * 60 * 1000 + 1 })).toBe(false);
+  });
+
+  test("requires downloaded converter output to have a GIF signature", () => {
+    expect(hasGifSignature(Buffer.from("GIF87a payload"))).toBe(true);
+    expect(hasGifSignature(Buffer.from("GIF89a payload"))).toBe(true);
+    expect(hasGifSignature(Buffer.from("not-a-gif"))).toBe(false);
+  });
+
+  test("caps server-side GIF conversion before ffmpeg writes the output", () => {
+    const args = buildVideoGifFfmpegArgs("input.mp4", "output.gif");
+    expect(args[args.indexOf("-fs") + 1]).toBe(String(imageStorageHardMaxBytes));
+    expect(args.join(" ")).toContain("min(30");
+    expect(args.join(" ")).toContain("1920");
+  });
+
+  test("restores interleaved local and remote attachment order", () => {
+    expect(restoreAttachmentOrder(
+      ["image-second", "image-fourth"],
+      ["video-first", "video-third"],
+      ["remote", "local", "remote", "local"],
+    )).toEqual(["video-first", "image-second", "video-third", "image-fourth"]);
+    expect(restoreAttachmentOrder(
+      ["only-local"],
+      ["only-remote"],
+      ["local"],
+    )).toBeNull();
+  });
+
+  test("keeps permanent converted-GIF errors attachment-specific after claim rollback", () => {
+    expect(shouldExposeRemoteGifIndexes(false, undefined)).toBe(true);
+    expect(shouldExposeRemoteGifIndexes(true, undefined)).toBe(false);
+    expect(shouldExposeRemoteGifIndexes(true, false)).toBe(false);
+    expect(shouldExposeRemoteGifIndexes(true, true)).toBe(true);
   });
 
   test("reads remote bodies without crossing the configured memory cap", async () => {

--- a/apps/server/src/lib/image-upload-policy.ts
+++ b/apps/server/src/lib/image-upload-policy.ts
@@ -145,10 +145,9 @@ export function validateConvertedGifClaim({
 }
 
 export function shouldExposeRemoteGifIndexes(
-  convertedGifClaimsRestored: boolean,
   permanentRemoteGifFailure: boolean | undefined,
 ): boolean {
-  return !convertedGifClaimsRestored || permanentRemoteGifFailure === true;
+  return permanentRemoteGifFailure === true;
 }
 
 export function isTrustedConvertedGifUrl(rawUrl: string): boolean {

--- a/apps/server/src/lib/image-upload-policy.ts
+++ b/apps/server/src/lib/image-upload-policy.ts
@@ -1,3 +1,4 @@
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import {
   DEFAULT_IMAGE_MAX_SIZE_MB,
   IMAGE_UPLOAD_SOURCE_HARD_MAX_SIZE_MB,
@@ -13,7 +14,175 @@ export const minImageMaxSizeMb = MIN_IMAGE_MAX_SIZE_MB;
 export const maxImageMaxSizeMb = MAX_IMAGE_MAX_SIZE_MB;
 export const imageUploadSourceHardMaxSizeMb = IMAGE_UPLOAD_SOURCE_HARD_MAX_SIZE_MB;
 export const imageStorageHardMaxBytes = imageUploadSourceHardMaxSizeMb * bytesPerMegabyte;
+export const trustedConvertedGifHostname = "cloudflarecnimg.scdn.io";
+export const convertedGifClaimTtlMs = 15 * 60 * 1000;
 export { normalizeImageMaxSizeMb };
+
+export type AttachmentOrderKind = "local" | "remote";
+
+export function isAttachmentOrderCompatible(
+  order: AttachmentOrderKind[],
+  localCount: number,
+  remoteCount: number,
+): boolean {
+  const localOrderCount = order.filter((kind) => kind === "local").length;
+  return order.length === localCount + remoteCount
+    && localOrderCount === localCount
+    && order.length - localOrderCount === remoteCount;
+}
+
+export function restoreAttachmentOrder<T>(
+  localAttachments: T[],
+  remoteAttachments: T[],
+  order: AttachmentOrderKind[],
+): T[] | null {
+  if (!isAttachmentOrderCompatible(order, localAttachments.length, remoteAttachments.length)) {
+    return null;
+  }
+  let localIndex = 0;
+  let remoteIndex = 0;
+  return order.map((kind) => (
+    kind === "local"
+      ? localAttachments[localIndex++]!
+      : remoteAttachments[remoteIndex++]!
+  ));
+}
+
+function convertedGifClaimSignature({
+  url,
+  tenantId,
+  userId,
+  expiresAt,
+  nonce,
+  sessionTokenHash,
+  signingSecret,
+}: {
+  url: string;
+  tenantId: string;
+  userId: string;
+  expiresAt: number;
+  nonce: string;
+  sessionTokenHash: string;
+  signingSecret: string;
+}): Buffer {
+  const payload = JSON.stringify([url, tenantId, userId, sessionTokenHash, expiresAt, nonce]);
+  return createHmac("sha256", signingSecret)
+    .update("campux:converted-gif-claim:v1\n")
+    .update(payload)
+    .digest();
+}
+
+export function createConvertedGifClaim({
+  url,
+  tenantId,
+  userId,
+  sessionTokenHash,
+  signingSecret,
+  now = Date.now(),
+  nonce,
+}: {
+  url: string;
+  tenantId: string;
+  userId: string;
+  sessionTokenHash: string;
+  signingSecret: string;
+  now?: number;
+  nonce?: string;
+}): string {
+  const expiresAt = now + convertedGifClaimTtlMs;
+  const claimNonce = nonce ?? randomBytes(16).toString("base64url");
+  const signature = convertedGifClaimSignature({
+    url,
+    tenantId,
+    userId,
+    expiresAt,
+    nonce: claimNonce,
+    sessionTokenHash,
+    signingSecret,
+  });
+  return `${expiresAt}.${claimNonce}.${signature.toString("base64url")}`;
+}
+
+export function validateConvertedGifClaim({
+  url,
+  proof,
+  tenantId,
+  userId,
+  sessionTokenHash,
+  signingSecret,
+  now = Date.now(),
+}: {
+  url: string;
+  proof: string;
+  tenantId: string;
+  userId: string;
+  sessionTokenHash: string;
+  signingSecret: string;
+  now?: number;
+}): boolean {
+  const match = /^(\d+)\.([A-Za-z0-9_-]{16,64})\.([A-Za-z0-9_-]+)$/.exec(proof);
+  if (!match) {
+    return false;
+  }
+  const expiresAt = Number(match[1]);
+  const nonce = match[2]!;
+  if (!Number.isSafeInteger(expiresAt)
+    || expiresAt < now
+    || expiresAt - now > convertedGifClaimTtlMs) {
+    return false;
+  }
+  const supplied = Buffer.from(match[3]!, "base64url");
+  const expected = convertedGifClaimSignature({
+    url,
+    tenantId,
+    userId,
+    expiresAt,
+    nonce,
+    sessionTokenHash,
+    signingSecret,
+  });
+  return supplied.byteLength === expected.byteLength && timingSafeEqual(supplied, expected);
+}
+
+export function shouldExposeRemoteGifIndexes(
+  convertedGifClaimsRestored: boolean,
+  permanentRemoteGifFailure: boolean | undefined,
+): boolean {
+  return !convertedGifClaimsRestored || permanentRemoteGifFailure === true;
+}
+
+export function isTrustedConvertedGifUrl(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl);
+    return url.protocol === "https:"
+      && url.hostname === trustedConvertedGifHostname
+      && url.port === ""
+      && url.username === ""
+      && url.password === "";
+  } catch {
+    return false;
+  }
+}
+
+export function hasGifSignature(buffer: Uint8Array): boolean {
+  if (buffer.byteLength < 6) {
+    return false;
+  }
+  const signature = Buffer.from(buffer.buffer, buffer.byteOffset, 6).toString("ascii");
+  return signature === "GIF87a" || signature === "GIF89a";
+}
+
+export function buildVideoGifFfmpegArgs(inputPath: string, outputPath: string): string[] {
+  const filter = "fps=fps='min(30,source_fps)',scale=w='min(1920,iw)':h='min(1920,ih)':force_original_aspect_ratio=decrease,split[s0][s1];[s0]palettegen=stats_mode=full:max_colors=256[p];[s1][p]paletteuse=dither=floyd_steinberg";
+  return [
+    "-y", "-i", inputPath,
+    "-vf", filter,
+    "-threads", "1",
+    "-loop", "0",
+    "-fs", String(imageStorageHardMaxBytes),
+    outputPath,
+  ];
+}
 
 export function buildImageSourceSizeErrorMessage({
   compressionEnabled,
@@ -70,6 +239,9 @@ export async function readResponseBufferWithLimit(response: Response, maxBytes: 
   }
 
   const contentLength = response.headers.get("content-length")?.trim();
+  const declaredLength = contentLength && /^\d+$/.test(contentLength)
+    ? Number(contentLength)
+    : null;
   if (contentLength && /^\d+$/.test(contentLength) && BigInt(contentLength) > BigInt(maxBytes)) {
     await response.body?.cancel().catch(() => undefined);
     throw new ResponseBodyTooLargeError(maxBytes);
@@ -79,27 +251,40 @@ export async function readResponseBufferWithLimit(response: Response, maxBytes: 
     return Buffer.alloc(0);
   }
 
-  const reader = response.body.getReader();
-  const chunks: Buffer[] = [];
+  const initialCapacity = declaredLength !== null
+    ? declaredLength
+    : Math.min(maxBytes, 64 * 1024);
+  let output = Buffer.allocUnsafe(initialCapacity);
   let totalBytes = 0;
+  const reader = response.body.getReader();
   try {
     while (true) {
       const { done, value } = await reader.read();
       if (done) {
         break;
       }
-      totalBytes += value.byteLength;
-      if (totalBytes > maxBytes) {
+      const nextTotal = totalBytes + value.byteLength;
+      if (nextTotal > maxBytes) {
         await reader.cancel().catch(() => undefined);
         throw new ResponseBodyTooLargeError(maxBytes);
       }
-      chunks.push(Buffer.from(value));
+      if (nextTotal > output.byteLength) {
+        const nextCapacity = Math.min(
+          maxBytes,
+          Math.max(nextTotal, Math.max(64 * 1024, output.byteLength * 2)),
+        );
+        const grown = Buffer.allocUnsafe(nextCapacity);
+        output.copy(grown, 0, 0, totalBytes);
+        output = grown;
+      }
+      Buffer.from(value.buffer, value.byteOffset, value.byteLength).copy(output, totalBytes);
+      totalBytes = nextTotal;
     }
   } finally {
     reader.releaseLock();
   }
 
-  return Buffer.concat(chunks, totalBytes);
+  return output.subarray(0, totalBytes);
 }
 
 export function validateProcessedImageSize(sizeBytes: number, maxSizeMb: unknown):

--- a/apps/server/src/lib/post-create-transaction-outcome.test.ts
+++ b/apps/server/src/lib/post-create-transaction-outcome.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import {
+  reconcilePostCreateTransactionOutcome,
+  shouldCompensatePostAttachments,
+} from "./post-create-transaction-outcome";
+
+describe("reconcilePostCreateTransactionOutcome", () => {
+  test("treats a persisted candidate post as committed after an acknowledgement error", async () => {
+    const post = { id: "post-1" };
+    const outcome = await reconcilePostCreateTransactionOutcome(async () => post);
+
+    expect(outcome).toEqual({ kind: "committed", post });
+  });
+
+  test("allows compensation only after a successful read proves the candidate is absent", async () => {
+    const outcome = await reconcilePostCreateTransactionOutcome(async () => null);
+
+    expect(outcome).toEqual({ kind: "rolled-back" });
+  });
+
+  test("forbids compensation when the commit outcome cannot be read", async () => {
+    const outcome = await reconcilePostCreateTransactionOutcome(async () => {
+      throw new Error("database unavailable");
+    });
+
+    expect(outcome.kind).toBe("unknown");
+  });
+});
+
+describe("shouldCompensatePostAttachments", () => {
+  test("allows cleanup only before persistence or after a positively known rollback", () => {
+    expect(shouldCompensatePostAttachments("not-started")).toBe(true);
+    expect(shouldCompensatePostAttachments("rolled-back")).toBe(true);
+    expect(shouldCompensatePostAttachments("committed")).toBe(false);
+    expect(shouldCompensatePostAttachments("unknown")).toBe(false);
+  });
+});

--- a/apps/server/src/lib/post-create-transaction-outcome.ts
+++ b/apps/server/src/lib/post-create-transaction-outcome.ts
@@ -1,0 +1,23 @@
+export type PostPersistenceState = "not-started" | "rolled-back" | "committed" | "unknown";
+
+export function shouldCompensatePostAttachments(state: PostPersistenceState): boolean {
+  return state === "not-started" || state === "rolled-back";
+}
+
+export type PostCreateTransactionOutcome<T> =
+  | { kind: "committed"; post: T }
+  | { kind: "rolled-back" }
+  | { kind: "unknown"; error: unknown };
+
+export async function reconcilePostCreateTransactionOutcome<T>(
+  loadCandidatePost: () => Promise<T | null>,
+): Promise<PostCreateTransactionOutcome<T>> {
+  try {
+    const post = await loadCandidatePost();
+    return post
+      ? { kind: "committed", post }
+      : { kind: "rolled-back" };
+  } catch (error) {
+    return { kind: "unknown", error };
+  }
+}

--- a/apps/server/src/lib/post-transaction-wiring.test.ts
+++ b/apps/server/src/lib/post-transaction-wiring.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("../routes/posts.ts", import.meta.url), "utf8");
+
+describe("post transaction compensation wiring", () => {
+  test("rejects unavailable converted-GIF claims before remote ingestion", () => {
+    const claimPreflight = source.indexOf("convertedGifClaimStore.assertAvailable(");
+    const remoteFetch = source.indexOf("await fetch(gifUrl", claimPreflight);
+
+    expect(claimPreflight).toBeGreaterThan(-1);
+    expect(remoteFetch).toBeGreaterThan(claimPreflight);
+  });
+
+  test("consumes converted-GIF claims inside the same Prisma transaction as post creation", () => {
+    const transactionStart = source.indexOf("post = await prisma.$transaction(");
+    const transactionEnd = source.indexOf("{ isolationLevel: TransactionIsolationLevel.Serializable }", transactionStart);
+    const claimConsume = source.indexOf("convertedGifClaimStore.consumeUsing(", transactionStart);
+    const postCreate = source.indexOf("const created = await tx.post.create(", transactionStart);
+
+    expect(transactionStart).toBeGreaterThan(-1);
+    expect(transactionEnd).toBeGreaterThan(transactionStart);
+    expect(claimConsume).toBeGreaterThan(transactionStart);
+    expect(claimConsume).toBeLessThan(transactionEnd);
+    expect(postCreate).toBeGreaterThan(claimConsume);
+    expect(postCreate).toBeLessThan(transactionEnd);
+    expect(source).not.toContain("convertedGifClaimStore.restore(");
+  });
+
+  test("handles unknown commit outcomes before attachment compensation", () => {
+    const routeCatch = source.indexOf("if (err instanceof PostCreateTransactionOutcomeUnknownError)");
+    const attachmentCleanup = source.indexOf("await deleteAttachmentObjects(config, uploadedKeys)", routeCatch);
+
+    expect(routeCatch).toBeGreaterThan(-1);
+    expect(attachmentCleanup).toBeGreaterThan(routeCatch);
+  });
+});

--- a/apps/server/src/lib/public-forum-media.ts
+++ b/apps/server/src/lib/public-forum-media.ts
@@ -1,5 +1,6 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import type { CampuxConfig } from "@campux/config";
+import { getServerSigningSecret } from "./server-signing-secret";
 
 const forumMediaLifetimeSeconds = 48 * 60 * 60;
 
@@ -28,16 +29,7 @@ export function verifyPublicForumMediaSignature(key: string, expires: number, si
 }
 
 function signForumMedia(key: string, expires: number) {
-  return createHmac("sha256", getSigningSecret())
+  return createHmac("sha256", getServerSigningSecret())
     .update(`${expires}\n${key}`)
     .digest("base64url");
-}
-
-function getSigningSecret() {
-  const secret = process.env.CAMPUX_BOT_SESSION_SECRET
-    ?? (process.env.NODE_ENV === "production" ? null : process.env.DATABASE_URL);
-  if (!secret) {
-    throw new Error("CAMPUX_BOT_SESSION_SECRET is required to sign QQ forum media URLs");
-  }
-  return secret;
 }

--- a/apps/server/src/lib/runtime-image-dependencies.test.ts
+++ b/apps/server/src/lib/runtime-image-dependencies.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const dockerfilePath = fileURLToPath(new URL("../../../../Dockerfile", import.meta.url));
+
+describe("server runtime image dependencies", () => {
+  test("installs ffprobe for server-side video validation", async () => {
+    const dockerfile = await readFile(dockerfilePath, "utf8");
+    const runtimeStage = dockerfile.split(/\bAS runtime\b/)[1];
+
+    expect(runtimeStage).toBeDefined();
+    expect(runtimeStage).toMatch(/\bapk add\b[^\n]*\bffmpeg\b/);
+  });
+});

--- a/apps/server/src/lib/server-signing-secret.ts
+++ b/apps/server/src/lib/server-signing-secret.ts
@@ -1,0 +1,8 @@
+export function getServerSigningSecret(): string {
+  const secret = process.env.CAMPUX_BOT_SESSION_SECRET
+    ?? (process.env.NODE_ENV === "production" ? null : process.env.DATABASE_URL);
+  if (!secret) {
+    throw new Error("CAMPUX_BOT_SESSION_SECRET is required for server-signed claims");
+  }
+  return secret;
+}

--- a/apps/server/src/lib/single-video-upload.test.ts
+++ b/apps/server/src/lib/single-video-upload.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import multipart from "@fastify/multipart";
+import Fastify, { type FastifyInstance } from "fastify";
+import { readSingleVideoUpload, SingleVideoUploadError } from "./single-video-upload";
+
+const apps: FastifyInstance[] = [];
+
+async function buildApp() {
+  const app = Fastify();
+  apps.push(app);
+  await app.register(multipart);
+  app.post("/upload", async (request, reply) => {
+    try {
+      const upload = await readSingleVideoUpload(request, {
+        maxBytes: 1024,
+        isAllowedMimeType: (mimetype) => mimetype === "video/mp4",
+        missingMessage: "missing",
+        sizeMessage: "too large",
+        shapeMessage: "invalid shape",
+        typeMessage: "invalid type",
+      });
+      return reply.send({ size: upload.buffer.byteLength, filename: upload.filename });
+    } catch (error) {
+      if (error instanceof SingleVideoUploadError) {
+        return reply.code(error.status).send({ message: error.message });
+      }
+      throw error;
+    }
+  });
+  return app;
+}
+
+afterEach(async () => {
+  await Promise.all(apps.splice(0).map((app) => app.close()));
+});
+
+function videoFile(contents: string, name = "clip.mp4") {
+  return new File([contents], name, { type: "video/mp4" });
+}
+
+describe("readSingleVideoUpload", () => {
+  test("accepts exactly one video file", async () => {
+    const app = await buildApp();
+    const form = new FormData();
+    form.append("video", videoFile("abc"));
+
+    const response = await app.inject({ method: "POST", url: "/upload", payload: form as never });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe('{"size":3,"filename":"clip.mp4"}');
+  });
+
+  test("rejects a trailing field after the video file", async () => {
+    const app = await buildApp();
+    const form = new FormData();
+    form.append("video", videoFile("abc"));
+    form.append("extra", "value");
+
+    const response = await app.inject({ method: "POST", url: "/upload", payload: form as never });
+
+    expect(response.statusCode).toBe(413);
+    expect(response.body).toBe('{"message":"invalid shape"}');
+  });
+
+  test("rejects a trailing second file after the video file", async () => {
+    const app = await buildApp();
+    const form = new FormData();
+    form.append("video", videoFile("abc"));
+    form.append("video2", videoFile("def", "second.mp4"));
+
+    const response = await app.inject({ method: "POST", url: "/upload", payload: form as never });
+
+    expect(response.statusCode).toBe(413);
+    expect(response.body).toBe('{"message":"invalid shape"}');
+  });
+
+  test("rejects a field before the video file", async () => {
+    const app = await buildApp();
+    const form = new FormData();
+    form.append("extra", "value");
+    form.append("video", videoFile("abc"));
+
+    const response = await app.inject({ method: "POST", url: "/upload", payload: form as never });
+
+    expect(response.statusCode).toBe(413);
+    expect(response.body).toBe('{"message":"invalid shape"}');
+  });
+
+  test("rejects an empty multipart request", async () => {
+    const app = await buildApp();
+    const form = new FormData();
+
+    const response = await app.inject({ method: "POST", url: "/upload", payload: form as never });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toBe('{"message":"missing"}');
+  });
+
+  test("rejects a non-video MIME type", async () => {
+    const app = await buildApp();
+    const form = new FormData();
+    form.append("video", new File(["abc"], "clip.txt", { type: "text/plain" }));
+
+    const response = await app.inject({ method: "POST", url: "/upload", payload: form as never });
+
+    expect(response.statusCode).toBe(415);
+    expect(response.body).toBe('{"message":"invalid type"}');
+  });
+
+  test("rejects a video above the byte cap", async () => {
+    const app = await buildApp();
+    const form = new FormData();
+    form.append("video", videoFile("x".repeat(1025)));
+
+    const response = await app.inject({ method: "POST", url: "/upload", payload: form as never });
+
+    expect(response.statusCode).toBe(413);
+    expect(response.body).toBe('{"message":"too large"}');
+  });
+});

--- a/apps/server/src/lib/single-video-upload.ts
+++ b/apps/server/src/lib/single-video-upload.ts
@@ -1,0 +1,107 @@
+import { Buffer } from "node:buffer";
+import type { FastifyRequest } from "fastify";
+
+const multipartLimitCodes = new Set([
+  "FST_PARTS_LIMIT",
+  "FST_FILES_LIMIT",
+  "FST_FIELDS_LIMIT",
+  "FST_REQ_FILE_TOO_LARGE",
+]);
+
+export class SingleVideoUploadError extends Error {
+  constructor(
+    readonly status: 400 | 413 | 415,
+    message: string,
+  ) {
+    super(message);
+    this.name = "SingleVideoUploadError";
+  }
+}
+
+function errorCode(error: unknown): string {
+  return error instanceof Error && "code" in error ? String(error.code) : "";
+}
+
+export async function readSingleVideoUpload(
+  request: FastifyRequest,
+  {
+    maxBytes,
+    isAllowedMimeType,
+    missingMessage,
+    sizeMessage,
+    shapeMessage,
+    typeMessage,
+  }: {
+    maxBytes: number;
+    isAllowedMimeType: (mimetype: string) => boolean;
+    missingMessage: string;
+    sizeMessage: string;
+    shapeMessage: string;
+    typeMessage: string;
+  },
+): Promise<{ buffer: Buffer; filename: string; mimetype: string }> {
+  let upload: { buffer: Buffer; filename: string; mimetype: string } | null = null;
+
+  try {
+    for await (const part of request.parts({
+      limits: {
+        fieldNameSize: 64,
+        fieldSize: 1,
+        fields: 0,
+        files: 1,
+        headerPairs: 32,
+        parts: 1,
+        fileSize: maxBytes,
+      },
+    })) {
+      if (part.type !== "file" || upload) {
+        if (part.type === "file") {
+          part.file.destroy();
+        }
+        throw new SingleVideoUploadError(413, shapeMessage);
+      }
+      if (!isAllowedMimeType(part.mimetype || "")) {
+        part.file.destroy();
+        throw new SingleVideoUploadError(415, typeMessage);
+      }
+
+      let transferredBytes = 0;
+      const chunks: Buffer[] = [];
+      for await (const chunk of part.file) {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        transferredBytes += buffer.byteLength;
+        if (transferredBytes > maxBytes) {
+          part.file.destroy();
+          throw new SingleVideoUploadError(413, sizeMessage);
+        }
+        chunks.push(buffer);
+      }
+      if (part.file.truncated) {
+        throw new SingleVideoUploadError(413, sizeMessage);
+      }
+
+      upload = {
+        buffer: Buffer.concat(chunks, transferredBytes),
+        filename: part.filename || "video.mp4",
+        mimetype: part.mimetype || "application/octet-stream",
+      };
+    }
+  } catch (error) {
+    if (error instanceof SingleVideoUploadError) {
+      throw error;
+    }
+    const code = errorCode(error);
+    if (code === "FST_REQ_FILE_TOO_LARGE") {
+      throw new SingleVideoUploadError(413, sizeMessage);
+    }
+    if (multipartLimitCodes.has(code)) {
+      throw new SingleVideoUploadError(413, shapeMessage);
+    }
+    throw error;
+  }
+
+  if (!upload) {
+    throw new SingleVideoUploadError(400, missingMessage);
+  }
+  return upload;
+}

--- a/apps/server/src/routes/posts.ts
+++ b/apps/server/src/routes/posts.ts
@@ -15,11 +15,20 @@ import { prisma } from "../lib/prisma";
 import { readTenantPendingPostLimit, readTenantImageCompression } from "../lib/tenant-metadata";
 import {
   buildImageSourceSizeErrorMessage,
+  buildVideoGifFfmpegArgs,
   convertedVideoGifSizeErrorMessage,
+  createConvertedGifClaim,
+  hasGifSignature,
   imageStorageHardMaxBytes,
+  isAttachmentOrderCompatible,
+  isTrustedConvertedGifUrl,
   readResponseBufferWithLimit,
   resolveImageUploadLimits,
+  restoreAttachmentOrder,
   ResponseBodyTooLargeError,
+  shouldExposeRemoteGifIndexes,
+  type AttachmentOrderKind,
+  validateConvertedGifClaim,
   validateConvertedVideoGifSize,
   validateProcessedImageSize,
 } from "../lib/image-upload-policy";
@@ -32,6 +41,14 @@ import type { RuntimeQueue } from "../runtime/queue";
 import type { OneBotRuntime } from "../runtime/onebot";
 import { autoTagPost } from "../runtime/post-tagging";
 import { verifyPublicForumMediaSignature } from "../lib/public-forum-media";
+import { getServerSigningSecret } from "../lib/server-signing-secret";
+import {
+  ConvertedGifClaimStore,
+  ConvertedGifClaimUnavailableError,
+  convertedGifClaimSettingPrefix,
+  type ConvertedGifClaimSetting,
+} from "../lib/converted-gif-claim-store";
+import { readSingleVideoUpload, SingleVideoUploadError } from "../lib/single-video-upload";
 
 const fileQuerySchema = z.object({
   key: z.string().min(1),
@@ -66,6 +83,13 @@ class PendingPostLimitError extends Error {
     readonly limit: number,
   ) {
     super("pending post limit exceeded");
+  }
+}
+
+class ConvertedVideoGifSizeError extends Error {
+  constructor() {
+    super(convertedVideoGifSizeErrorMessage);
+    this.name = "ConvertedVideoGifSizeError";
   }
 }
 
@@ -106,21 +130,170 @@ function isConvertibleVideoType(contentType: string): boolean {
   return VIDEO_CONVERT_MIME_TYPES.has(contentType);
 }
 
-const VIDEO_SIZE_CAP = 100 * 1024 * 1024; // 100MB
+const VIDEO_SIZE_CAP = 15 * 1024 * 1024;
+const REMOTE_VIDEO_SIZE_CAP = VIDEO_SIZE_CAP;
 const MAX_VIDEO_DURATION_SEC = 60;
+const SCDN_API_URL = "https://img.scdn.io/api/v1.php";
+const SCDN_RESPONSE_MAX_BYTES = 64 * 1024;
+const MAX_CONCURRENT_VIDEO_GIF_CONVERSIONS = 2;
+const VIDEO_UPLOAD_DEADLINE_MS = 30_000;
+const activeVideoGifConversions = new Set<string>();
+const convertedGifClaimStore = new ConvertedGifClaimStore({
+  transaction: (callback) => prisma.$transaction(async (tx) => callback({
+    deleteByKeys: async (keys) => {
+      const deleted = await tx.systemSetting.deleteMany({
+        where: { key: { in: keys } },
+      });
+      return deleted.count;
+    },
+  })),
+  pruneAndCreate: async (cutoff, setting) => {
+    await prisma.$transaction([
+      prisma.systemSetting.deleteMany({
+        where: {
+          key: { startsWith: convertedGifClaimSettingPrefix },
+          updatedAt: { lte: cutoff },
+        },
+      }),
+      prisma.systemSetting.create({ data: setting }),
+    ]);
+  },
+  restore: async (settings) => {
+    await prisma.systemSetting.createMany({ data: settings });
+  },
+});
+
+function reserveVideoGifConversion(conversionKey: string): (() => void) | null {
+  if (activeVideoGifConversions.has(conversionKey)
+    || activeVideoGifConversions.size >= MAX_CONCURRENT_VIDEO_GIF_CONVERSIONS) {
+    return null;
+  }
+  activeVideoGifConversions.add(conversionKey);
+  return () => {
+    activeVideoGifConversions.delete(conversionKey);
+  };
+}
+
+const VIDEO_CONTAINER_FORMATS = new Set([
+  "3gp",
+  "3g2",
+  "avi",
+  "matroska",
+  "mj2",
+  "mov",
+  "mp4",
+  "webm",
+]);
+
+async function probeVideoFile(inputPath: string): Promise<number> {
+  const { spawn } = await import("node:child_process");
+  return new Promise<number>((resolve, reject) => {
+    const proc = spawn("ffprobe", [
+      "-v", "quiet",
+      "-print_format", "json",
+      "-show_entries", "format=duration,format_name:stream=codec_type",
+      inputPath,
+    ], { timeout: 10000 });
+    let stdout = "";
+    let stdoutBytes = 0;
+    let stdoutTooLarge = false;
+    proc.stdout?.on("data", (data: Buffer) => {
+      stdoutBytes += data.byteLength;
+      if (stdoutBytes > 64 * 1024) {
+        stdoutTooLarge = true;
+        proc.kill("SIGKILL");
+        return;
+      }
+      stdout += data.toString();
+    });
+    proc.on("close", (code) => {
+      if (stdoutTooLarge) {
+        reject(new Error("视频元数据过大"));
+        return;
+      }
+      if (code !== 0) {
+        reject(new Error("无法解析视频信息"));
+        return;
+      }
+      try {
+        const info = JSON.parse(stdout) as {
+          format?: { duration?: string; format_name?: string };
+          streams?: Array<{ codec_type?: string }>;
+        };
+        const duration = Number(info.format?.duration);
+        const formats = new Set((info.format?.format_name ?? "").split(","));
+        const hasSupportedContainer = [...formats].some((format) => VIDEO_CONTAINER_FORMATS.has(format));
+        const hasVideoStream = info.streams?.some((stream) => stream.codec_type === "video") ?? false;
+        if (!Number.isFinite(duration) || duration <= 0 || !hasSupportedContainer || !hasVideoStream) {
+          reject(new Error("文件不是受支持的视频"));
+          return;
+        }
+        resolve(duration);
+      } catch {
+        reject(new Error("无法解析视频信息"));
+      }
+    });
+    proc.on("error", (error: NodeJS.ErrnoException) => {
+      reject(error.code === "ENOENT"
+        ? new Error("服务端未安装 ffprobe，请使用 Web 前端投稿")
+        : error);
+    });
+  });
+}
+
+async function probeVideoBuffer(videoBuffer: Buffer): Promise<number> {
+  const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  const { tmpdir } = await import("node:os");
+  const tmpDir = mkdtempSync(join(tmpdir(), "campux-video-probe-"));
+  const inputPath = join(tmpDir, "input.bin");
+  try {
+    writeFileSync(inputPath, videoBuffer);
+    return await probeVideoFile(inputPath);
+  } finally {
+    try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+}
+
+async function uploadVideoToScdn(videoBuffer: Buffer, fileName: string, mimeType: string): Promise<string> {
+  const formData = new FormData();
+  formData.append("image", new Blob([Uint8Array.from(videoBuffer)], { type: mimeType }), fileName);
+  formData.append("outputFormat", "gif");
+  formData.append("cdn_domain", "cloudflarecnimg.scdn.io");
+  formData.append("storage_destination", "telegram");
+
+  const response = await fetch(SCDN_API_URL, {
+    method: "POST",
+    body: formData,
+    redirect: "manual",
+    signal: AbortSignal.timeout(90_000),
+  });
+  if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error(`视频转换服务返回 HTTP ${response.status}`);
+  }
+  const body = await readResponseBufferWithLimit(response, SCDN_RESPONSE_MAX_BYTES);
+  let payload: { success?: boolean; data?: { url?: string }; message?: string; error?: string };
+  try {
+    payload = JSON.parse(body.toString("utf8"));
+  } catch {
+    throw new Error("视频转换服务返回了无效响应");
+  }
+  const url = payload.data?.url;
+  if (!payload.success || typeof url !== "string" || !isTrustedConvertedGifUrl(url)) {
+    throw new Error(payload.message || payload.error || "视频转换服务未返回可信 GIF 地址");
+  }
+  return url;
+}
 
 /**
- * Convert video buffer to GIF using ffmpeg.
- * Uses original resolution and framerate with full 256-color palette
- * for maximum quality (every frame, original dimensions).
- *
- * Note: The web frontend now converts videos to GIF in-browser, so this
- * server-side path is only hit by API clients. If ffmpeg is not available,
- * a clear error is thrown.
+ * Convert a bounded video buffer to a bounded GIF using ffmpeg.
+ * Output is constrained before encoding starts so crafted videos cannot grow
+ * unbounded temporary files or heap allocations.
  */
-async function convertVideoToGif(videoBuffer: Buffer, originalName: string): Promise<{ buffer: Buffer }> {
+async function convertVideoToGif(videoBuffer: Buffer): Promise<{ buffer: Buffer }> {
   const { spawn } = await import("node:child_process");
-  const { mkdtempSync, writeFileSync, readFileSync, rmSync } = await import("node:fs");
+  const { mkdtempSync, writeFileSync, readFileSync, rmSync, statSync } = await import("node:fs");
   const { join } = await import("node:path");
   const { tmpdir } = await import("node:os");
 
@@ -131,42 +304,18 @@ async function convertVideoToGif(videoBuffer: Buffer, originalName: string): Pro
   try {
     writeFileSync(inputPath, videoBuffer);
 
-    // Check duration
-    const duration = await new Promise<number>((resolve, reject) => {
-      const proc = spawn("ffprobe", [
-        "-v", "quiet", "-print_format", "json", "-show_format", inputPath,
-      ], { timeout: 10000 });
-      let stdout = "";
-      proc.stdout?.on("data", (d: Buffer) => { stdout += d.toString(); });
-      proc.on("close", (code) => {
-        if (code !== 0) { reject(new Error("无法解析视频信息")); return; }
-        try {
-          const info = JSON.parse(stdout);
-          resolve(parseFloat(info.format?.duration || "0"));
-        } catch { reject(new Error("无法解析视频时长")); }
-      });
-      proc.on("error", (err: NodeJS.ErrnoException) => {
-        if (err.code === "ENOENT") {
-          reject(new Error("服务端未安装 ffprobe，请使用 Web 前端投稿"));
-        } else {
-          reject(err);
-        }
-      });
-    });
+    const duration = await probeVideoFile(inputPath);
 
     if (duration > MAX_VIDEO_DURATION_SEC) {
       throw new Error(`视频时长 ${Math.round(duration)}s 超过限制 (${MAX_VIDEO_DURATION_SEC}s)`);
     }
 
-    // Convert to GIF: original resolution & framerate, full 256-color palette
     await new Promise<void>((resolve, reject) => {
-      const ffmpeg = spawn("ffmpeg", [
-        "-y", "-i", inputPath,
-        "-vf", "fps=source,split[s0][s1];[s0]palettegen=stats_mode=full:max_colors=256[p];[s1][p]paletteuse=dither=floyd_steinberg",
-        "-loop", "0", outputPath,
-      ], { timeout: 60000 });
+      const ffmpeg = spawn("ffmpeg", buildVideoGifFfmpegArgs(inputPath, outputPath), { timeout: 60000 });
       let stderr = "";
-      ffmpeg.stderr?.on("data", (d: Buffer) => { stderr += d.toString(); });
+      ffmpeg.stderr?.on("data", (d: Buffer) => {
+        stderr = `${stderr}${d.toString()}`.slice(-4_096);
+      });
       ffmpeg.on("close", (code) => {
         if (code !== 0) { reject(new Error(`ffmpeg 转换失败: ${stderr.slice(-200)}`)); return; }
         resolve();
@@ -180,6 +329,10 @@ async function convertVideoToGif(videoBuffer: Buffer, originalName: string): Pro
       });
     });
 
+    const sizeValidation = validateConvertedVideoGifSize(statSync(outputPath).size);
+    if (!sizeValidation.ok) {
+      throw new ConvertedVideoGifSizeError();
+    }
     return { buffer: readFileSync(outputPath) };
   } finally {
     try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
@@ -196,6 +349,20 @@ function isUploadTooLargeError(error: unknown) {
   }
   const code = "code" in error ? String(error.code) : "";
   return code === "FST_REQ_FILE_TOO_LARGE" || error.message.includes("size limit exceeded") || error.message.includes("File size limit exceeded");
+}
+
+const multipartLimitErrorCodes = new Set([
+  "FST_PARTS_LIMIT",
+  "FST_FILES_LIMIT",
+  "FST_FIELDS_LIMIT",
+  "FST_REQ_FILE_TOO_LARGE",
+]);
+
+function isMultipartLimitError(error: unknown): boolean {
+  return Boolean(error
+    && typeof error === "object"
+    && "code" in error
+    && multipartLimitErrorCodes.has(String(error.code)));
 }
 
 function isTransactionSerializationFailure(value: unknown) {
@@ -248,6 +415,98 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
     return reply.send(Buffer.from(object.bytes));
   });
 
+  app.post("/api/uploads/video-gif", async (request, reply) => {
+    const context = await requireReadyTenant(request, reply, "submitter");
+    const activeBan = await prisma.banRecord.findFirst({
+      where: {
+        tenantId: context.selectedTenant.id,
+        userId: context.user.id,
+        endsAt: { gt: new Date() },
+      },
+      orderBy: { endsAt: "desc" },
+    });
+    if (activeBan) {
+      return reply.code(403).send({ message: `账号已被封禁：${activeBan.comment}` });
+    }
+    const signingSecret = getServerSigningSecret();
+    const conversionKey = `${context.selectedTenant.id}:${context.user.id}`;
+    const releaseConversion = reserveVideoGifConversion(conversionKey);
+    if (!releaseConversion) {
+      reply.header("Connection", "close");
+      reply.raw.once("finish", () => request.raw.destroy());
+      return reply.code(429).send({ message: "视频转换繁忙，请稍后重试" });
+    }
+    const uploadDeadline = setTimeout(() => {
+      request.raw.destroy(new Error("video upload deadline exceeded"));
+    }, VIDEO_UPLOAD_DEADLINE_MS);
+
+    try {
+      let videoUpload: Awaited<ReturnType<typeof readSingleVideoUpload>>;
+      try {
+        videoUpload = await readSingleVideoUpload(request, {
+          maxBytes: REMOTE_VIDEO_SIZE_CAP,
+          isAllowedMimeType: isConvertibleVideoType,
+          missingMessage: "请选择视频文件",
+          sizeMessage: "视频原文件不能超过 15MB",
+          shapeMessage: "视频上传字段或附件超过限制",
+          typeMessage: "仅支持 MP4、WebM、MOV、AVI、MKV 或 3GP 视频",
+        });
+        clearTimeout(uploadDeadline);
+      } catch (error) {
+        if (error instanceof SingleVideoUploadError) {
+          return reply.code(error.status).send({ message: error.message });
+        }
+        throw error;
+      }
+      const {
+        buffer: videoBuffer,
+        filename: videoFilename,
+        mimetype: videoMimetype,
+      } = videoUpload;
+
+      try {
+        const duration = await probeVideoBuffer(videoBuffer);
+        if (duration > MAX_VIDEO_DURATION_SEC) {
+          return reply.code(400).send({ message: `视频时长不能超过 ${MAX_VIDEO_DURATION_SEC} 秒` });
+        }
+      } catch (error) {
+        return reply.code(400).send({
+          message: error instanceof Error ? error.message : "无法解析视频信息",
+        });
+      }
+
+      let url: string;
+      try {
+        url = await uploadVideoToScdn(
+          videoBuffer,
+          videoFilename,
+          videoMimetype,
+        );
+      } catch (error) {
+        app.log.warn({ error }, "server-side video GIF conversion failed");
+        return reply.code(502).send({
+          message: error instanceof Error ? error.message : "视频转换服务暂时不可用",
+        });
+      }
+
+      const claimNow = Date.now();
+      const proof = createConvertedGifClaim({
+        url,
+        tenantId: context.selectedTenant.id,
+        userId: context.user.id,
+        sessionTokenHash: context.session.tokenHash,
+        signingSecret,
+        now: claimNow,
+      });
+      await convertedGifClaimStore.issue(proof, claimNow);
+      reply.header("Cache-Control", "no-store");
+      return reply.send({ url, proof });
+    } finally {
+      clearTimeout(uploadDeadline);
+      releaseConversion();
+    }
+  });
+
   app.post("/api/posts", async (request, reply) => {
     const context = await requireReadyTenant(request, reply, "submitter");
     const compression = await readTenantImageCompression(prisma, context.selectedTenant.id);
@@ -281,12 +540,30 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
     let textColor: string | null = null;
     let font: string | null = null;
     const staged: PostAttachment[] = [];
-    const remoteGifUrls: string[] = [];
+    const remoteGifClaims: Array<{ url: string; proof: string }> = [];
+    let attachmentOrder: AttachmentOrderKind[] | null = null;
+    let consumedConvertedGifClaimSettings: ConvertedGifClaimSetting[] = [];
 
     try {
       let fileIndex = 0;
-      for await (const part of request.parts()) {
+      for await (const part of request.parts({
+        limits: {
+          fieldNameSize: 64,
+          fieldSize: 32 * 1024,
+          fields: 10,
+          files: 9,
+          headerPairs: 32,
+          parts: 19,
+          fileSize: Math.max(REMOTE_VIDEO_SIZE_CAP, imageUploadLimits.sourceMaxBytes),
+        },
+      })) {
         if (part.type === "field") {
+          if (part.fieldnameTruncated || part.valueTruncated) {
+            throw {
+              status: 413,
+              message: "投稿字段过大",
+            };
+          }
           if (part.fieldname === "text") {
             text = String(part.value ?? "");
           } else if (part.fieldname === "anonymous") {
@@ -299,15 +576,48 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
             textColor = String(part.value ?? "") || null;
           } else if (part.fieldname === "font") {
             font = String(part.value ?? "") || null;
-          } else if (part.fieldname === "remoteGifUrls") {
-            // Accept JSON array of GIF URLs from 失控图床 API conversion
+          } else if (part.fieldname === "attachmentOrder") {
             try {
               const parsed = JSON.parse(String(part.value ?? "[]"));
-              if (Array.isArray(parsed)) {
-                remoteGifUrls.push(...parsed.filter((u): u is string => typeof u === "string" && u.length > 0));
+              if (!Array.isArray(parsed)
+                || parsed.length > 9
+                || parsed.some((kind) => kind !== "local" && kind !== "remote")) {
+                throw new Error("invalid attachment order");
               }
+              attachmentOrder = parsed;
             } catch {
-              // ignore malformed JSON
+              throw {
+                status: 400,
+                message: "附件顺序格式无效",
+              };
+            }
+          } else if (part.fieldname === "remoteGifUrls") {
+            throw {
+              status: 400,
+              message: "视频转换凭证缺失，请重新转换",
+            };
+          } else if (part.fieldname === "remoteGifClaims") {
+            try {
+              const parsed = JSON.parse(String(part.value ?? "[]"));
+              if (!Array.isArray(parsed)
+                || parsed.length > 9
+                || parsed.some((claim) => !claim
+                  || typeof claim !== "object"
+                  || typeof claim.url !== "string"
+                  || claim.url.length > 2_048
+                  || typeof claim.proof !== "string"
+                  || claim.proof.length > 256)) {
+                throw new Error("invalid claims");
+              }
+              remoteGifClaims.push(...parsed.map((claim) => ({
+                url: claim.url,
+                proof: claim.proof,
+              })));
+            } catch {
+              throw {
+                status: 400,
+                message: "视频转换凭证格式无效",
+              };
             }
           }
           continue;
@@ -342,37 +652,74 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
         const isVideo = isConvertibleVideoType(mime);
         const cap = isVideo ? VIDEO_SIZE_CAP : imageUploadLimits.sourceMaxBytes;
         const sizeErrorMessage = isVideo
-          ? "视频原文件不能超过 100MB"
+          ? "视频原文件不能超过 15MB"
           : buildImageSourceSizeErrorMessage({
               compressionEnabled: compression.enabled,
               maxSizeMb: compression.maxSizeMb,
             });
-
-        // Read file with size cap using Transform
-        const buf = await readPartCapped(part.file, cap, fileIndex, sizeErrorMessage);
+        const releaseConversion = isVideo
+          ? reserveVideoGifConversion(`${context.selectedTenant.id}:${context.user.id}`)
+          : null;
+        if (isVideo && !releaseConversion) {
+          part.file.destroy();
+          reply.header("Connection", "close");
+          reply.raw.once("finish", () => request.raw.destroy());
+          throw {
+            status: 429,
+            message: "视频转换繁忙，请稍后重试",
+            fileIndex,
+          };
+        }
+        const uploadDeadline = isVideo
+          ? setTimeout(() => request.raw.destroy(new Error("video upload deadline exceeded")), VIDEO_UPLOAD_DEADLINE_MS)
+          : null;
 
         let finalBuf: Buffer;
         let finalMime: string;
         let finalFileName: string;
-
-        if (isVideo) {
-          // Convert video to GIF
-          try {
-            const converted = await convertVideoToGif(buf, part.filename || "video");
-            finalBuf = converted.buffer;
-            finalMime = "image/gif";
-            finalFileName = (part.filename || "video").replace(/\.[^.]+$/, ".gif");
-          } catch (convErr) {
+        try {
+          const buf = await readPartCapped(part.file, cap, fileIndex, sizeErrorMessage);
+          if (uploadDeadline) {
+            clearTimeout(uploadDeadline);
+          }
+          if (part.file.truncated) {
             throw {
-              status: 400,
-              message: `视频转换失败：${convErr instanceof Error ? convErr.message : "未知错误"}`,
+              status: 413,
+              message: sizeErrorMessage,
               fileIndex,
             };
           }
-        } else {
-          finalBuf = await compressImageBuffer(buf, mime, compression);
-          finalMime = mime;
-          finalFileName = part.filename || "attachment.jpg";
+
+          if (isVideo) {
+            try {
+              const converted = await convertVideoToGif(buf);
+              finalBuf = converted.buffer;
+              finalMime = "image/gif";
+              finalFileName = (part.filename || "video").replace(/\.[^.]+$/, ".gif");
+            } catch (convErr) {
+              if (convErr instanceof ConvertedVideoGifSizeError) {
+                throw {
+                  status: 413,
+                  message: convertedVideoGifSizeErrorMessage,
+                  fileIndex,
+                };
+              }
+              throw {
+                status: 400,
+                message: `视频转换失败：${convErr instanceof Error ? convErr.message : "未知错误"}`,
+                fileIndex,
+              };
+            }
+          } else {
+            finalBuf = await compressImageBuffer(buf, mime, compression);
+            finalMime = mime;
+            finalFileName = part.filename || "attachment.jpg";
+          }
+        } finally {
+          if (uploadDeadline) {
+            clearTimeout(uploadDeadline);
+          }
+          releaseConversion?.();
         }
 
         const sizeValidation = isVideo
@@ -400,68 +747,25 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
         fileIndex += 1;
       }
 
-      // 检查远程 GIF URL 的 SSRF 风险
-      const urlValidation = validateRemoteGifUrls(remoteGifUrls);
-      if (!urlValidation.valid) {
+      if (staged.length + remoteGifClaims.length > 9) {
         throw {
           status: 400,
-          message: urlValidation.reason,
+          message: "最多 9 个文件",
+        };
+      }
+      const localAttachmentCount = staged.length;
+      if (attachmentOrder && !isAttachmentOrderCompatible(
+        attachmentOrder,
+        localAttachmentCount,
+        remoteGifClaims.length,
+      )) {
+        throw {
+          status: 400,
+          message: "附件顺序与文件数量不匹配",
         };
       }
 
-      // Process remote GIF URLs (from 失控图床 API conversion)
-      for (const gifUrl of remoteGifUrls) {
-        if (staged.length >= 9) {
-          break;
-        }
-        try {
-          const response = await fetch(gifUrl);
-          if (!response.ok) {
-            app.log.warn({ url: gifUrl, status: response.status }, "failed to fetch remote GIF");
-            continue;
-          }
-          let buf: Buffer;
-          try {
-            buf = await readResponseBufferWithLimit(response, imageStorageHardMaxBytes);
-          } catch (error) {
-            if (error instanceof ResponseBodyTooLargeError) {
-              throw {
-                status: 413,
-                message: convertedVideoGifSizeErrorMessage,
-                fileIndex: staged.length,
-              };
-            }
-            throw error;
-          }
-          const sizeValidation = validateConvertedVideoGifSize(buf.byteLength);
-          if (!sizeValidation.ok) {
-            throw {
-              status: sizeValidation.status,
-              message: sizeValidation.message,
-              fileIndex: staged.length,
-            };
-          }
-
-          const att = await uploadAttachmentBytes({
-            config,
-            tenantId: context.selectedTenant.id,
-            kind: "image",
-            contentType: "image/gif",
-            fileName: "video.gif",
-            body: buf,
-          });
-          uploadedKeys.push(att.key);
-          staged.push(att);
-        } catch (fetchErr) {
-          if (fetchErr && typeof fetchErr === "object" && "status" in fetchErr && "message" in fetchErr) {
-            throw fetchErr;
-          }
-          app.log.warn({ error: fetchErr, url: gifUrl }, "failed to process remote GIF");
-          // Skip failed URLs rather than failing the entire post
-        }
-      }
-
-      // Validate text
+      // Validate content before any remote GIF network work.
       if (text.trim().length === 0) {
         throw {
           status: 400,
@@ -501,6 +805,175 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
           status: 403,
           message: `投稿包含不安全内容，账号已被封禁 24 小时：${injectionResult.reason}`,
         };
+      }
+
+      const remoteGifUrls = remoteGifClaims.map((claim) => claim.url);
+      const remoteGifSigningSecret = remoteGifClaims.length > 0
+        ? getServerSigningSecret()
+        : null;
+      const invalidRemoteGifUrlIndexes = remoteGifUrls.flatMap((url, remoteGifIndex) => {
+        const validation = validateRemoteGifUrls([url]);
+        return validation.valid && isTrustedConvertedGifUrl(url) ? [] : [remoteGifIndex];
+      });
+      if (invalidRemoteGifUrlIndexes.length > 0) {
+        throw {
+          status: 400,
+          message: "视频转换结果来源不受信任",
+          remoteGifIndexes: invalidRemoteGifUrlIndexes,
+        };
+      }
+      const invalidRemoteGifIndexes = remoteGifClaims.flatMap((claim, remoteGifIndex) => (
+        validateConvertedGifClaim({
+          url: claim.url,
+          proof: claim.proof,
+          tenantId: context.selectedTenant.id,
+          userId: context.user.id,
+          sessionTokenHash: context.session.tokenHash,
+          signingSecret: remoteGifSigningSecret!,
+        }) ? [] : [remoteGifIndex]
+      ));
+      if (invalidRemoteGifIndexes.length > 0) {
+        throw {
+          status: 403,
+          message: "视频转换凭证无效或已过期，请重新转换",
+          remoteGifIndexes: invalidRemoteGifIndexes,
+        };
+      }
+
+      const releaseRemoteGifIngestion = remoteGifClaims.length > 0
+        ? reserveVideoGifConversion(`${context.selectedTenant.id}:${context.user.id}`)
+        : null;
+      if (remoteGifClaims.length > 0 && !releaseRemoteGifIngestion) {
+        throw {
+          status: 429,
+          message: "视频处理繁忙，请稍后重试",
+        };
+      }
+      const remoteGifIngestionSignal = remoteGifClaims.length > 0
+        ? AbortSignal.timeout(60_000)
+        : null;
+
+      try {
+        if (remoteGifClaims.length > 0) {
+          try {
+            consumedConvertedGifClaimSettings = await convertedGifClaimStore.consume(
+              remoteGifClaims.map((claim) => claim.proof),
+            );
+          } catch (error) {
+            if (error instanceof ConvertedGifClaimUnavailableError) {
+              throw {
+                status: 403,
+                message: "视频转换凭证已使用、重复或已失效，请重新转换",
+                remoteGifIndexes: remoteGifClaims.map((_, index) => index),
+              };
+            }
+            throw error;
+          }
+        }
+
+        // Only server-issued converted-video claims receive the stable 50MB cap.
+        for (const [remoteGifIndex, { url: gifUrl }] of remoteGifClaims.entries()) {
+        try {
+          const response = await fetch(gifUrl, {
+            redirect: "manual",
+            signal: remoteGifIngestionSignal,
+          });
+          if (response.status >= 300 && response.status < 400) {
+            await response.body?.cancel().catch(() => undefined);
+            throw {
+              status: 400,
+              message: "视频转换结果不允许重定向",
+              remoteGifIndexes: [remoteGifIndex],
+              permanentRemoteGifFailure: true,
+            };
+          }
+          if (!response.ok) {
+            await response.body?.cancel().catch(() => undefined);
+            app.log.warn({ url: gifUrl, status: response.status }, "failed to fetch remote GIF");
+            const permanentRemoteGifFailure = response.status >= 400
+              && response.status < 500
+              && ![408, 425, 429].includes(response.status);
+            throw {
+              status: permanentRemoteGifFailure ? 410 : 502,
+              message: permanentRemoteGifFailure
+                ? "视频转换结果已失效，请重新转换"
+                : "视频转换结果下载失败，请重试",
+              remoteGifIndexes: [remoteGifIndex],
+              permanentRemoteGifFailure,
+            };
+          }
+          if (response.url && !isTrustedConvertedGifUrl(response.url)) {
+            await response.body?.cancel().catch(() => undefined);
+            throw {
+              status: 400,
+              message: "视频转换结果来源不受信任",
+              remoteGifIndexes: [remoteGifIndex],
+              permanentRemoteGifFailure: true,
+            };
+          }
+          let buf: Buffer;
+          try {
+            buf = await readResponseBufferWithLimit(response, imageStorageHardMaxBytes);
+          } catch (error) {
+            if (error instanceof ResponseBodyTooLargeError) {
+              throw {
+                status: 413,
+                message: convertedVideoGifSizeErrorMessage,
+                remoteGifIndexes: [remoteGifIndex],
+                permanentRemoteGifFailure: true,
+              };
+            }
+            throw error;
+          }
+          if (!hasGifSignature(buf)) {
+            throw {
+              status: 415,
+              message: "视频转换结果不是有效的 GIF",
+              remoteGifIndexes: [remoteGifIndex],
+              permanentRemoteGifFailure: true,
+            };
+          }
+          const sizeValidation = validateConvertedVideoGifSize(buf.byteLength);
+          if (!sizeValidation.ok) {
+            throw {
+              status: sizeValidation.status,
+              message: sizeValidation.message,
+              remoteGifIndexes: [remoteGifIndex],
+              permanentRemoteGifFailure: true,
+            };
+          }
+
+          const att = await uploadAttachmentBytes({
+            config,
+            tenantId: context.selectedTenant.id,
+            kind: "image",
+            contentType: "image/gif",
+            fileName: "video.gif",
+            body: buf,
+          });
+          uploadedKeys.push(att.key);
+          staged.push(att);
+        } catch (fetchErr) {
+          if (fetchErr && typeof fetchErr === "object" && "status" in fetchErr && "message" in fetchErr) {
+            throw fetchErr;
+          }
+          app.log.warn({ error: fetchErr, url: gifUrl }, "failed to process remote GIF");
+          throw {
+            status: 502,
+            message: "视频转换结果下载失败，请重试",
+            remoteGifIndexes: [remoteGifIndex],
+          };
+        }
+        }
+      } finally {
+        releaseRemoteGifIngestion?.();
+      }
+
+      if (attachmentOrder) {
+        const localAttachments = staged.slice(0, localAttachmentCount);
+        const remoteAttachments = staged.slice(localAttachmentCount);
+        const ordered = restoreAttachmentOrder(localAttachments, remoteAttachments, attachmentOrder)!;
+        staged.splice(0, staged.length, ...ordered);
       }
 
       const initialStatus: "pending_approval" = "pending_approval";
@@ -598,6 +1071,9 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
         };
       }
 
+      // Post creation commits one-time converted-GIF claim consumption.
+      consumedConvertedGifClaimSettings = [];
+
       oneBot?.notifyNewPost(post.id).catch((error) => {
         app.log.warn({ error, postId: post.id }, "failed to notify review group");
       });
@@ -613,12 +1089,36 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
         post: toPostListItem(post),
       };
     } catch (err) {
+      let convertedGifClaimRestoreFailed = false;
+      let convertedGifClaimsRestored = false;
+      if (consumedConvertedGifClaimSettings.length > 0) {
+        try {
+          await convertedGifClaimStore.restore(consumedConvertedGifClaimSettings);
+          consumedConvertedGifClaimSettings = [];
+          convertedGifClaimsRestored = true;
+        } catch (restoreErr) {
+          convertedGifClaimRestoreFailed = true;
+          app.log.error({ error: restoreErr }, "failed to restore converted GIF claims");
+        }
+      }
+
       // Cleanup uploaded files on error
       await deleteAttachmentObjects(config, uploadedKeys).catch((cleanupErr) => {
         app.log.warn({ error: cleanupErr }, "failed to cleanup uploaded attachments");
       });
 
+      if (convertedGifClaimRestoreFailed) {
+        return reply.code(503).send({
+          message: "视频处理失败且转换凭证无法恢复，请移除视频后重新添加",
+          remoteGifIndexes: remoteGifClaims.map((_, index) => index),
+        });
+      }
+
       // Handle errors
+      if (isMultipartLimitError(err)) {
+        return reply.code(413).send({ message: "投稿附件或字段超过限制" });
+      }
+
       if (err instanceof PendingPostLimitError) {
         return reply.code(409).send({
           message: `你还有 ${err.pendingCount} 条稿件待审核，当前校园墙最多同时保留 ${err.limit} 条待审核稿件。`,
@@ -626,10 +1126,23 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
       }
 
       if (typeof err === "object" && err !== null && "status" in err && "message" in err) {
-        const errorObj = err as { status: number; message: string; fileIndex?: number };
+        const errorObj = err as {
+          status: number;
+          message: string;
+          fileIndex?: number;
+          remoteGifIndexes?: number[];
+          permanentRemoteGifFailure?: boolean;
+        };
         return reply.code(errorObj.status).send({
           message: errorObj.message,
           ...(errorObj.fileIndex !== undefined ? { fileIndex: errorObj.fileIndex } : {}),
+          ...(errorObj.remoteGifIndexes
+            && shouldExposeRemoteGifIndexes(
+              convertedGifClaimsRestored,
+              errorObj.permanentRemoteGifFailure,
+            )
+            ? { remoteGifIndexes: errorObj.remoteGifIndexes }
+            : {}),
         });
       }
 

--- a/apps/server/src/routes/posts.ts
+++ b/apps/server/src/routes/posts.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
 import { Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { z } from "zod";
@@ -46,8 +47,12 @@ import {
   ConvertedGifClaimStore,
   ConvertedGifClaimUnavailableError,
   convertedGifClaimSettingPrefix,
-  type ConvertedGifClaimSetting,
 } from "../lib/converted-gif-claim-store";
+import {
+  reconcilePostCreateTransactionOutcome,
+  shouldCompensatePostAttachments,
+  type PostPersistenceState,
+} from "../lib/post-create-transaction-outcome";
 import { readSingleVideoUpload, SingleVideoUploadError } from "../lib/single-video-upload";
 
 const fileQuerySchema = z.object({
@@ -90,6 +95,16 @@ class ConvertedVideoGifSizeError extends Error {
   constructor() {
     super(convertedVideoGifSizeErrorMessage);
     this.name = "ConvertedVideoGifSizeError";
+  }
+}
+
+class PostCreateTransactionOutcomeUnknownError extends Error {
+  constructor(
+    readonly postCandidateId: string,
+    readonly reconciliationError: unknown,
+  ) {
+    super("post creation transaction outcome is unknown");
+    this.name = "PostCreateTransactionOutcomeUnknownError";
   }
 }
 
@@ -140,6 +155,13 @@ const VIDEO_UPLOAD_DEADLINE_MS = 30_000;
 const activeVideoGifConversions = new Set<string>();
 const convertedGifClaimStore = new ConvertedGifClaimStore({
   transaction: (callback) => prisma.$transaction(async (tx) => callback({
+    findExistingKeys: async (keys) => {
+      const records = await tx.systemSetting.findMany({
+        where: { key: { in: keys } },
+        select: { key: true },
+      });
+      return records.map((record) => record.key);
+    },
     deleteByKeys: async (keys) => {
       const deleted = await tx.systemSetting.deleteMany({
         where: { key: { in: keys } },
@@ -157,9 +179,6 @@ const convertedGifClaimStore = new ConvertedGifClaimStore({
       }),
       prisma.systemSetting.create({ data: setting }),
     ]);
-  },
-  restore: async (settings) => {
-    await prisma.systemSetting.createMany({ data: settings });
   },
 });
 
@@ -542,7 +561,7 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
     const staged: PostAttachment[] = [];
     const remoteGifClaims: Array<{ url: string; proof: string }> = [];
     let attachmentOrder: AttachmentOrderKind[] | null = null;
-    let consumedConvertedGifClaimSettings: ConvertedGifClaimSetting[] = [];
+    let postPersistenceState: PostPersistenceState = "not-started";
 
     try {
       let fileIndex = 0;
@@ -820,6 +839,7 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
           status: 400,
           message: "视频转换结果来源不受信任",
           remoteGifIndexes: invalidRemoteGifUrlIndexes,
+          permanentRemoteGifFailure: true,
         };
       }
       const invalidRemoteGifIndexes = remoteGifClaims.flatMap((claim, remoteGifIndex) => (
@@ -837,7 +857,26 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
           status: 403,
           message: "视频转换凭证无效或已过期，请重新转换",
           remoteGifIndexes: invalidRemoteGifIndexes,
+          permanentRemoteGifFailure: true,
         };
+      }
+
+      try {
+        await convertedGifClaimStore.assertAvailable(
+          remoteGifClaims.map(({ proof }) => proof),
+        );
+      } catch (caught) {
+        if (caught instanceof ConvertedGifClaimUnavailableError) {
+          throw {
+            status: 403,
+            message: "视频转换凭证已使用、重复或已失效，请重新转换",
+            remoteGifIndexes: caught.unavailableIndexes.length > 0
+              ? caught.unavailableIndexes
+              : remoteGifClaims.map((_, index) => index),
+            permanentRemoteGifFailure: true,
+          };
+        }
+        throw caught;
       }
 
       const releaseRemoteGifIngestion = remoteGifClaims.length > 0
@@ -854,23 +893,6 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
         : null;
 
       try {
-        if (remoteGifClaims.length > 0) {
-          try {
-            consumedConvertedGifClaimSettings = await convertedGifClaimStore.consume(
-              remoteGifClaims.map((claim) => claim.proof),
-            );
-          } catch (error) {
-            if (error instanceof ConvertedGifClaimUnavailableError) {
-              throw {
-                status: 403,
-                message: "视频转换凭证已使用、重复或已失效，请重新转换",
-                remoteGifIndexes: remoteGifClaims.map((_, index) => index),
-              };
-            }
-            throw error;
-          }
-        }
-
         // Only server-issued converted-video claims receive the stable 50MB cap.
         for (const [remoteGifIndex, { url: gifUrl }] of remoteGifClaims.entries()) {
         try {
@@ -979,12 +1001,33 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
       const initialStatus: "pending_approval" = "pending_approval";
       const logComment = "投稿创建";
 
-      // Create post in transaction with retry logic
+      // Create post and consume converted-GIF claims in one transaction with retry logic.
+      // A stable candidate ID lets us reconcile a lost commit acknowledgement safely.
+      const postCandidateId = randomUUID();
       let post: Awaited<ReturnType<typeof prisma.post.create>> | null = null;
       for (let attempt = 0; attempt < 3; attempt += 1) {
         try {
           post = await prisma.$transaction(
             async (tx) => {
+              await convertedGifClaimStore.consumeUsing(
+                remoteGifClaims.map((claim) => claim.proof),
+                {
+                  findExistingKeys: async (keys) => {
+                    const records = await tx.systemSetting.findMany({
+                      where: { key: { in: keys } },
+                      select: { key: true },
+                    });
+                    return records.map((record) => record.key);
+                  },
+                  deleteByKeys: async (keys) => {
+                    const deleted = await tx.systemSetting.deleteMany({
+                      where: { key: { in: keys } },
+                    });
+                    return deleted.count;
+                  },
+                },
+              );
+
               // 只有待审核状态才受待审核数量限制
               if (initialStatus === "pending_approval") {
                 const pendingPostLimit = await readTenantPendingPostLimit(tx, context.selectedTenant.id);
@@ -1019,6 +1062,7 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
 
               const created = await tx.post.create({
                 data: {
+                  id: postCandidateId,
                   tenantId: context.selectedTenant.id,
                   authorId: context.user.id,
                   displayId,
@@ -1054,11 +1098,51 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
           );
           break;
         } catch (caught) {
+          if (isTransactionSerializationFailure(caught)) {
+            if (attempt < 2) {
+              continue;
+            }
+            postPersistenceState = "rolled-back";
+            throw caught;
+          }
+
+          // Reconcile by the stable candidate ID before mapping any domain error.
+          // This closes the lost-acknowledgement path without restoring claims or
+          // deleting objects that may already be referenced by a committed post.
+          const outcome = await reconcilePostCreateTransactionOutcome(() => (
+            prisma.post.findUnique({
+              where: { id: postCandidateId },
+              include: {
+                tagAssignments: {
+                  include: { tag: true },
+                  orderBy: { createdAt: "asc" },
+                },
+              },
+            })
+          ));
+          if (outcome.kind === "committed") {
+            postPersistenceState = "committed";
+            post = outcome.post;
+            break;
+          }
+          if (outcome.kind === "unknown") {
+            postPersistenceState = "unknown";
+            throw new PostCreateTransactionOutcomeUnknownError(postCandidateId, outcome.error);
+          }
+
+          postPersistenceState = "rolled-back";
           if (caught instanceof PendingPostLimitError) {
             throw caught;
           }
-          if (isTransactionSerializationFailure(caught) && attempt < 2) {
-            continue;
+          if (caught instanceof ConvertedGifClaimUnavailableError) {
+            throw {
+              status: 403,
+              message: "视频转换凭证已使用、重复或已失效，请重新转换",
+              remoteGifIndexes: caught.unavailableIndexes.length > 0
+                ? caught.unavailableIndexes
+                : remoteGifClaims.map((_, index) => index),
+              permanentRemoteGifFailure: true,
+            };
           }
           throw caught;
         }
@@ -1070,9 +1154,7 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
           message: "投稿人数较多，请稍后再试",
         };
       }
-
-      // Post creation commits one-time converted-GIF claim consumption.
-      consumedConvertedGifClaimSettings = [];
+      postPersistenceState = "committed";
 
       oneBot?.notifyNewPost(post.id).catch((error) => {
         app.log.warn({ error, postId: post.id }, "failed to notify review group");
@@ -1089,28 +1171,20 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
         post: toPostListItem(post),
       };
     } catch (err) {
-      let convertedGifClaimRestoreFailed = false;
-      let convertedGifClaimsRestored = false;
-      if (consumedConvertedGifClaimSettings.length > 0) {
-        try {
-          await convertedGifClaimStore.restore(consumedConvertedGifClaimSettings);
-          consumedConvertedGifClaimSettings = [];
-          convertedGifClaimsRestored = true;
-        } catch (restoreErr) {
-          convertedGifClaimRestoreFailed = true;
-          app.log.error({ error: restoreErr }, "failed to restore converted GIF claims");
-        }
+      if (err instanceof PostCreateTransactionOutcomeUnknownError) {
+        app.log.error({
+          error: err.reconciliationError,
+          postCandidateId: err.postCandidateId,
+        }, "post transaction outcome is unknown; skipped attachment compensation");
+        return reply.code(503).send({
+          message: "投稿结果暂时无法确认，请勿重复提交，稍后刷新稿件列表确认",
+        });
       }
 
-      // Cleanup uploaded files on error
-      await deleteAttachmentObjects(config, uploadedKeys).catch((cleanupErr) => {
-        app.log.warn({ error: cleanupErr }, "failed to cleanup uploaded attachments");
-      });
-
-      if (convertedGifClaimRestoreFailed) {
-        return reply.code(503).send({
-          message: "视频处理失败且转换凭证无法恢复，请移除视频后重新添加",
-          remoteGifIndexes: remoteGifClaims.map((_, index) => index),
+      // Cleanup is safe only before persistence or after a successful read proved rollback.
+      if (shouldCompensatePostAttachments(postPersistenceState)) {
+        await deleteAttachmentObjects(config, uploadedKeys).catch((cleanupErr) => {
+          app.log.warn({ error: cleanupErr }, "failed to cleanup uploaded attachments");
         });
       }
 
@@ -1137,10 +1211,7 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, _
           message: errorObj.message,
           ...(errorObj.fileIndex !== undefined ? { fileIndex: errorObj.fileIndex } : {}),
           ...(errorObj.remoteGifIndexes
-            && shouldExposeRemoteGifIndexes(
-              convertedGifClaimsRestored,
-              errorObj.permanentRemoteGifFailure,
-            )
+            && shouldExposeRemoteGifIndexes(errorObj.permanentRemoteGifFailure)
             ? { remoteGifIndexes: errorObj.remoteGifIndexes }
             : {}),
         });

--- a/apps/server/src/runtime/onebot.ts
+++ b/apps/server/src/runtime/onebot.ts
@@ -1979,6 +1979,9 @@ export class OneBotRuntime {
           return await fetchPrivatePostImage(resolvedUrl, fileName);
         }
       } catch (error) {
+        if (error instanceof BotWorkflowError && error.statusCode === 413) {
+          throw error;
+        }
         this.logger.debug({ error, botQqUin }, "onebot get_image fallback failed");
       }
     }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -448,27 +448,34 @@ export function App() {
   }
 
   async function submitPost() {
+    if (pendingAttachments.some((p) => p.status === "converting")) {
+      toast.error("请等待视频转换完成后再投稿");
+      return;
+    }
+    if (!validateBeforeUpload()) {
+      return;
+    }
     if (pendingAttachments.some((p) => p.status === "failed")) {
-      toast.error("请移除上传失败的图片后再投稿");
+      toast.error("请移除上传失败的附件后再投稿");
       return;
     }
     if (postText.trim().length === 0) {
       toast.error("正文不能为空");
       return;
     }
-    if (!validateBeforeUpload()) {
-      return;
-    }
     setBusy(true);
     markUploading();
     try {
-      // Local image files only (remote GIF URLs are sent separately)
+      // Local image files only; claimed remote GIFs are sent separately.
       const files = pendingAttachments
         .filter((p) => !p.remoteGifUrl)
         .map((p) => p.file);
-      const remoteGifUrls = pendingAttachments
-        .map((p) => p.remoteGifUrl)
-        .filter((url): url is string => Boolean(url));
+      const remoteGifClaims = pendingAttachments
+        .filter((p) => p.remoteGifUrl)
+        .map((p) => ({ url: p.remoteGifUrl!, proof: p.remoteGifProof ?? "" }));
+      const attachmentOrder = pendingAttachments.map((p) => (
+        p.remoteGifUrl ? "remote" as const : "local" as const
+      ));
       await createPostWithAttachments(
         postText,
         anonymous,
@@ -476,7 +483,8 @@ export function App() {
         (totalPercent) => {
           setProgress(totalPercent);
         },
-        remoteGifUrls.length > 0 ? remoteGifUrls : undefined,
+        remoteGifClaims.length > 0 ? remoteGifClaims : undefined,
+        attachmentOrder,
         postBgColor || undefined,
         postTextColor || undefined,
         postFont || undefined,
@@ -498,9 +506,9 @@ export function App() {
     } catch (caught) {
       const message = caught instanceof Error ? caught.message : "投稿失败";
       if (caught instanceof CreatePostError) {
-        markFailed(caught.fileIndex, message);
+        markFailed(caught.fileIndex, caught.remoteGifIndexes, message);
       } else {
-        markFailed(undefined, message);
+        markFailed(undefined, undefined, message);
       }
       toast.error(message);
     } finally {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,8 +1,12 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { TenantSummary } from "@campux/domain";
 import { toast } from "sonner";
 import { api, createPostWithAttachments, CreatePostError } from "@/lib/api";
 import { canAccess, defaultMetadata, navItems } from "@/lib/app-model";
+import {
+  canAcceptAttachmentSelection,
+  runWhenSubmissionIdle,
+} from "@/lib/attachment-upload-state";
 import { readQueryInt, writeQueryParams } from "@/lib/url-query";
 import type { ActiveBan, AdminTab, AuthenticatedMe, CurrentMembership, MainTab, MeResponse, OAuthAuthorizeClientResponse, Pagination, PostItem, PostsTab, TenantMetadata } from "@/types/app";
 import { usePendingAttachments } from "@/hooks/useUploadImages";
@@ -99,6 +103,7 @@ export function App() {
   const [adminUserDetailTarget, setAdminUserDetailTarget] = useState<{ userId: string; nonce: number } | null>(null);
   const [error, setError] = useState("");
   const [busy, setBusy] = useState(false);
+  const submissionBusyRef = useRef(false);
   const { pending: pendingAttachments, add: addAttachments, remove: removeAttachment, validateBeforeUpload, markUploading, setProgress, markFailed, clearAll: clearAttachments } = usePendingAttachments({
     maxSizeMb: metadata.imageMaxSizeMb,
     compressionEnabled: metadata.imageCompression.enabled,
@@ -440,14 +445,25 @@ export function App() {
     await loadTenantData(1);
   }
 
+  function mutateSubmissionForm(mutation: () => void): boolean {
+    return runWhenSubmissionIdle(submissionBusyRef.current, mutation);
+  }
+
   async function handleUploadFiles(files: ArrayLike<File> | null) {
-    if (!files?.length) {
+    if (!canAcceptAttachmentSelection(submissionBusyRef.current, files?.length ?? 0)) {
       return;
     }
     addAttachments(files);
   }
 
+  function handleRemoveAttachment(attachmentId: string) {
+    mutateSubmissionForm(() => removeAttachment(attachmentId));
+  }
+
   async function submitPost() {
+    if (submissionBusyRef.current) {
+      return;
+    }
     if (pendingAttachments.some((p) => p.status === "converting")) {
       toast.error("请等待视频转换完成后再投稿");
       return;
@@ -463,17 +479,20 @@ export function App() {
       toast.error("正文不能为空");
       return;
     }
+    const submissionAttachments = [...pendingAttachments];
+    const submissionAttachmentIds = new Set(submissionAttachments.map((attachment) => attachment.id));
+    submissionBusyRef.current = true;
     setBusy(true);
-    markUploading();
+    markUploading(submissionAttachmentIds);
     try {
       // Local image files only; claimed remote GIFs are sent separately.
-      const files = pendingAttachments
+      const files = submissionAttachments
         .filter((p) => !p.remoteGifUrl)
         .map((p) => p.file);
-      const remoteGifClaims = pendingAttachments
+      const remoteGifClaims = submissionAttachments
         .filter((p) => p.remoteGifUrl)
         .map((p) => ({ url: p.remoteGifUrl!, proof: p.remoteGifProof ?? "" }));
-      const attachmentOrder = pendingAttachments.map((p) => (
+      const attachmentOrder = submissionAttachments.map((p) => (
         p.remoteGifUrl ? "remote" as const : "local" as const
       ));
       await createPostWithAttachments(
@@ -490,7 +509,7 @@ export function App() {
         postFont || undefined,
         anonymousAvatar || undefined,
       );
-      clearAttachments();
+      clearAttachments(submissionAttachmentIds);
       setPostText("");
       setAnonymous(false);
       setAnonymousAvatar("");
@@ -506,12 +525,18 @@ export function App() {
     } catch (caught) {
       const message = caught instanceof Error ? caught.message : "投稿失败";
       if (caught instanceof CreatePostError) {
-        markFailed(caught.fileIndex, caught.remoteGifIndexes, message);
+        markFailed(
+          caught.fileIndex,
+          caught.remoteGifIndexes,
+          message,
+          submissionAttachments,
+        );
       } else {
-        markFailed(undefined, undefined, message);
+        markFailed(undefined, undefined, message, submissionAttachments);
       }
       toast.error(message);
     } finally {
+      submissionBusyRef.current = false;
       setBusy(false);
     }
   }
@@ -648,16 +673,16 @@ export function App() {
       pendingAttachments={pendingAttachments}
       onActiveTabChange={setActiveTab}
       onAdminTabChange={setAdminSubTab}
-      onAnonymousChange={setAnonymous}
-      onAnonymousAvatarChange={setAnonymousAvatar}
-      onBgColorChange={setPostBgColor}
-      onTextColorChange={setPostTextColor}
-      onFontChange={setPostFont}
+      onAnonymousChange={(value) => mutateSubmissionForm(() => setAnonymous(value))}
+      onAnonymousAvatarChange={(value) => mutateSubmissionForm(() => setAnonymousAvatar(value))}
+      onBgColorChange={(value) => mutateSubmissionForm(() => setPostBgColor(value))}
+      onTextColorChange={(value) => mutateSubmissionForm(() => setPostTextColor(value))}
+      onFontChange={(value) => mutateSubmissionForm(() => setPostFont(value))}
       onFilesSelected={handleUploadFiles}
       onLogout={logout}
       onOpenOps={showOpsUi && canOpenOps(me) ? () => navigate({ kind: "ops" }) : undefined}
       onSelectTenant={selectTenant}
-      onPostTextChange={setPostText}
+      onPostTextChange={(value) => mutateSubmissionForm(() => setPostText(value))}
       onPostsTabChange={setPostsSubTab}
       onRefreshMe={refreshMe}
       adminUserDetailTarget={adminUserDetailTarget}
@@ -666,7 +691,7 @@ export function App() {
       onOpenPostDetailFromAdmin={openPostDetailFromAdmin}
       onPostsPageChange={setPostsPage}
       onRefreshTenantData={() => refreshTenantData(postsPage)}
-      onRemoveAttachment={removeAttachment}
+      onRemoveAttachment={handleRemoveAttachment}
       onSubmitPost={submitPost}
     />
   );

--- a/apps/web/src/features/posts/PostPage.tsx
+++ b/apps/web/src/features/posts/PostPage.tsx
@@ -4,6 +4,7 @@ import type { TenantSummary } from "@campux/domain";
 import { FONT_OPTIONS, IMAGE_UPLOAD_SOURCE_HARD_MAX_SIZE_MB, isDefaultFont } from "@campux/domain";
 import { ChevronDownIcon, ImagePlusIcon, LoaderIcon, MegaphoneIcon, SendIcon } from "lucide-react";
 import { defaultMetadata } from "@/lib/app-model";
+import { canAcceptAttachmentSelection } from "@/lib/attachment-upload-state";
 import { builtInSvgAvatarFilenames } from "@/lib/built-in-svg-avatars";
 import type { PendingAttachment, TenantMetadata } from "@/types/app";
 import { Badge } from "@/components/ui/badge";
@@ -92,6 +93,9 @@ export function PostPage({
   }, [anonymous]);
 
   function pasteImages(event: ClipboardEvent<HTMLTextAreaElement>) {
+    if (!canAcceptAttachmentSelection(busy, event.clipboardData.items.length)) {
+      return;
+    }
     const files = Array.from(event.clipboardData.items)
       .filter((item) => item.kind === "file" && item.type.startsWith("image/"))
       .map((item) => item.getAsFile())
@@ -104,7 +108,7 @@ export function PostPage({
   }
 
   function confirmRemoveAttachment() {
-    if (!attachmentToRemove) {
+    if (busy || !attachmentToRemove) {
       return;
     }
     onRemoveAttachment(attachmentToRemove.id);
@@ -140,6 +144,7 @@ export function PostPage({
           className="min-h-36 w-full resize-none rounded-none border-0 bg-white px-0 py-1 text-base leading-7 text-slate-900 shadow-none placeholder:text-slate-400 focus-visible:ring-0"
           onChange={(event) => onPostTextChange(event.target.value)}
           onPaste={pasteImages}
+          disabled={busy}
         />
 
         <div className="mt-3 flex flex-wrap gap-2">
@@ -147,7 +152,7 @@ export function PostPage({
             <button
               key={item.id}
               className="relative h-[70px] w-[70px] overflow-hidden rounded-md border border-slate-200 bg-slate-100"
-              disabled={item.status === "uploading" || item.status === "converting"}
+              disabled={busy || item.status === "uploading" || item.status === "converting"}
               onClick={() => setAttachmentToRemove(item)}
             >
               {item.originalVideo && item.status === "converting" ? (
@@ -242,6 +247,7 @@ export function PostPage({
                               ? "border-slate-700 bg-slate-700 text-white shadow-sm"
                               : "border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50"
                           }`}
+                          disabled={busy}
                           onClick={() => onBgColorChange(postBgColor === opt.value ? "" : opt.value)}
                         >
                           <span className="inline-block size-3.5 rounded-full border border-slate-200/50" style={{ backgroundColor: opt.hex }} />
@@ -265,6 +271,7 @@ export function PostPage({
                               ? "border-slate-700 bg-slate-700 text-white shadow-sm"
                               : "border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50"
                           }`}
+                          disabled={busy}
                           onClick={() => onTextColorChange(postTextColor === opt.value ? "" : opt.value)}
                         >
                           <span className="inline-block size-3.5 rounded-full border border-slate-200/50" style={{ backgroundColor: opt.hex }} />
@@ -292,6 +299,7 @@ export function PostPage({
                             ? "border-green-500 ring-2 ring-green-200"
                             : "border-slate-200 hover:border-slate-300"
                         }`}
+                        disabled={busy}
                         onClick={() => onAnonymousAvatarChange(anonymousAvatar === filename ? "" : filename)}
                         title={filename.replace(".svg", "")}
                       >
@@ -322,6 +330,7 @@ export function PostPage({
                             ? "border-slate-700 bg-slate-700 text-white shadow-sm"
                             : "border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50"
                         }`}
+                        disabled={busy}
                         onClick={() => onFontChange(postFont === opt.value ? "" : opt.value)}
                         title={opt.label}
                       >
@@ -386,7 +395,7 @@ export function PostPage({
             <Button variant="outline" onClick={() => setAttachmentToRemove(null)}>
               取消
             </Button>
-            <Button variant="destructive" onClick={confirmRemoveAttachment}>
+            <Button variant="destructive" disabled={busy} onClick={confirmRemoveAttachment}>
               {attachmentToRemove?.status === "failed" ? "移除" : "删除"}
             </Button>
           </DialogFooter>

--- a/apps/web/src/features/posts/PostPage.tsx
+++ b/apps/web/src/features/posts/PostPage.tsx
@@ -178,7 +178,7 @@ export function PostPage({
               ) : null}
               {item.status === "failed" ? (
                 <div className="absolute inset-0 flex flex-col items-center justify-center gap-0.5 bg-red-500/35 px-1 text-center text-[11px] font-medium leading-tight text-red-900">
-                  <span>转换失败</span>
+                  <span>无法上传</span>
                   <span className="line-clamp-2 max-w-full break-words font-normal">{item.errorMessage || "请重试"}</span>
                 </div>
               ) : null}

--- a/apps/web/src/hooks/useUploadImages.ts
+++ b/apps/web/src/hooks/useUploadImages.ts
@@ -2,11 +2,17 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { PendingAttachment } from "@/types/app";
 import { uploadVideoToGif, ScdnApiError, SCDN_MAX_VIDEO_SIZE } from "@/lib/scdn-api";
-import { getSelectedImageRejection } from "@/lib/image-upload-policy";
+import { getSelectedImageRejection, getSelectedImageRejections } from "@/lib/image-upload-policy";
+import { applyAttachmentUploadFailure } from "@/lib/attachment-upload-state";
 
 type ConversionJob = {
   attachmentId: string;
   file: File;
+};
+
+type ActiveConversion = {
+  attachmentId: string;
+  controller: AbortController;
 };
 
 export function usePendingAttachments({
@@ -17,78 +23,87 @@ export function usePendingAttachments({
   compressionEnabled: boolean;
 }) {
   const [pending, setPending] = useState<PendingAttachment[]>([]);
-  const blobUrlsRef = useRef<string[]>([]);
+  const ownedBlobUrlsRef = useRef(new Map<string, string>());
   const conversionQueueRef = useRef<ConversionJob[]>([]);
+  const activeConversionRef = useRef<ActiveConversion | null>(null);
   const convertingRef = useRef(false);
+  const unmountedRef = useRef(false);
 
   useEffect(() => {
+    unmountedRef.current = false;
     return () => {
-      for (const url of blobUrlsRef.current) {
+      unmountedRef.current = true;
+      activeConversionRef.current?.controller.abort();
+      activeConversionRef.current = null;
+      conversionQueueRef.current = [];
+      for (const url of ownedBlobUrlsRef.current.values()) {
         URL.revokeObjectURL(url);
       }
-      blobUrlsRef.current = [];
+      ownedBlobUrlsRef.current.clear();
     };
   }, []);
 
   /** Process the next video conversion job in the queue */
   const processNextConversion = useCallback(async () => {
-    if (convertingRef.current || conversionQueueRef.current.length === 0) {
+    if (unmountedRef.current
+      || convertingRef.current
+      || conversionQueueRef.current.length === 0) {
       return;
     }
     convertingRef.current = true;
 
     const job = conversionQueueRef.current.shift()!;
     const { attachmentId, file } = job;
+    const controller = new AbortController();
+    activeConversionRef.current = { attachmentId, controller };
 
     try {
-      // Update status to "converting"
       setPending((current) =>
         current.map((p) =>
           p.id === attachmentId ? { ...p, status: "converting" as const, progress: 0 } : p,
         ),
       );
 
-      // Step 1: Upload video to API → get GIF URL
       const uploadData = await uploadVideoToGif(file, (percent) => {
+        if (controller.signal.aborted || unmountedRef.current) return;
         setPending((current) =>
           current.map((p) =>
             p.id === attachmentId ? { ...p, progress: percent } : p,
           ),
         );
-      });
+      }, controller.signal);
 
-      // Step 2: Keep the GIF URL — the backend will download it from the CDN
-      // (browser fetch is blocked by CORS on the CloudFlare CN CDN domain)
-      const gifBlobUrl = uploadData.url;
+      if (controller.signal.aborted || unmountedRef.current) return;
 
-      // Create a placeholder file so the attachment is trackable
       const gifFile = new File([""], file.name.replace(/\.[^.]+$/, ".gif"), {
         type: "image/gif",
       });
+      const ownedBlobUrl = ownedBlobUrlsRef.current.get(attachmentId);
+      if (ownedBlobUrl) {
+        URL.revokeObjectURL(ownedBlobUrl);
+        ownedBlobUrlsRef.current.delete(attachmentId);
+      }
 
-      // Replace the attachment with the GIF version (remote URL based)
       setPending((current) =>
         current.map((p) =>
           p.id === attachmentId
             ? {
                 ...p,
                 file: gifFile,
-                blobUrl: gifBlobUrl,
+                blobUrl: uploadData.url,
                 status: "ready" as const,
                 progress: 100,
                 originalVideo: file,
                 remoteGifUrl: uploadData.url,
+                remoteGifProof: uploadData.proof,
               }
             : p,
         ),
       );
     } catch (error) {
-      const message =
-        error instanceof ScdnApiError
-          ? error.message
-          : "视频转换失败";
+      if (controller.signal.aborted || unmountedRef.current) return;
+      const message = error instanceof ScdnApiError ? error.message : "视频转换失败";
       toast.error(`视频转换失败：${message}`);
-      // Mark as failed so user can remove it
       setPending((current) =>
         current.map((p) =>
           p.id === attachmentId
@@ -97,9 +112,13 @@ export function usePendingAttachments({
         ),
       );
     } finally {
+      if (activeConversionRef.current?.attachmentId === attachmentId) {
+        activeConversionRef.current = null;
+      }
       convertingRef.current = false;
-      // Process next job in queue
-      processNextConversion();
+      if (!unmountedRef.current) {
+        processNextConversion();
+      }
     }
   }, []);
 
@@ -147,7 +166,7 @@ export function usePendingAttachments({
 
           const id = crypto.randomUUID();
           const blobUrl = URL.createObjectURL(file);
-          blobUrlsRef.current.push(blobUrl);
+          ownedBlobUrlsRef.current.set(id, blobUrl);
 
           accepted.push({
             id,
@@ -181,50 +200,58 @@ export function usePendingAttachments({
   );
 
   const remove = useCallback((id: string) => {
-    setPending((current) => {
-      const item = current.find((p) => p.id === id);
-      if (item) {
-        URL.revokeObjectURL(item.blobUrl);
-        blobUrlsRef.current = blobUrlsRef.current.filter(
-          (url) => url !== item.blobUrl,
-        );
-      }
-      return current.filter((p) => p.id !== id);
-    });
-    // Also remove from conversion queue if pending
+    if (activeConversionRef.current?.attachmentId === id) {
+      activeConversionRef.current.controller.abort();
+    }
+    const ownedBlobUrl = ownedBlobUrlsRef.current.get(id);
+    if (ownedBlobUrl) {
+      URL.revokeObjectURL(ownedBlobUrl);
+      ownedBlobUrlsRef.current.delete(id);
+    }
     conversionQueueRef.current = conversionQueueRef.current.filter(
       (job) => job.attachmentId !== id,
     );
+    setPending((current) => current.filter((p) => p.id !== id));
   }, []);
 
   const validateBeforeUpload = useCallback(() => {
-    let rejected: { item: PendingAttachment; message: string } | null = null;
-    for (const item of pending) {
-      if (item.status !== "ready" || item.originalVideo || item.remoteGifUrl) {
-        continue;
-      }
-      const message = getSelectedImageRejection({
-        fileName: item.file.name,
-        sizeBytes: item.file.size,
-        maxSizeMb,
-        compressionEnabled,
-      });
-      if (message) {
-        rejected = { item, message };
-        break;
-      }
+    const missingClaims = pending.filter((item) =>
+      item.status === "ready" && item.remoteGifUrl && !item.remoteGifProof);
+    if (missingClaims.length > 0) {
+      const missingIds = new Set(missingClaims.map((item) => item.id));
+      const message = "视频转换凭证缺失，请移除后重新添加";
+      setPending((current) => current.map((item) => missingIds.has(item.id)
+        ? { ...item, status: "failed" as const, errorMessage: message, progress: 0 }
+        : item));
+      toast.error(message);
+      return false;
     }
-    if (!rejected) {
+
+    const rejected = getSelectedImageRejections({
+      images: pending
+        .filter((item) => item.status === "ready" && !item.originalVideo && !item.remoteGifUrl)
+        .map((item) => ({
+          id: item.id,
+          fileName: item.file.name,
+          sizeBytes: item.file.size,
+        })),
+      maxSizeMb,
+      compressionEnabled,
+    });
+    if (rejected.length === 0) {
       return true;
     }
 
-    const { item: rejectedItem, message } = rejected;
-    setPending((current) => current.map((item) =>
-      item.id === rejectedItem.id
+    const errorsById = new Map(rejected.map((item) => [item.id, item.message]));
+    setPending((current) => current.map((item) => {
+      const message = errorsById.get(item.id);
+      return message
         ? { ...item, status: "failed" as const, errorMessage: message, progress: 0 }
-        : item,
-    ));
-    toast.error(message);
+        : item;
+    }));
+    toast.error(rejected.length === 1
+      ? rejected[0]!.message
+      : `${rejected.length} 张图片不符合当前上传限制`);
     return false;
   }, [compressionEnabled, maxSizeMb, pending]);
 
@@ -247,31 +274,26 @@ export function usePendingAttachments({
   }, []);
 
   const markFailed = useCallback(
-    (fileIndex: number | undefined, message: string) => {
-      setPending((current) =>
-        current.map((p, index) => {
-          if (fileIndex !== undefined && index === fileIndex) {
-            return { ...p, status: "failed" as const, errorMessage: message };
-          }
-          if (p.status === "uploading") {
-            return { ...p, status: "ready" as const, progress: 0 };
-          }
-          return p;
-        }),
-      );
+    (fileIndex: number | undefined, remoteGifIndexes: number[] | undefined, message: string) => {
+      setPending((current) => applyAttachmentUploadFailure(
+        current,
+        fileIndex,
+        remoteGifIndexes,
+        message,
+      ));
     },
     [],
   );
 
   const clearAll = useCallback(() => {
-    setPending((current) => {
-      for (const item of current) {
-        URL.revokeObjectURL(item.blobUrl);
-      }
-      blobUrlsRef.current = [];
-      return [];
-    });
+    activeConversionRef.current?.controller.abort();
+    activeConversionRef.current = null;
     conversionQueueRef.current = [];
+    for (const url of ownedBlobUrlsRef.current.values()) {
+      URL.revokeObjectURL(url);
+    }
+    ownedBlobUrlsRef.current.clear();
+    setPending([]);
   }, []);
 
   return {

--- a/apps/web/src/hooks/useUploadImages.ts
+++ b/apps/web/src/hooks/useUploadImages.ts
@@ -3,7 +3,12 @@ import { toast } from "sonner";
 import type { PendingAttachment } from "@/types/app";
 import { uploadVideoToGif, ScdnApiError, SCDN_MAX_VIDEO_SIZE } from "@/lib/scdn-api";
 import { getSelectedImageRejection, getSelectedImageRejections } from "@/lib/image-upload-policy";
-import { applyAttachmentUploadFailure } from "@/lib/attachment-upload-state";
+import {
+  applyAttachmentUploadFailure,
+  cleanupAttachmentLifecycle,
+  markAttachmentsUploading,
+  removeAttachmentsById,
+} from "@/lib/attachment-upload-state";
 
 type ConversionJob = {
   attachmentId: string;
@@ -255,14 +260,8 @@ export function usePendingAttachments({
     return false;
   }, [compressionEnabled, maxSizeMb, pending]);
 
-  const markUploading = useCallback(() => {
-    setPending((current) =>
-      current.map((p) => ({
-        ...p,
-        status: "uploading" as const,
-        progress: 0,
-      })),
-    );
+  const markUploading = useCallback((attachmentIds: ReadonlySet<string>) => {
+    setPending((current) => markAttachmentsUploading(current, attachmentIds));
   }, []);
 
   const setProgress = useCallback((totalPercent: number) => {
@@ -274,26 +273,36 @@ export function usePendingAttachments({
   }, []);
 
   const markFailed = useCallback(
-    (fileIndex: number | undefined, remoteGifIndexes: number[] | undefined, message: string) => {
+    (
+      fileIndex: number | undefined,
+      remoteGifIndexes: number[] | undefined,
+      message: string,
+      submissionAttachments: PendingAttachment[],
+    ) => {
       setPending((current) => applyAttachmentUploadFailure(
         current,
         fileIndex,
         remoteGifIndexes,
         message,
+        submissionAttachments,
       ));
     },
     [],
   );
 
-  const clearAll = useCallback(() => {
-    activeConversionRef.current?.controller.abort();
-    activeConversionRef.current = null;
-    conversionQueueRef.current = [];
-    for (const url of ownedBlobUrlsRef.current.values()) {
-      URL.revokeObjectURL(url);
-    }
-    ownedBlobUrlsRef.current.clear();
-    setPending([]);
+  const clearAll = useCallback((attachmentIds?: ReadonlySet<string>) => {
+    const nextLifecycle = cleanupAttachmentLifecycle({
+      activeConversion: activeConversionRef.current,
+      conversionQueue: conversionQueueRef.current,
+      ownedBlobUrls: ownedBlobUrlsRef.current,
+      attachmentIds,
+      revokeObjectUrl: (url) => URL.revokeObjectURL(url),
+    });
+    activeConversionRef.current = nextLifecycle.activeConversion;
+    conversionQueueRef.current = nextLifecycle.conversionQueue;
+    setPending((current) => attachmentIds
+      ? removeAttachmentsById(current, attachmentIds)
+      : []);
   }, []);
 
   return {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -20,13 +20,17 @@ export async function api<T>(path: string, options: RequestInit = {}) {
 
 export class CreatePostError extends Error {
   fileIndex?: number;
+  remoteGifIndexes?: number[];
   status: number;
-  constructor(message: string, status: number, fileIndex?: number) {
+  constructor(message: string, status: number, fileIndex?: number, remoteGifIndexes?: number[]) {
     super(message);
     this.name = "CreatePostError";
     this.status = status;
     if (fileIndex !== undefined) {
       this.fileIndex = fileIndex;
+    }
+    if (remoteGifIndexes) {
+      this.remoteGifIndexes = remoteGifIndexes;
     }
   }
 }
@@ -39,12 +43,18 @@ export function normalizePostFont(font: string | null | undefined): string | und
   return font && !isDefaultFont(font) ? font : undefined;
 }
 
+export type RemoteGifClaim = {
+  url: string;
+  proof: string;
+};
+
 export function createPostWithAttachments(
   text: string,
   anonymous: boolean,
   files: File[],
   onProgress?: (totalPercent: number) => void,
-  remoteGifUrls?: string[],
+  remoteGifClaims?: RemoteGifClaim[],
+  attachmentOrder?: Array<"local" | "remote">,
   bgColor?: string,
   textColor?: string,
   font?: string,
@@ -62,9 +72,13 @@ export function createPostWithAttachments(
     });
 
     xhr.addEventListener("load", () => {
-      let parsed: CreatePostResponse | { message?: string; fileIndex?: number };
+      let parsed: CreatePostResponse | { message?: string; fileIndex?: number; remoteGifIndexes?: number[] };
       try {
-        parsed = JSON.parse(xhr.responseText) as CreatePostResponse | { message?: string; fileIndex?: number };
+        parsed = JSON.parse(xhr.responseText) as CreatePostResponse | {
+          message?: string;
+          fileIndex?: number;
+          remoteGifIndexes?: number[];
+        };
       } catch {
         reject(new CreatePostError(xhr.statusText || `投稿失败：${xhr.status}`, xhr.status));
         return;
@@ -75,8 +89,21 @@ export function createPostWithAttachments(
         return;
       }
 
-      const errorBody = parsed as { message?: string; fileIndex?: number };
-      reject(new CreatePostError(errorBody.message || `投稿失败：${xhr.status}`, xhr.status, errorBody.fileIndex));
+      const errorBody = parsed as { message?: string; fileIndex?: number; remoteGifIndexes?: number[] };
+      const fileIndex = typeof errorBody.fileIndex === "number"
+        && Number.isInteger(errorBody.fileIndex)
+        && errorBody.fileIndex >= 0
+        ? errorBody.fileIndex
+        : undefined;
+      const remoteGifIndexes = Array.isArray(errorBody.remoteGifIndexes)
+        ? errorBody.remoteGifIndexes.filter((value) => Number.isInteger(value) && value >= 0)
+        : undefined;
+      reject(new CreatePostError(
+        errorBody.message || `投稿失败：${xhr.status}`,
+        xhr.status,
+        fileIndex,
+        remoteGifIndexes,
+      ));
     });
 
     xhr.addEventListener("error", () => {
@@ -103,11 +130,14 @@ export function createPostWithAttachments(
     if (normalizedFont) {
       formData.append("font", normalizedFont);
     }
+    if (attachmentOrder) {
+      formData.append("attachmentOrder", JSON.stringify(attachmentOrder));
+    }
     for (const file of files) {
       formData.append("images", file, file.name);
     }
-    if (remoteGifUrls && remoteGifUrls.length > 0) {
-      formData.append("remoteGifUrls", JSON.stringify(remoteGifUrls));
+    if (remoteGifClaims && remoteGifClaims.length > 0) {
+      formData.append("remoteGifClaims", JSON.stringify(remoteGifClaims));
     }
     xhr.send(formData);
   });

--- a/apps/web/src/lib/attachment-upload-state.test.ts
+++ b/apps/web/src/lib/attachment-upload-state.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import type { PendingAttachment } from "@/types/app";
+import { applyAttachmentUploadFailure } from "./attachment-upload-state";
+
+function attachment(id: string, remote = false): PendingAttachment {
+  return {
+    id,
+    file: new File([], `${id}.${remote ? "gif" : "png"}`, {
+      type: remote ? "image/gif" : "image/png",
+    }),
+    blobUrl: `blob:${id}`,
+    kind: "image",
+    sortOrder: 0,
+    progress: 50,
+    status: "uploading",
+    originalVideo: undefined,
+    ...(remote ? {
+      remoteGifUrl: `https://cloudflarecnimg.scdn.io/${id}.gif`,
+      remoteGifProof: "proof",
+    } : {}),
+  };
+}
+
+describe("applyAttachmentUploadFailure", () => {
+  test("maps a local file index within interleaved local and remote attachments", () => {
+    const result = applyAttachmentUploadFailure([
+      attachment("video-first", true),
+      attachment("image-second"),
+      attachment("video-third", true),
+      attachment("image-fourth"),
+    ], 0, undefined, "image failed");
+
+    expect(result.map(({ id, status }) => ({ id, status }))).toEqual([
+      { id: "video-first", status: "ready" },
+      { id: "image-second", status: "failed" },
+      { id: "video-third", status: "ready" },
+      { id: "image-fourth", status: "ready" },
+    ]);
+  });
+
+  test("marks every invalid remote claim by its remote-only index", () => {
+    const result = applyAttachmentUploadFailure([
+      attachment("image-first"),
+      attachment("video-second", true),
+      attachment("image-third"),
+      attachment("video-fourth", true),
+    ], undefined, [0, 1], "claim expired");
+
+    expect(result.map(({ id, status }) => ({ id, status }))).toEqual([
+      { id: "image-first", status: "ready" },
+      { id: "video-second", status: "failed" },
+      { id: "image-third", status: "ready" },
+      { id: "video-fourth", status: "failed" },
+    ]);
+  });
+
+  test("returns uploading attachments to ready when the server restored consumed claims", () => {
+    const result = applyAttachmentUploadFailure([
+      attachment("image-first"),
+      attachment("video-second", true),
+    ], undefined, undefined, "temporary upstream error");
+
+    expect(result.map(({ id, status, progress }) => ({ id, status, progress }))).toEqual([
+      { id: "image-first", status: "ready", progress: 0 },
+      { id: "video-second", status: "ready", progress: 0 },
+    ]);
+  });
+});

--- a/apps/web/src/lib/attachment-upload-state.test.ts
+++ b/apps/web/src/lib/attachment-upload-state.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import type { PendingAttachment } from "@/types/app";
-import { applyAttachmentUploadFailure } from "./attachment-upload-state";
+import {
+  applyAttachmentUploadFailure,
+  canAcceptAttachmentSelection,
+  cleanupAttachmentLifecycle,
+  markAttachmentsUploading,
+  removeAttachmentsById,
+  runWhenSubmissionIdle,
+} from "./attachment-upload-state";
 
 function attachment(id: string, remote = false): PendingAttachment {
   return {
@@ -54,7 +61,7 @@ describe("applyAttachmentUploadFailure", () => {
     ]);
   });
 
-  test("returns uploading attachments to ready when the server restored consumed claims", () => {
+  test("returns uploading attachments to ready after a transient submission failure", () => {
     const result = applyAttachmentUploadFailure([
       attachment("image-first"),
       attachment("video-second", true),
@@ -64,5 +71,101 @@ describe("applyAttachmentUploadFailure", () => {
       { id: "image-first", status: "ready", progress: 0 },
       { id: "video-second", status: "ready", progress: 0 },
     ]);
+  });
+
+  test("maps failure indexes against the immutable submission snapshot", () => {
+    const submitted = [attachment("submitted-local"), attachment("submitted-remote", true)];
+    const late = { ...attachment("late-local"), status: "ready" as const };
+    const result = applyAttachmentUploadFailure(
+      [late, ...submitted],
+      0,
+      undefined,
+      "submitted image failed",
+      submitted,
+    );
+
+    expect(result.map(({ id, status }) => ({ id, status }))).toEqual([
+      { id: "late-local", status: "ready" },
+      { id: "submitted-local", status: "failed" },
+      { id: "submitted-remote", status: "ready" },
+    ]);
+  });
+});
+
+describe("submission attachment isolation", () => {
+  test("rejects attachment input while a submission is busy", () => {
+    expect(canAcceptAttachmentSelection(true, 1)).toBe(false);
+    expect(canAcceptAttachmentSelection(false, 0)).toBe(false);
+    expect(canAcceptAttachmentSelection(false, 1)).toBe(true);
+  });
+
+  test("drops stale mutation callbacks while a submission is busy", () => {
+    const values: string[] = [];
+
+    expect(runWhenSubmissionIdle(true, () => values.push("stale"))).toBe(false);
+    expect(runWhenSubmissionIdle(false, () => values.push("accepted"))).toBe(true);
+    expect(values).toEqual(["accepted"]);
+  });
+
+  test("removes only attachments captured in the successful submission snapshot", () => {
+    const result = removeAttachmentsById([
+      attachment("submitted-image"),
+      attachment("late-paste"),
+    ], new Set(["submitted-image"]));
+
+    expect(result.map(({ id }) => id)).toEqual(["late-paste"]);
+  });
+
+  test("marks only snapshot attachments as uploading", () => {
+    const submitted = { ...attachment("submitted-image"), status: "ready" as const };
+    const late = { ...attachment("late-image"), status: "ready" as const };
+    const result = markAttachmentsUploading(
+      [submitted, late],
+      new Set([submitted.id]),
+    );
+
+    expect(result.map(({ id, status }) => ({ id, status }))).toEqual([
+      { id: "submitted-image", status: "uploading" },
+      { id: "late-image", status: "ready" },
+    ]);
+  });
+
+  test("selective cleanup preserves later active conversion, queue entry, and blob URL", () => {
+    const aborted: string[] = [];
+    const revoked: string[] = [];
+    const activeConversion = {
+      attachmentId: "late-active",
+      controller: { abort: () => aborted.push("late-active") },
+    };
+    const submittedQueued = {
+      attachmentId: "submitted-queued",
+      file: new File([], "submitted.mp4"),
+    };
+    const lateQueued = {
+      attachmentId: "late-queued",
+      file: new File([], "late.mp4"),
+    };
+    const ownedBlobUrls = new Map([
+      ["submitted-queued", "blob:submitted"],
+      ["late-active", "blob:late-active"],
+      ["late-queued", "blob:late-queued"],
+    ]);
+
+    const result = cleanupAttachmentLifecycle({
+      activeConversion,
+      conversionQueue: [submittedQueued, lateQueued],
+      ownedBlobUrls,
+      attachmentIds: new Set(["submitted-queued"]),
+      revokeObjectUrl: (url) => revoked.push(url),
+    });
+
+    expect(result.activeConversion).toBe(activeConversion);
+    expect(result.conversionQueue.map(({ attachmentId }) => attachmentId)).toEqual(["late-queued"]);
+    expect([...ownedBlobUrls.entries()]).toEqual([
+      ["late-active", "blob:late-active"],
+      ["late-queued", "blob:late-queued"],
+    ]);
+    expect(aborted).toEqual([]);
+    expect(revoked).toEqual(["blob:submitted"]);
   });
 });

--- a/apps/web/src/lib/attachment-upload-state.ts
+++ b/apps/web/src/lib/attachment-upload-state.ts
@@ -1,0 +1,31 @@
+import type { PendingAttachment } from "@/types/app";
+
+export function applyAttachmentUploadFailure(
+  attachments: PendingAttachment[],
+  fileIndex: number | undefined,
+  remoteGifIndexes: number[] | undefined,
+  message: string,
+): PendingAttachment[] {
+  const failedRemoteIndexes = new Set(remoteGifIndexes ?? []);
+  let localIndex = 0;
+  let remoteIndex = 0;
+
+  return attachments.map((attachment) => {
+    const isRemoteGif = Boolean(attachment.remoteGifUrl);
+    const isFailedAttachment = isRemoteGif
+      ? failedRemoteIndexes.has(remoteIndex++)
+      : fileIndex !== undefined && localIndex++ === fileIndex;
+    if (isFailedAttachment) {
+      return {
+        ...attachment,
+        status: "failed",
+        errorMessage: message,
+        progress: 0,
+      };
+    }
+    if (attachment.status === "uploading") {
+      return { ...attachment, status: "ready", progress: 0 };
+    }
+    return attachment;
+  });
+}

--- a/apps/web/src/lib/attachment-upload-state.ts
+++ b/apps/web/src/lib/attachment-upload-state.ts
@@ -1,21 +1,56 @@
 import type { PendingAttachment } from "@/types/app";
 
+export function canAcceptAttachmentSelection(busy: boolean, fileCount: number): boolean {
+  return !busy && fileCount > 0;
+}
+
+export function runWhenSubmissionIdle(busy: boolean, mutation: () => void): boolean {
+  if (busy) return false;
+  mutation();
+  return true;
+}
+
+export function removeAttachmentsById(
+  attachments: PendingAttachment[],
+  attachmentIds: ReadonlySet<string>,
+): PendingAttachment[] {
+  return attachments.filter((attachment) => !attachmentIds.has(attachment.id));
+}
+
+export function markAttachmentsUploading(
+  attachments: PendingAttachment[],
+  attachmentIds: ReadonlySet<string>,
+): PendingAttachment[] {
+  return attachments.map((attachment) => attachmentIds.has(attachment.id)
+    ? { ...attachment, status: "uploading" as const, progress: 0 }
+    : attachment);
+}
+
 export function applyAttachmentUploadFailure(
   attachments: PendingAttachment[],
   fileIndex: number | undefined,
   remoteGifIndexes: number[] | undefined,
   message: string,
+  submissionAttachments: PendingAttachment[] = attachments,
 ): PendingAttachment[] {
   const failedRemoteIndexes = new Set(remoteGifIndexes ?? []);
+  const failedAttachmentIds = new Set<string>();
+  const submissionAttachmentIds = new Set(submissionAttachments.map(({ id }) => id));
   let localIndex = 0;
   let remoteIndex = 0;
 
-  return attachments.map((attachment) => {
+  for (const attachment of submissionAttachments) {
     const isRemoteGif = Boolean(attachment.remoteGifUrl);
     const isFailedAttachment = isRemoteGif
       ? failedRemoteIndexes.has(remoteIndex++)
       : fileIndex !== undefined && localIndex++ === fileIndex;
     if (isFailedAttachment) {
+      failedAttachmentIds.add(attachment.id);
+    }
+  }
+
+  return attachments.map((attachment) => {
+    if (failedAttachmentIds.has(attachment.id)) {
       return {
         ...attachment,
         status: "failed",
@@ -23,9 +58,60 @@ export function applyAttachmentUploadFailure(
         progress: 0,
       };
     }
-    if (attachment.status === "uploading") {
+    if (submissionAttachmentIds.has(attachment.id) && attachment.status === "uploading") {
       return { ...attachment, status: "ready", progress: 0 };
     }
     return attachment;
   });
+}
+
+type ActiveConversionLike = {
+  attachmentId: string;
+  controller: { abort: () => void };
+};
+
+type ConversionJobLike = {
+  attachmentId: string;
+};
+
+export function cleanupAttachmentLifecycle<
+  Active extends ActiveConversionLike,
+  Job extends ConversionJobLike,
+>({
+  activeConversion,
+  conversionQueue,
+  ownedBlobUrls,
+  attachmentIds,
+  revokeObjectUrl,
+}: {
+  activeConversion: Active | null;
+  conversionQueue: Job[];
+  ownedBlobUrls: Map<string, string>;
+  attachmentIds: ReadonlySet<string> | undefined;
+  revokeObjectUrl: (url: string) => void;
+}): {
+  activeConversion: Active | null;
+  conversionQueue: Job[];
+} {
+  const shouldCleanup = (attachmentId: string) => !attachmentIds || attachmentIds.has(attachmentId);
+  let nextActiveConversion = activeConversion;
+
+  if (activeConversion && shouldCleanup(activeConversion.attachmentId)) {
+    activeConversion.controller.abort();
+    nextActiveConversion = null;
+  }
+
+  const nextConversionQueue = conversionQueue.filter(
+    (job) => !shouldCleanup(job.attachmentId),
+  );
+  for (const [attachmentId, url] of ownedBlobUrls) {
+    if (!shouldCleanup(attachmentId)) continue;
+    revokeObjectUrl(url);
+    ownedBlobUrls.delete(attachmentId);
+  }
+
+  return {
+    activeConversion: nextActiveConversion,
+    conversionQueue: nextConversionQueue,
+  };
 }

--- a/apps/web/src/lib/image-upload-policy.test.ts
+++ b/apps/web/src/lib/image-upload-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getSelectedImageRejection, normalizeImageMaxSizeDraft } from "./image-upload-policy";
+import { getSelectedImageRejection, getSelectedImageRejections, normalizeImageMaxSizeDraft } from "./image-upload-policy";
 
 describe("getSelectedImageRejection", () => {
   test("uses the tenant limit immediately when automatic compression is disabled", () => {
@@ -27,6 +27,21 @@ describe("getSelectedImageRejection", () => {
       maxSizeMb: 10,
       compressionEnabled: true,
     })).toBe("huge.jpg 原图超过 50MB，无法自动压缩");
+  });
+
+  test("returns every image invalidated by a tenant-limit change", () => {
+    expect(getSelectedImageRejections({
+      images: [
+        { id: "first", fileName: "first.png", sizeBytes: 6 * 1024 * 1024 },
+        { id: "second", fileName: "second.jpg", sizeBytes: 7 * 1024 * 1024 },
+        { id: "valid", fileName: "valid.webp", sizeBytes: 4 * 1024 * 1024 },
+      ],
+      maxSizeMb: 5,
+      compressionEnabled: false,
+    })).toEqual([
+      { id: "first", message: "first.png 超过 5MB 限制" },
+      { id: "second", message: "second.jpg 超过 5MB 限制" },
+    ]);
   });
 });
 

--- a/apps/web/src/lib/image-upload-policy.ts
+++ b/apps/web/src/lib/image-upload-policy.ts
@@ -34,3 +34,23 @@ export function getSelectedImageRejection({
   }
   return null;
 }
+
+export function getSelectedImageRejections({
+  images,
+  maxSizeMb,
+  compressionEnabled,
+}: {
+  images: Array<{ id: string; fileName: string; sizeBytes: number }>;
+  maxSizeMb: number;
+  compressionEnabled: boolean;
+}): Array<{ id: string; message: string }> {
+  return images.flatMap((image) => {
+    const message = getSelectedImageRejection({
+      fileName: image.fileName,
+      sizeBytes: image.sizeBytes,
+      maxSizeMb,
+      compressionEnabled,
+    });
+    return message ? [{ id: image.id, message }] : [];
+  });
+}

--- a/apps/web/src/lib/scdn-api.test.ts
+++ b/apps/web/src/lib/scdn-api.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ScdnApiError, uploadVideoToGif } from "./scdn-api";
+
+class FakeXMLHttpRequest {
+  static latest: FakeXMLHttpRequest | null = null;
+
+  readonly upload = {
+    addEventListener: () => undefined,
+  };
+  readonly listeners = new Map<string, () => void>();
+  status = 0;
+  statusText = "";
+  responseText = "";
+  timeout = 0;
+  withCredentials = false;
+  aborted = false;
+
+  constructor() {
+    FakeXMLHttpRequest.latest = this;
+  }
+
+  open() {}
+  send() {}
+
+  addEventListener(type: string, listener: () => void) {
+    this.listeners.set(type, listener);
+  }
+
+  abort() {
+    this.aborted = true;
+    this.listeners.get("abort")?.();
+  }
+}
+
+const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "XMLHttpRequest");
+
+beforeEach(() => {
+  FakeXMLHttpRequest.latest = null;
+  Object.defineProperty(globalThis, "XMLHttpRequest", {
+    configurable: true,
+    writable: true,
+    value: FakeXMLHttpRequest,
+  });
+});
+
+afterEach(() => {
+  if (originalDescriptor) {
+    Object.defineProperty(globalThis, "XMLHttpRequest", originalDescriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, "XMLHttpRequest");
+  }
+});
+
+describe("uploadVideoToGif", () => {
+  test("aborts the active XHR and rejects without waiting for a response", async () => {
+    const controller = new AbortController();
+    const upload = uploadVideoToGif(
+      new File(["video"], "clip.mp4", { type: "video/mp4" }),
+      undefined,
+      controller.signal,
+    );
+
+    controller.abort();
+
+    expect(FakeXMLHttpRequest.latest?.aborted).toBe(true);
+    await expect(upload).rejects.toEqual(expect.objectContaining({
+      name: ScdnApiError.name,
+      message: "上传已取消",
+    }));
+  });
+});

--- a/apps/web/src/lib/scdn-api.ts
+++ b/apps/web/src/lib/scdn-api.ts
@@ -1,15 +1,12 @@
 /**
- * 失控图床 API 客户端
+ * Campux video-to-GIF upload client.
  *
- * API 端点: https://img.scdn.io/api/v1.php
- *
- * 将视频上传至失控图床，服务端自动转码为 GIF 并返回外链。
- * 前端下载 GIF 后作为普通附件参与投稿流程。
+ * The browser uploads the source video to Campux. The server validates the
+ * media, calls the external converter, and returns a short-lived claim bound
+ * to the current session, user, and tenant.
  */
 
-const API_BASE = "https://img.scdn.io/api/v1.php";
-
-/** 失控图床对视频文件的尺寸限制 */
+/** External converter source-video limit, also enforced by Campux. */
 export const SCDN_MAX_VIDEO_SIZE = 15 * 1024 * 1024; // 15MB
 
 export class ScdnApiError extends Error {
@@ -19,97 +16,98 @@ export class ScdnApiError extends Error {
   }
 }
 
-/** 上传成功响应的 data 部分 */
 export interface ScdnUploadData {
   url: string;
-  filename: string;
-  storage_backend: "local" | "telegram" | "r2";
-  original_size?: number;
-  compressed_size?: number;
-  compression_ratio?: number;
+  proof: string;
+}
+
+type VideoGifUploadResponse = {
+  url?: string;
+  proof?: string;
   message?: string;
-}
+};
 
-/** 上传成功响应 */
-export interface ScdnUploadResponse {
-  success: true;
-  url: string;
-  data: ScdnUploadData;
-  message?: string;
-}
-
-/** 上传失败响应 */
-export interface ScdnErrorResponse {
-  success: false;
-  error: string;
-  message: string;
-}
-
-export type ScdnResponse = ScdnUploadResponse | ScdnErrorResponse;
-
-/**
- * 将视频文件上传至失控图床，服务端自动转为 GIF。
- *
- * @param file - 视频文件（≤ 15MB）
- * @param onProgress - 上传进度回调（0-100）
- * @returns 上传成功后的 data 对象（含 GIF 外链 url）
- */
+/** Upload a video to Campux for validated server-side GIF conversion. */
 export async function uploadVideoToGif(
   file: File,
   onProgress?: (percent: number) => void,
+  signal?: AbortSignal,
 ): Promise<ScdnUploadData> {
   if (file.size > SCDN_MAX_VIDEO_SIZE) {
     throw new ScdnApiError(
-      `视频超过 ${SCDN_MAX_VIDEO_SIZE / 1024 / 1024}MB 限制（失控图床限制）`,
+      `视频超过 ${SCDN_MAX_VIDEO_SIZE / 1024 / 1024}MB 限制（转换服务限制）`,
     );
   }
 
   const formData = new FormData();
-  formData.append("image", file);
-  formData.append("outputFormat", "gif");
-  formData.append("cdn_domain", "cloudflarecnimg.scdn.io");
-  formData.append("storage_destination", "telegram");
+  formData.append("video", file, file.name);
 
-  const data = await new Promise<ScdnResponse>((resolve, reject) => {
+  return new Promise<ScdnUploadData>((resolve, reject) => {
     const xhr = new XMLHttpRequest();
-    xhr.open("POST", API_BASE);
+    let settled = false;
+    const handleSignalAbort = () => xhr.abort();
+    const cleanup = () => signal?.removeEventListener("abort", handleSignalAbort);
+    const resolveOnce = (data: ScdnUploadData) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(data);
+    };
+    const rejectOnce = (error: ScdnApiError) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+
+    if (signal?.aborted) {
+      rejectOnce(new ScdnApiError("上传已取消"));
+      return;
+    }
+    signal?.addEventListener("abort", handleSignalAbort, { once: true });
+
+    xhr.open("POST", "/api/uploads/video-gif");
+    xhr.withCredentials = true;
+    xhr.timeout = 120_000;
 
     xhr.upload.addEventListener("progress", (event) => {
-      if (event.lengthComputable && onProgress) {
+      if (!signal?.aborted && event.lengthComputable && onProgress) {
         onProgress(Math.round((event.loaded / event.total) * 100));
       }
     });
 
     xhr.addEventListener("load", () => {
+      let parsed: VideoGifUploadResponse;
       try {
-        const parsed = JSON.parse(xhr.responseText) as ScdnResponse;
-        resolve(parsed);
+        parsed = JSON.parse(xhr.responseText) as VideoGifUploadResponse;
       } catch {
-        reject(new ScdnApiError(`解析响应失败：${xhr.statusText || xhr.status}`));
+        rejectOnce(new ScdnApiError(`解析响应失败：${xhr.statusText || xhr.status}`));
+        return;
       }
+
+      if (xhr.status < 200 || xhr.status >= 300) {
+        rejectOnce(new ScdnApiError(parsed.message || `视频转换失败：${xhr.status}`));
+        return;
+      }
+      if (typeof parsed.url !== "string" || typeof parsed.proof !== "string") {
+        rejectOnce(new ScdnApiError("视频转换服务未返回有效凭证"));
+        return;
+      }
+      resolveOnce({ url: parsed.url, proof: parsed.proof });
     });
 
     xhr.addEventListener("error", () => {
-      reject(new ScdnApiError("网络错误，上传至图床失败"));
+      rejectOnce(new ScdnApiError("网络错误，视频转换失败"));
+    });
+
+    xhr.addEventListener("timeout", () => {
+      rejectOnce(new ScdnApiError("视频转换超时，请重试"));
     });
 
     xhr.addEventListener("abort", () => {
-      reject(new ScdnApiError("上传已取消"));
+      rejectOnce(new ScdnApiError("上传已取消"));
     });
 
     xhr.send(formData);
   });
-
-  if (!data.success) {
-    throw new ScdnApiError(data.message || data.error || "图床上传失败");
-  }
-
-  return data.data;
 }
-
-/**
- * GIF 下载由后端服务器完成（避免浏览器 CDN CORS 限制），
- * 前端仅需将图床返回的 GIF URL 通过投稿接口传给后端。
- *
- * @see POST /api/posts — 使用 remoteGifUrls 字段
- */

--- a/apps/web/src/types/app.ts
+++ b/apps/web/src/types/app.ts
@@ -153,8 +153,10 @@ export type PendingAttachment = {
   errorMessage?: string;
   /** Original video file before GIF conversion (if attachment started as video) */
   originalVideo: File | undefined;
-  /** Remote GIF URL from 失控图床 API (if converted via external API) */
+  /** Remote GIF URL returned by the validated server-side converter. */
   remoteGifUrl?: string;
+  /** Short-lived server claim authorizing the converted GIF URL. */
+  remoteGifProof?: string;
 };
 
 export type PostItem = {


### PR DESCRIPTION
## Summary

Follow-up hardening for #137:

- enforce tenant-aware image limits consistently across upload, storage, and publisher paths
- harden video-to-GIF conversion with bounded multipart parsing, process/network/memory limits, no redirects, and global/per-user concurrency controls
- install Alpine `ffmpeg` in the runtime image so the server's `ffprobe`/`ffmpeg` subprocesses exist in production, with a runtime-stage regression test
- issue session-bound HMAC claims backed by durable single-use storage
- reject already-consumed/replayed converted-GIF claims before remote ingestion without consuming valid claims
- consume converted-GIF claims inside the same Serializable Prisma transaction as post creation; mixed or unavailable claims roll back atomically and return precise remote-only indexes
- reconcile ambiguous commit acknowledgements by a stable candidate post ID and compensate uploaded objects only when rollback is positively known
- preserve mixed attachment ordering and map failures against an immutable submission snapshot
- synchronously block stale file-picker/dialog/form callbacks while submitting, then clear only submitted attachments while preserving later XHR/queue/blob state

## Verification

- `bun run typecheck`
- `bun test` — 408 passed, 5 skipped, 0 failed
- multipart regression tests cover file-only, file + trailing field, file + trailing file, field-first, missing file, invalid MIME, and byte-cap rejection
- transaction harness covers claim/post rollback, mixed unavailable claims, non-consuming replay preflight, and no nested claim transaction
- frontend lifecycle harness covers stale mutation rejection, immutable failure-index mapping, snapshot-only uploading/cleanup, and preservation of later active conversion/queue/blob URLs
- `git diff --check`
- production stale-path and added-line secret/debug scans — no findings
- independent fail-closed backend and frontend reviews after final remediation — PASS, 0 blockers
