### PR TITLE
feat(ops): show live tenant bot and publish status

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -113,7 +113,7 @@ registerPostTagRoutes(app);
 registerReviewRoutes(app, queue, oneBot);
 registerSvgRoutes(app);
 registerStatsRoutes(app);
-registerSystemRoutes(app, queue, config);
+registerSystemRoutes(app, queue, config, oneBot);
 registerPluginRoutes(app, pluginRegistry);
 
 // 通知所有插件路由已注册完毕

--- a/apps/server/src/routes/system-tenant-runtime.test.ts
+++ b/apps/server/src/routes/system-tenant-runtime.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { toSystemTenant } from "./system";
+
+describe("toSystemTenant runtime status", () => {
+  test("serializes live OneBot connections and QZone target readiness", () => {
+    const tenant = {
+      id: "tenant-1", slug: "wall", host: null, name: "测试墙", status: "active" as const,
+      readyAt: new Date("2026-08-21T00:00:00.000Z"), archiveWarningAt: null,
+      createdAt: new Date("2026-08-20T00:00:00.000Z"), updatedAt: new Date("2026-08-21T00:00:00.000Z"),
+      botAccounts: [{
+        id: "bot-1", platform: "onebot", qqUin: 10001n, displayName: "墙号", enabled: true,
+        reviewGroupId: "20001", lastSeenAt: new Date("2026-08-21T01:02:03.000Z"),
+        sessions: [{ healthStatus: "available" }],
+        publishTargets: [{ id: "target-1", type: "qzone", displayName: "QQ 空间", enabled: true, required: true }],
+      }],
+      _count: { botAccounts: 1, posts: 2, memberships: 3 },
+    };
+
+    const result = toSystemTenant(tenant, { getBotConnectionStatus: () => ({ online: true, connectionCount: 2 }) });
+
+    expect(result.bots[0]?.connection).toEqual({ online: true, connectionCount: 2 });
+    expect(result.bots[0]?.publishTargets[0]?.status).toBe("ready");
+  });
+
+  test("marks enabled QZone targets unavailable without a healthy session", () => {
+    const tenant = {
+      id: "tenant-2", slug: "wall-2", host: null, name: "离线墙", status: "active" as const,
+      readyAt: null, archiveWarningAt: null, createdAt: new Date(), updatedAt: new Date(),
+      botAccounts: [{
+        id: "bot-2", platform: "onebot", qqUin: 10002n, displayName: "墙号 2", enabled: true,
+        reviewGroupId: null, lastSeenAt: null, sessions: [],
+        publishTargets: [{ id: "target-2", type: "qzone", displayName: "QQ 空间", enabled: true, required: true }],
+      }],
+      _count: { botAccounts: 1, posts: 0, memberships: 0 },
+    };
+
+    const result = toSystemTenant(tenant, { getBotConnectionStatus: () => ({ online: false, connectionCount: 0 }) });
+
+    expect(result.bots[0]?.connection.online).toBe(false);
+    expect(result.bots[0]?.publishTargets[0]?.status).toBe("unavailable");
+  });
+});

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -30,6 +30,7 @@ import {
 } from "../lib/tenant-domain";
 import { buildUserContainsSearch } from "../lib/user-search";
 import type { RuntimeQueue } from "../runtime/queue";
+import type { OneBotRuntime } from "../runtime/onebot";
 import type { EventBus, PluginEvent } from "@campux/plugin";
 
 const tenantStatusSchema = z.enum(["active", "paused", "archived"]);
@@ -96,15 +97,20 @@ type SystemTenantRecord = {
   archiveWarningAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
-  botAccounts?: Array<{
+  botAccounts: Array<{
     id: string;
+    platform: string;
     qqUin: bigint;
     displayName: string;
     enabled: boolean;
     reviewGroupId: string | null;
     lastSeenAt: Date | null;
+    sessions: Array<{
+      healthStatus: string;
+    }>;
     publishTargets: Array<{
       id: string;
+      type: string;
       displayName: string;
       enabled: boolean;
       required: boolean;
@@ -117,7 +123,9 @@ type SystemTenantRecord = {
   };
 };
 
-function toSystemTenant(tenant: SystemTenantRecord) {
+type BotConnectionStatusProvider = Pick<OneBotRuntime, "getBotConnectionStatus">;
+
+export function toSystemTenant(tenant: SystemTenantRecord, oneBot?: BotConnectionStatusProvider) {
   return {
     id: tenant.id,
     slug: tenant.slug,
@@ -132,18 +140,27 @@ function toSystemTenant(tenant: SystemTenantRecord) {
     botAccountCount: tenant._count.botAccounts,
     postCount: tenant._count.posts,
     memberCount: tenant._count.memberships,
-    bots: (tenant.botAccounts ?? []).map((bot) => ({
+    bots: tenant.botAccounts.map((bot) => ({
       id: bot.id,
+      platform: bot.platform,
       qqUin: bot.qqUin.toString(),
       displayName: bot.displayName,
       enabled: bot.enabled,
       reviewGroupId: bot.reviewGroupId,
       lastSeenAt: bot.lastSeenAt?.toISOString() ?? null,
+      connection: bot.platform === "official_qq"
+        ? { online: bot.enabled, connectionCount: bot.enabled ? 1 : 0 }
+        : oneBot?.getBotConnectionStatus(bot.qqUin.toString()) ?? { online: false, connectionCount: 0 },
       publishTargets: bot.publishTargets.map((target) => ({
         id: target.id,
         displayName: target.displayName,
         enabled: target.enabled,
         required: target.required,
+        status: !bot.enabled || !target.enabled
+          ? "disabled" as const
+          : target.type !== "qzone" || bot.sessions[0]?.healthStatus === "available"
+            ? "ready" as const
+            : "unavailable" as const,
       })),
     })),
   };
@@ -206,7 +223,7 @@ async function assertHostNotReserved(host: string | null, reply: FastifyReply, o
   }
 }
 
-async function listSystemTenants(context: PlatformContext) {
+async function listSystemTenants(context: PlatformContext, oneBot?: OneBotRuntime) {
   const tenantIds = manageableTenantIds(context);
   const tenants = await prisma.tenant.findMany({
     where: tenantIds === null ? {} : { id: { in: tenantIds } },
@@ -217,6 +234,12 @@ async function listSystemTenants(context: PlatformContext) {
             orderBy: {
               displayName: "asc",
             },
+          },
+          sessions: {
+            where: { type: "qzone" },
+            orderBy: { refreshedAt: "desc" },
+            take: 1,
+            select: { healthStatus: true },
           },
         },
         orderBy: {
@@ -234,7 +257,7 @@ async function listSystemTenants(context: PlatformContext) {
     orderBy: [{ status: "asc" }, { createdAt: "asc" }],
   });
 
-  return tenants.map(toSystemTenant);
+  return tenants.map((tenant) => toSystemTenant(tenant, oneBot));
 }
 
 function tenantDomainSuffixForResponse(config: CampuxConfig) {
@@ -248,7 +271,7 @@ function tenantDomainSuffixForResponse(config: CampuxConfig) {
   }
 }
 
-export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, config: CampuxConfig) {
+export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, config: CampuxConfig, oneBot?: OneBotRuntime) {
   app.get("/api/system/settings", async (request, reply) => {
     const context = await requirePlatformAdmin(request, reply);
     if (!isSystemOperator(context)) {
@@ -306,7 +329,7 @@ export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, 
     const context = await requirePlatformAdmin(request, reply);
 
     return {
-      tenants: await listSystemTenants(context),
+      tenants: await listSystemTenants(context, oneBot),
       tenantDomainSuffix: tenantDomainSuffixForResponse(config),
     };
   });
@@ -467,7 +490,7 @@ export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, 
     });
 
     return {
-      tenants: await listSystemTenants(context),
+      tenants: await listSystemTenants(context, oneBot),
       tenantDomainSuffix: tenantDomainSuffixForResponse(config),
     };
   });
@@ -653,7 +676,7 @@ export function registerSystemRoutes(app: FastifyInstance, queue: RuntimeQueue, 
     }
 
     return {
-      tenants: await listSystemTenants(context),
+      tenants: await listSystemTenants(context, oneBot),
       tenantDomainSuffix: tenantDomainSuffixForResponse(config),
     };
   });

--- a/apps/web/src/features/ops/OpsPanel.tsx
+++ b/apps/web/src/features/ops/OpsPanel.tsx
@@ -172,6 +172,7 @@ export function OpsPanel({
 }) {
   const isSystemMode = mode === "system";
   const tenantRequestGate = useRef(createLatestRequestGate());
+  const overviewRequestGate = useRef(createLatestRequestGate());
   const [tenants, setTenants] = useState<SystemTenant[]>([]);
   const [selectedTenantId, setSelectedTenantId] = useState("");
   const [users, setUsers] = useState<SystemUser[]>([]);
@@ -275,6 +276,7 @@ export function OpsPanel({
 
   async function refreshOverview(nextSelectedId?: string) {
     const requestGeneration = tenantRequestGate.current.begin();
+    const overviewGeneration = overviewRequestGate.current.begin();
     setLoadingOverview(true);
     setQueueLoadState("loading");
     try {
@@ -294,27 +296,32 @@ export function OpsPanel({
         const nextTenant = candidateTenants.find((tenant) => tenant.id === nextSelectedId) ?? candidateTenants.find((tenant) => tenant.id === selectedTenantId) ?? candidateTenants[0];
         setSelectedTenantId(nextTenant?.id ?? "");
       }
-      if (queueResult.ok) {
-        setQueue(queueResult.value);
-        setQueueLoadState("ready");
-      } else {
-        setQueue(null);
-        setQueueLoadState("error");
-        toast.error(queueResult.error instanceof Error ? `任务队列状态读取失败：${queueResult.error.message}` : "任务队列状态读取失败");
-      }
-      if (userResult.ok) {
-        setSystemUserTotal(userResult.value.total);
-      } else {
-        setSystemUserTotal(null);
-        toast.error(userResult.error instanceof Error ? `用户总数读取失败：${userResult.error.message}` : "用户总数读取失败");
+      if (overviewRequestGate.current.isCurrent(overviewGeneration)) {
+        if (queueResult.ok) {
+          setQueue(queueResult.value);
+          setQueueLoadState("ready");
+        } else {
+          setQueue(null);
+          setQueueLoadState("error");
+          toast.error(queueResult.error instanceof Error ? `任务队列状态读取失败：${queueResult.error.message}` : "任务队列状态读取失败");
+        }
+        if (userResult.ok) {
+          setSystemUserTotal(userResult.value.total);
+        } else {
+          setSystemUserTotal(null);
+          toast.error(userResult.error instanceof Error ? `用户总数读取失败：${userResult.error.message}` : "用户总数读取失败");
+        }
       }
       return data.tenants;
     } catch (caught) {
+      if (!overviewRequestGate.current.isCurrent(overviewGeneration)) return [];
       setQueue(null);
       setQueueLoadState("error");
       throw caught;
     } finally {
-      setLoadingOverview(false);
+      if (overviewRequestGate.current.isCurrent(overviewGeneration)) {
+        setLoadingOverview(false);
+      }
     }
   }
 

--- a/apps/web/src/features/ops/OpsPanel.tsx
+++ b/apps/web/src/features/ops/OpsPanel.tsx
@@ -20,6 +20,8 @@ import {
   ShieldPlusIcon,
   Trash2Icon,
   UsersRoundIcon,
+  WifiIcon,
+  WifiOffIcon,
 } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@/lib/api";
@@ -29,6 +31,7 @@ import {
   buildMembershipRoleChangeConfirmation,
 } from "./membership-removal-confirmation";
 import { buildOverviewTenantNavigation } from "./overview-tenant-navigation";
+import { summarizeTenantRuntime } from "./tenant-runtime-summary";
 import type { AuditLogItem, Pagination, SystemQueueSnapshot, SystemRole, SystemTenant, SystemUser, TenantRole, TenantStatus } from "@/types/app";
 import { PaginationControls } from "@/components/app/utility";
 import { Badge } from "@/components/ui/badge";
@@ -310,6 +313,12 @@ export function OpsPanel({
     }
   }
 
+  async function refreshTenantRuntime() {
+    const data = await api<{ tenants: SystemTenant[]; tenantDomainSuffix?: string | null }>("/api/system/tenants");
+    setTenants(data.tenants);
+    setTenantDomainSuffix(data.tenantDomainSuffix ?? null);
+  }
+
   async function refreshSettings() {
     if (!isSystemMode) {
       setManagementHostDraft("");
@@ -406,6 +415,15 @@ export function OpsPanel({
       toast.error(caught instanceof Error ? caught.message : "无法读取运维面板数据");
     });
   }, []);
+
+  useEffect(() => {
+    if (activeSection !== "overview" && activeSection !== "tenants") return;
+    const interval = window.setInterval(() => {
+      if (document.visibilityState !== "visible") return;
+      void refreshTenantRuntime().catch(() => undefined);
+    }, 10_000);
+    return () => window.clearInterval(interval);
+  }, [activeSection]);
 
   useEffect(() => {
     if (!isSystemMode && activeSection === "platform") {
@@ -1019,6 +1037,7 @@ ${impact}`)) {
                           <span>{tenant.botAccountCount} 墙号</span>
                           <span>{tenant.postCount} 稿件</span>
                         </span>
+                        <TenantRuntimeStrip tenant={tenant} />
                       </button>
                     ))}
                     {filteredVisibleTenants.length === 0 ? (
@@ -1408,6 +1427,35 @@ function OnboardingGuide({
   );
 }
 
+function TenantRuntimeStrip({ tenant }: { tenant: SystemTenant }) {
+  const runtime = summarizeTenantRuntime(tenant);
+  const online = runtime.onlineBots > 0;
+  const targetTone = runtime.unavailableTargets > 0
+    ? "border-red-200 bg-red-50 text-red-700"
+    : runtime.readyTargets > 0
+      ? "border-green-200 bg-green-50 text-green-700"
+      : "border-slate-200 bg-white text-slate-500";
+
+  return (
+    <span className="mt-2 grid gap-1 border-t border-slate-200/70 pt-2 text-[10px] font-semibold text-slate-500">
+      <span className="flex flex-wrap items-center gap-1.5">
+        <span className={`inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 ${online ? "bg-green-100 text-green-800" : "bg-slate-200 text-slate-600"}`}>
+          {online ? <WifiIcon className="size-3" /> : <WifiOffIcon className="size-3" />}
+          机器人 {runtime.onlineBots}/{runtime.totalBots} 在线
+        </span>
+        <span className={`rounded-full border px-1.5 py-0.5 ${targetTone}`}>
+          {runtime.totalTargets === 0
+            ? "发布目标未配置"
+            : runtime.unavailableTargets > 0
+              ? `发布目标 ${runtime.unavailableTargets} 异常`
+              : `发布目标 ${runtime.readyTargets}/${runtime.totalTargets} 正常`}
+        </span>
+      </span>
+      <span>最后连接：{formatDateTime(runtime.lastConnectedAt)}</span>
+    </span>
+  );
+}
+
 function TenantBotCard({ bot }: { bot: SystemTenant["bots"][number] }) {
   return (
     <div className="rounded-md border border-slate-100 bg-slate-50 p-3">
@@ -1416,19 +1464,29 @@ function TenantBotCard({ bot }: { bot: SystemTenant["bots"][number] }) {
           <p className="truncate text-sm font-semibold">{bot.displayName}</p>
           <p className="mt-0.5 text-xs font-bold text-slate-500">QQ {bot.qqUin}</p>
         </div>
-        <Badge variant={bot.enabled ? "secondary" : "outline"}>{bot.enabled ? "启用" : "停用"}</Badge>
+        <div className="flex flex-wrap gap-1.5">
+          <Badge className={`gap-1 rounded-full shadow-none ${bot.connection.online ? "bg-green-50 text-green-800 ring-1 ring-green-200" : "bg-slate-200 text-slate-600"}`}>
+            {bot.connection.online ? <WifiIcon className="size-3" /> : <WifiOffIcon className="size-3" />}
+            {bot.connection.online ? "在线" : "离线"}
+          </Badge>
+          {!bot.enabled ? <Badge variant="outline">停用</Badge> : null}
+        </div>
       </div>
       <div className="mt-2 grid gap-1 text-xs text-slate-500 sm:grid-cols-2">
         <span>审核群：{bot.reviewGroupId ?? "未配置"}</span>
-        <span>最近连接：{formatDateTime(bot.lastSeenAt)}</span>
+        <span>最后连接：{formatDateTime(bot.lastSeenAt)}</span>
       </div>
       <div className="mt-3 flex flex-wrap gap-1.5">
         {bot.publishTargets.length > 0 ? (
           bot.publishTargets.map((target) => (
-            <Badge key={target.id} variant={target.enabled ? "outline" : "secondary"} className="gap-1">
+            <Badge
+              key={target.id}
+              variant="outline"
+              className={`gap-1 ${target.status === "ready" ? "border-green-200 bg-green-50 text-green-700" : target.status === "unavailable" ? "border-red-200 bg-red-50 text-red-700" : "border-slate-200 bg-white text-slate-500"}`}
+            >
               {target.displayName}
+              {target.status === "ready" ? " · 正常" : target.status === "unavailable" ? " · 登录态异常" : " · 停用"}
               {target.required ? " · 必发" : ""}
-              {!target.enabled ? " · 停用" : ""}
             </Badge>
           ))
         ) : (

--- a/apps/web/src/features/ops/OpsPanel.tsx
+++ b/apps/web/src/features/ops/OpsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIcon,
   ArchiveIcon,
@@ -31,6 +31,7 @@ import {
   buildMembershipRoleChangeConfirmation,
 } from "./membership-removal-confirmation";
 import { buildOverviewTenantNavigation } from "./overview-tenant-navigation";
+import { createLatestRequestGate } from "./latest-request-gate";
 import { summarizeTenantRuntime } from "./tenant-runtime-summary";
 import type { AuditLogItem, Pagination, SystemQueueSnapshot, SystemRole, SystemTenant, SystemUser, TenantRole, TenantStatus } from "@/types/app";
 import { PaginationControls } from "@/components/app/utility";
@@ -170,6 +171,7 @@ export function OpsPanel({
   onEnterTenant?: ((tenantId: string) => Promise<void>) | undefined;
 }) {
   const isSystemMode = mode === "system";
+  const tenantRequestGate = useRef(createLatestRequestGate());
   const [tenants, setTenants] = useState<SystemTenant[]>([]);
   const [selectedTenantId, setSelectedTenantId] = useState("");
   const [users, setUsers] = useState<SystemUser[]>([]);
@@ -272,6 +274,7 @@ export function OpsPanel({
   const expectedTenantHostLabel = tenantFormHost ? "专属访问域名" : "预计访问域名";
 
   async function refreshOverview(nextSelectedId?: string) {
+    const requestGeneration = tenantRequestGate.current.begin();
     setLoadingOverview(true);
     setQueueLoadState("loading");
     try {
@@ -284,8 +287,13 @@ export function OpsPanel({
           .then((value) => ({ ok: true as const, value }))
           .catch((error: unknown) => ({ ok: false as const, error })),
       ]);
-      setTenants(data.tenants);
-      setTenantDomainSuffix(data.tenantDomainSuffix ?? null);
+      if (tenantRequestGate.current.isCurrent(requestGeneration)) {
+        setTenants(data.tenants);
+        setTenantDomainSuffix(data.tenantDomainSuffix ?? null);
+        const candidateTenants = showArchivedTenants ? data.tenants : data.tenants.filter((tenant) => tenant.status !== "archived");
+        const nextTenant = candidateTenants.find((tenant) => tenant.id === nextSelectedId) ?? candidateTenants.find((tenant) => tenant.id === selectedTenantId) ?? candidateTenants[0];
+        setSelectedTenantId(nextTenant?.id ?? "");
+      }
       if (queueResult.ok) {
         setQueue(queueResult.value);
         setQueueLoadState("ready");
@@ -300,9 +308,6 @@ export function OpsPanel({
         setSystemUserTotal(null);
         toast.error(userResult.error instanceof Error ? `用户总数读取失败：${userResult.error.message}` : "用户总数读取失败");
       }
-      const candidateTenants = showArchivedTenants ? data.tenants : data.tenants.filter((tenant) => tenant.status !== "archived");
-      const nextTenant = candidateTenants.find((tenant) => tenant.id === nextSelectedId) ?? candidateTenants.find((tenant) => tenant.id === selectedTenantId) ?? candidateTenants[0];
-      setSelectedTenantId(nextTenant?.id ?? "");
       return data.tenants;
     } catch (caught) {
       setQueue(null);
@@ -314,7 +319,9 @@ export function OpsPanel({
   }
 
   async function refreshTenantRuntime() {
+    const requestGeneration = tenantRequestGate.current.begin();
     const data = await api<{ tenants: SystemTenant[]; tenantDomainSuffix?: string | null }>("/api/system/tenants");
+    if (!tenantRequestGate.current.isCurrent(requestGeneration)) return;
     setTenants(data.tenants);
     setTenantDomainSuffix(data.tenantDomainSuffix ?? null);
   }
@@ -561,6 +568,7 @@ ${impact}`)) {
         }),
       });
       createdTenants = data.tenants;
+      tenantRequestGate.current.invalidate();
       setTenants(data.tenants);
       created = data.tenants.find((tenant) => tenant.slug === slug);
       setSelectedTenantId(created?.id ?? data.tenants[0]?.id ?? "");

--- a/apps/web/src/features/ops/latest-request-gate.test.ts
+++ b/apps/web/src/features/ops/latest-request-gate.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { createLatestRequestGate } from "./latest-request-gate";
+
+describe("createLatestRequestGate", () => {
+  test("accepts only the newest overlapping request", () => {
+    const gate = createLatestRequestGate();
+    const older = gate.begin();
+    const newer = gate.begin();
+
+    expect(gate.isCurrent(older)).toBe(false);
+    expect(gate.isCurrent(newer)).toBe(true);
+  });
+
+  test("invalidates in-flight reads after a mutation response", () => {
+    const gate = createLatestRequestGate();
+    const read = gate.begin();
+
+    gate.invalidate();
+
+    expect(gate.isCurrent(read)).toBe(false);
+  });
+});

--- a/apps/web/src/features/ops/latest-request-gate.ts
+++ b/apps/web/src/features/ops/latest-request-gate.ts
@@ -1,0 +1,21 @@
+export type LatestRequestGate = {
+  begin: () => number;
+  isCurrent: (generation: number) => boolean;
+  invalidate: () => void;
+};
+
+export function createLatestRequestGate(): LatestRequestGate {
+  let generation = 0;
+  return {
+    begin() {
+      generation += 1;
+      return generation;
+    },
+    isCurrent(candidate) {
+      return candidate === generation;
+    },
+    invalidate() {
+      generation += 1;
+    },
+  };
+}

--- a/apps/web/src/features/ops/tenant-runtime-summary.test.ts
+++ b/apps/web/src/features/ops/tenant-runtime-summary.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { summarizeTenantRuntime } from "./tenant-runtime-summary";
+import type { SystemTenant } from "../../types/app";
+
+const tenant = {
+  bots: [
+    {
+      lastSeenAt: "2026-08-21T01:00:00.000Z",
+      connection: { online: true, connectionCount: 1 },
+      publishTargets: [
+        { status: "ready" },
+        { status: "unavailable" },
+      ],
+    },
+    {
+      lastSeenAt: "2026-08-21T02:00:00.000Z",
+      connection: { online: false, connectionCount: 0 },
+      publishTargets: [{ status: "disabled" }],
+    },
+  ],
+} as SystemTenant;
+
+describe("summarizeTenantRuntime", () => {
+  test("summarizes online bots, latest connection, and publish target states", () => {
+    expect(summarizeTenantRuntime(tenant)).toEqual({
+      onlineBots: 1,
+      totalBots: 2,
+      lastConnectedAt: "2026-08-21T02:00:00.000Z",
+      readyTargets: 1,
+      unavailableTargets: 1,
+      disabledTargets: 1,
+      totalTargets: 3,
+    });
+  });
+
+  test("returns empty runtime values for a tenant without bots", () => {
+    expect(summarizeTenantRuntime({ bots: [] } as unknown as SystemTenant)).toEqual({
+      onlineBots: 0,
+      totalBots: 0,
+      lastConnectedAt: null,
+      readyTargets: 0,
+      unavailableTargets: 0,
+      disabledTargets: 0,
+      totalTargets: 0,
+    });
+  });
+});

--- a/apps/web/src/features/ops/tenant-runtime-summary.ts
+++ b/apps/web/src/features/ops/tenant-runtime-summary.ts
@@ -1,0 +1,30 @@
+import type { SystemTenant } from "../../types/app";
+
+export type TenantRuntimeSummary = {
+  onlineBots: number;
+  totalBots: number;
+  lastConnectedAt: string | null;
+  readyTargets: number;
+  unavailableTargets: number;
+  disabledTargets: number;
+  totalTargets: number;
+};
+
+export function summarizeTenantRuntime(tenant: SystemTenant): TenantRuntimeSummary {
+  const targets = tenant.bots.flatMap((bot) => bot.publishTargets);
+  const lastConnectedAt = tenant.bots.reduce<string | null>((latest, bot) => {
+    if (!bot.lastSeenAt) return latest;
+    if (!latest) return bot.lastSeenAt;
+    return Date.parse(bot.lastSeenAt) > Date.parse(latest) ? bot.lastSeenAt : latest;
+  }, null);
+
+  return {
+    onlineBots: tenant.bots.filter((bot) => bot.connection.online).length,
+    totalBots: tenant.bots.length,
+    lastConnectedAt,
+    readyTargets: targets.filter((target) => target.status === "ready").length,
+    unavailableTargets: targets.filter((target) => target.status === "unavailable").length,
+    disabledTargets: targets.filter((target) => target.status === "disabled").length,
+    totalTargets: targets.length,
+  };
+}

--- a/apps/web/src/types/app.ts
+++ b/apps/web/src/types/app.ts
@@ -693,16 +693,22 @@ export type SystemTenant = {
   memberCount: number;
   bots: Array<{
     id: string;
+    platform: string;
     qqUin: string;
     displayName: string;
     enabled: boolean;
     reviewGroupId: string | null;
     lastSeenAt: string | null;
+    connection: {
+      online: boolean;
+      connectionCount: number;
+    };
     publishTargets: Array<{
       id: string;
       displayName: string;
       enabled: boolean;
       required: boolean;
+      status: "ready" | "unavailable" | "disabled";
     }>;
   }>;
 };


### PR DESCRIPTION
## Summary
- expose live OneBot WebSocket connection state in the system tenant API
- derive QZone publish-target readiness from enabled state and latest verified session health
- show online count, last connection time, and publish-target status in the Ops campus-wall list and bot cards
- refresh runtime tenant status every 10 seconds while the overview or campus-wall section is visible

## Verification
- `bun test apps/web/src` — 43 passed
- `bun test apps/server/src/routes/system-tenant-runtime.test.ts` — 2 passed
- server typecheck/build passed
- web typecheck/production build passed
- `git diff --check` passed

## Summary by Sourcery

在整个运维（Ops）界面中显示实时租户机器人连接状况和发布目标的健康状态。

新功能：
- 在系统租户响应中暴露实时机器人连接状态和发布目标就绪情况。
- 在运维（Ops）租户列表和机器人卡片中显示机器人在线状态、最近连接时间以及发布目标的健康状况。

改进：
- 当运维总览页面或租户部分可见时，每 10 秒刷新一次租户运行时状态。
- 防止过期且重叠的租户和总览请求覆盖更新的状态。

测试：
- 添加服务器端和 Web 端测试，涵盖运行时状态序列化、租户摘要以及最新请求处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Show live tenant bot connectivity and publish-target health throughout the Ops interface.

New Features:
- Expose live bot connection status and publish-target readiness in system tenant responses.
- Display bot online state, last connection time, and publish-target health in Ops tenant lists and bot cards.

Enhancements:
- Refresh tenant runtime status every 10 seconds while the Ops overview or tenant section is visible.
- Prevent stale overlapping tenant and overview requests from overwriting newer state.

Tests:
- Add server and web tests covering runtime status serialization, tenant summaries, and latest-request handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在整个运维（Ops）界面中显示实时租户机器人连接状况和发布目标的健康状态。

新功能：
- 在系统租户响应中暴露实时机器人连接状态和发布目标就绪情况。
- 在运维（Ops）租户列表和机器人卡片中显示机器人在线状态、最近连接时间以及发布目标的健康状况。

改进：
- 当运维总览页面或租户部分可见时，每 10 秒刷新一次租户运行时状态。
- 防止过期且重叠的租户和总览请求覆盖更新的状态。

测试：
- 添加服务器端和 Web 端测试，涵盖运行时状态序列化、租户摘要以及最新请求处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Show live tenant bot connectivity and publish-target health throughout the Ops interface.

New Features:
- Expose live bot connection status and publish-target readiness in system tenant responses.
- Display bot online state, last connection time, and publish-target health in Ops tenant lists and bot cards.

Enhancements:
- Refresh tenant runtime status every 10 seconds while the Ops overview or tenant section is visible.
- Prevent stale overlapping tenant and overview requests from overwriting newer state.

Tests:
- Add server and web tests covering runtime status serialization, tenant summaries, and latest-request handling.

</details>

</details>

新功能：
- 在系统租户响应中暴露机器人实时连接状态和发布目标（publish-target）就绪情况。
- 在 Ops 租户概览和机器人卡片中显示机器人在线状态、最近连接时间以及发布目标健康状况。
- 当相关的 Ops 区域可见时，自动刷新租户运行时状态。

增强：
- 基于启用状态以及最新一次已验证的会话健康状况，推导 QZone 目标就绪状态。

测试：
- 为运行时状态序列化和租户运行时摘要新增服务器端和 Web 端的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在整个运维（Ops）界面中显示实时租户机器人连接状况和发布目标的健康状态。

新功能：
- 在系统租户响应中暴露实时机器人连接状态和发布目标就绪情况。
- 在运维（Ops）租户列表和机器人卡片中显示机器人在线状态、最近连接时间以及发布目标的健康状况。

改进：
- 当运维总览页面或租户部分可见时，每 10 秒刷新一次租户运行时状态。
- 防止过期且重叠的租户和总览请求覆盖更新的状态。

测试：
- 添加服务器端和 Web 端测试，涵盖运行时状态序列化、租户摘要以及最新请求处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Show live tenant bot connectivity and publish-target health throughout the Ops interface.

New Features:
- Expose live bot connection status and publish-target readiness in system tenant responses.
- Display bot online state, last connection time, and publish-target health in Ops tenant lists and bot cards.

Enhancements:
- Refresh tenant runtime status every 10 seconds while the Ops overview or tenant section is visible.
- Prevent stale overlapping tenant and overview requests from overwriting newer state.

Tests:
- Add server and web tests covering runtime status serialization, tenant summaries, and latest-request handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在整个运维（Ops）界面中显示实时租户机器人连接状况和发布目标的健康状态。

新功能：
- 在系统租户响应中暴露实时机器人连接状态和发布目标就绪情况。
- 在运维（Ops）租户列表和机器人卡片中显示机器人在线状态、最近连接时间以及发布目标的健康状况。

改进：
- 当运维总览页面或租户部分可见时，每 10 秒刷新一次租户运行时状态。
- 防止过期且重叠的租户和总览请求覆盖更新的状态。

测试：
- 添加服务器端和 Web 端测试，涵盖运行时状态序列化、租户摘要以及最新请求处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Show live tenant bot connectivity and publish-target health throughout the Ops interface.

New Features:
- Expose live bot connection status and publish-target readiness in system tenant responses.
- Display bot online state, last connection time, and publish-target health in Ops tenant lists and bot cards.

Enhancements:
- Refresh tenant runtime status every 10 seconds while the Ops overview or tenant section is visible.
- Prevent stale overlapping tenant and overview requests from overwriting newer state.

Tests:
- Add server and web tests covering runtime status serialization, tenant summaries, and latest-request handling.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant runtime monitoring to the operations panel.
  * Display bot platforms, online/offline status, connection activity, and publish-target readiness.
  * Added aggregate tenant health summaries for bot connectivity and publish targets.
  * Tenant status information refreshes automatically while the relevant operations view is active.

* **Bug Fixes**
  * Improved runtime status reporting for connected bots and unavailable or disabled publish targets.
  * Prevented outdated refresh results from replacing newer tenant status information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->