### PR TITLE
fix(web): restore dark post card contrast

### DIFF
--- a/apps/web/src/features/posts/PostsPage.tsx
+++ b/apps/web/src/features/posts/PostsPage.tsx
@@ -1686,7 +1686,7 @@ function ReviewCard({
   const cardTextColor = postCardTextColor(post.textColor);
 
   return (
-    <Card className={`overflow-hidden rounded-md border shadow-none ${palette}`} style={cardBg ? { background: cardBg.replace("background: ", "") } : undefined}>
+    <Card className={`post-themed-surface overflow-hidden rounded-md border shadow-none ${palette}`} style={cardBg ? { background: cardBg.replace("background: ", "") } : undefined}>
       <CardContent className="grid gap-2 p-2.5 md:gap-3 md:p-3">
         <PostMetaHeader
           displayId={`稿件 ${post.displayId}`}
@@ -1848,7 +1848,7 @@ function PostCard({
   const cardTextColor = postCardTextColor(post.textColor);
 
   return (
-    <Card className={`overflow-hidden rounded-md border shadow-none ${palette}`} style={cardBg ? { background: cardBg.replace("background: ", "") } : undefined}>
+    <Card className={`post-themed-surface overflow-hidden rounded-md border shadow-none ${palette}`} style={cardBg ? { background: cardBg.replace("background: ", "") } : undefined}>
       <CardContent className="grid gap-2 p-2.5 md:gap-3 md:p-3">
         <PostMetaHeader
           displayId={post.displayId}
@@ -2128,7 +2128,7 @@ function PublishedFeedPostBlock({
   const cardBg = postCardBgStyle(post.bgColor);
   const cardTextColor = postCardTextColor(post.textColor);
   return (
-    <div className="grid gap-2" style={cardBg ? { background: cardBg.replace("background: ", "") } : undefined}>
+    <div className="post-themed-surface grid gap-2" style={cardBg ? { background: cardBg.replace("background: ", "") } : undefined}>
       <div className="flex flex-wrap items-center gap-2">
         <span className="inline-flex items-center rounded bg-sky-50 px-1.5 py-0.5 text-xs font-bold text-sky-700">稿件 {post.displayId}</span>
       </div>
@@ -2189,7 +2189,7 @@ function PostTextBlock({ text, createdAt, updatedAt, compact = false, textColor 
   if (compact) {
     if (enableMarkdown) {
       return (
-        <div className="rounded-md border border-slate-100 bg-slate-50/70 px-2.5 py-2" style={textColor ? { color: textColor } : undefined}>
+        <div className="post-themed-text rounded-md border border-slate-100 bg-slate-50/70 px-2.5 py-2" style={textColor ? { color: textColor } : undefined}>
           <div className="mb-1 flex flex-wrap items-center gap-2 text-[11px] font-semibold text-slate-500">
             <span className="inline-flex items-center gap-1">
               <FileTextIcon className="size-3" />
@@ -2201,12 +2201,12 @@ function PostTextBlock({ text, createdAt, updatedAt, compact = false, textColor 
             </span>
             {updatedAt && updatedAt !== createdAt ? <span className="hidden sm:inline">更新 {formatFullDateTime(updatedAt)}</span> : null}
           </div>
-          <div className="markdown-content line-clamp-3 text-sm font-medium leading-5 md:line-clamp-4" style={textColor ? { color: textColor } : undefined} dangerouslySetInnerHTML={{ __html: renderMarkdown(text) }} />
+          <div className="post-themed-text markdown-content line-clamp-3 text-sm font-medium leading-5 md:line-clamp-4" style={textColor ? { color: textColor } : undefined} dangerouslySetInnerHTML={{ __html: renderMarkdown(text) }} />
         </div>
       );
     }
     return (
-      <div className="rounded-md border border-slate-100 bg-slate-50/70 px-2.5 py-2" style={textColor ? { color: textColor } : undefined}>
+      <div className="post-themed-text rounded-md border border-slate-100 bg-slate-50/70 px-2.5 py-2" style={textColor ? { color: textColor } : undefined}>
         <div className="mb-1 flex flex-wrap items-center gap-2 text-[11px] font-semibold text-slate-500">
           <span className="inline-flex items-center gap-1">
             <FileTextIcon className="size-3" />
@@ -2218,7 +2218,7 @@ function PostTextBlock({ text, createdAt, updatedAt, compact = false, textColor 
           </span>
           {updatedAt && updatedAt !== createdAt ? <span className="hidden sm:inline">更新 {formatFullDateTime(updatedAt)}</span> : null}
         </div>
-        <p className="line-clamp-3 whitespace-pre-wrap text-sm font-medium leading-5 md:line-clamp-4" style={textColor ? { color: textColor } : undefined}>{text}</p>
+        <p className="post-themed-text line-clamp-3 whitespace-pre-wrap text-sm font-medium leading-5 md:line-clamp-4" style={textColor ? { color: textColor } : undefined}>{text}</p>
       </div>
     );
   }
@@ -2237,7 +2237,7 @@ function PostTextBlock({ text, createdAt, updatedAt, compact = false, textColor 
           </span>
           {updatedAt && updatedAt !== createdAt ? <span>更新 {formatFullDateTime(updatedAt)}</span> : null}
         </div>
-        <div className="markdown-content text-[15px] font-medium leading-7" style={textColor ? { color: textColor } : undefined} dangerouslySetInnerHTML={{ __html: renderMarkdown(text) }} />
+        <div className="post-themed-text markdown-content text-[15px] font-medium leading-7" style={textColor ? { color: textColor } : undefined} dangerouslySetInnerHTML={{ __html: renderMarkdown(text) }} />
       </div>
     );
   }
@@ -2255,7 +2255,7 @@ function PostTextBlock({ text, createdAt, updatedAt, compact = false, textColor 
         </span>
         {updatedAt && updatedAt !== createdAt ? <span>更新 {formatFullDateTime(updatedAt)}</span> : null}
       </div>
-      <p className="whitespace-pre-wrap text-[15px] font-medium leading-7" style={textColor ? { color: textColor } : undefined}>{text}</p>
+      <p className="post-themed-text whitespace-pre-wrap text-[15px] font-medium leading-7" style={textColor ? { color: textColor } : undefined}>{text}</p>
     </div>
   );
 }

--- a/apps/web/src/features/posts/post-card-theme.test.ts
+++ b/apps/web/src/features/posts/post-card-theme.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./PostsPage.tsx", import.meta.url), "utf8");
+const styles = readFileSync(new URL("../../styles.css", import.meta.url), "utf8");
+
+describe("post card custom colors in dark mode", () => {
+  test("marks every author-colored card surface for a dark-mode override", () => {
+    const customBackgroundUses = source.match(/style=\{cardBg \?/g) ?? [];
+    const themedSurfaceUses = source.match(/post-themed-surface/g) ?? [];
+
+    expect(customBackgroundUses.length).toBeGreaterThan(0);
+    expect(themedSurfaceUses).toHaveLength(customBackgroundUses.length);
+    expect(styles).toMatch(/\.dark \.post-themed-surface\s*\{[^}]*background:/s);
+    expect(styles).toMatch(/\.dark \.post-themed-surface\s*\{[^}]*!important/s);
+  });
+
+  test("marks custom post text so its light-mode color cannot reduce dark-mode contrast", () => {
+    const customTextUses = source.match(/style=\{textColor \?/g) ?? [];
+    const themedTextUses = source.match(/post-themed-text/g) ?? [];
+
+    expect(customTextUses.length).toBeGreaterThan(0);
+    expect(themedTextUses).toHaveLength(customTextUses.length);
+    expect(styles).toMatch(/\.dark \.post-themed-text\s*\{[^}]*color:/s);
+    expect(styles).toMatch(/\.dark \.post-themed-text\s*\{[^}]*!important/s);
+  });
+});

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -396,6 +396,15 @@
   background: oklch(0.215 0.018 255);
 }
 
+/* 投稿配色只用于亮色预览；暗色模式统一回到可读的主题表面与前景色。 */
+.dark .post-themed-surface {
+  background: var(--card) !important;
+}
+
+.dark .post-themed-text {
+  color: var(--card-foreground) !important;
+}
+
 .dark .product-subsection {
   border-color: oklch(0.34 0.018 255);
   background: oklch(0.245 0.018 255);


### PR DESCRIPTION
## 问题
投稿选择背景色或文字色后，列表卡片通过 inline style 固定为亮色背景/深色文字；这些 inline style 的优先级高于暗色主题，导致卡片与辅助信息对比度异常。

## 修复
- 暗色模式下统一覆盖投稿自定义卡片背景为主题 card surface
- 暗色模式下统一覆盖投稿自定义文字为 card foreground
- 覆盖审核稿件、你的稿件和已发布稿件三处展示
- 亮色模式仍保留投稿者选择的背景色和文字色

## 验证
- `bun test apps/web/src`：41 pass
- `bun --cwd apps/web typecheck`
- `bun --cwd apps/web build`
- headless Chromium before/after 视觉验证通过

Fixes #142

## Summary by Sourcery

在保持作者自定义帖子卡片在浅色模式外观不变的前提下，恢复深色模式下的对比度。

Bug Fixes:
- 当作者自定义背景或文字颜色时，恢复深色模式下帖子卡片和帖子文本的可读对比度。

Enhancements:
- 在浅色模式中保留作者选择的帖子颜色，同时在审阅、个人和已发布帖子视图中，为深色模式统一应用主题卡片颜色。

Tests:
- 增加测试覆盖，验证所有自定义配色的帖子表面和文本在深色模式下都能正确应用主题覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore dark-mode contrast for author-customized post cards while preserving their appearance in light mode.

Bug Fixes:
- Restore readable contrast for post cards and post text in dark mode when authors customize background or text colors.

Enhancements:
- Preserve author-selected post colors in light mode while applying theme card colors in dark mode across review, personal, and published post views.

Tests:
- Add coverage verifying all custom-colored post surfaces and text receive dark-mode theme overrides.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持作者自定义帖子卡片在浅色模式外观不变的前提下，恢复深色模式下的对比度。

Bug Fixes:
- 当作者自定义背景或文字颜色时，恢复深色模式下帖子卡片和帖子文本的可读对比度。

Enhancements:
- 在浅色模式中保留作者选择的帖子颜色，同时在审阅、个人和已发布帖子视图中，为深色模式统一应用主题卡片颜色。

Tests:
- 增加测试覆盖，验证所有自定义配色的帖子表面和文本在深色模式下都能正确应用主题覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore dark-mode contrast for author-customized post cards while preserving their appearance in light mode.

Bug Fixes:
- Restore readable contrast for post cards and post text in dark mode when authors customize background or text colors.

Enhancements:
- Preserve author-selected post colors in light mode while applying theme card colors in dark mode across review, personal, and published post views.

Tests:
- Add coverage verifying all custom-colored post surfaces and text receive dark-mode theme overrides.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dark-mode display for posts with custom background and text colors.
  * Ensured themed post cards use consistent dark-mode backgrounds and readable text.
* **Tests**
  * Added coverage verifying theme-specific styling and dark-mode overrides for post cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->