### PR TITLE
fix(ci): verify deploy after gateway timeout

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -235,7 +235,12 @@ jobs:
           echo "--- Updating standalone stack via Portainer API ---" >&2
           redeploy_url="$portainer_url/api/stacks/$stack_id?endpointId=$endpoint_id"
           container_url="$portainer_url/api/endpoints/$endpoint_id/docker/containers/campux-admin/json"
-          previous_admin_id="$(curl -fsS "$container_url" -H "Authorization: Bearer $jwt" | jq -r '.Id')"
+          previous_admin_info="$(curl -fsS --connect-timeout 10 --max-time 30 "$container_url" -H "Authorization: Bearer $jwt" 2>/dev/null || true)"
+          previous_admin_id="$(printf '%s' "$previous_admin_info" | jq -r '.Id // empty' 2>/dev/null || true)"
+          if [ -z "$previous_admin_id" ]; then
+            echo "Unable to identify the current admin container; refusing an unverifiable deploy" >&2
+            exit 1
+          fi
           redeploy_response="$(curl -sS -w '\n%{http_code}' \
             -X PUT "$redeploy_url" \
             -H "Authorization: Bearer $jwt" \
@@ -252,7 +257,7 @@ jobs:
             echo "Portainer request timed out at the gateway; verifying the replacement container" >&2
             replacement_healthy=false
             for attempt in $(seq 1 30); do
-              container_info="$(curl -fsS "$container_url" -H "Authorization: Bearer $jwt" 2>/dev/null || true)"
+              container_info="$(curl -fsS --connect-timeout 10 --max-time 30 "$container_url" -H "Authorization: Bearer $jwt" 2>/dev/null || true)"
               current_admin_id="$(printf '%s' "$container_info" | jq -r '.Id // empty' 2>/dev/null || true)"
               current_admin_health="$(printf '%s' "$container_info" | jq -r '.State.Health.Status // empty' 2>/dev/null || true)"
               if [ -n "$current_admin_id" ] && [ "$current_admin_id" != "$previous_admin_id" ] && [ "$current_admin_health" = "healthy" ]; then

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -234,6 +234,8 @@ jobs:
 
           echo "--- Updating standalone stack via Portainer API ---" >&2
           redeploy_url="$portainer_url/api/stacks/$stack_id?endpointId=$endpoint_id"
+          container_url="$portainer_url/api/endpoints/$endpoint_id/docker/containers/campux-admin/json"
+          previous_admin_id="$(curl -fsS "$container_url" -H "Authorization: Bearer $jwt" | jq -r '.Id')"
           redeploy_response="$(curl -sS -w '\n%{http_code}' \
             -X PUT "$redeploy_url" \
             -H "Authorization: Bearer $jwt" \
@@ -243,6 +245,28 @@ jobs:
           redeploy_body="$(printf '%s' "$redeploy_response" | sed '$d')"
           if [ "$redeploy_http_code" = "200" ]; then
             echo "Redeploy succeeded (HTTP $redeploy_http_code)" >&2
+          elif [ "$redeploy_http_code" = "524" ]; then
+            # Cloudflare can time out the synchronous Portainer response while
+            # Portainer continues the stack update. Do not report success from
+            # the timeout alone: require a replaced, healthy admin container.
+            echo "Portainer request timed out at the gateway; verifying the replacement container" >&2
+            replacement_healthy=false
+            for attempt in $(seq 1 30); do
+              container_info="$(curl -fsS "$container_url" -H "Authorization: Bearer $jwt" 2>/dev/null || true)"
+              current_admin_id="$(printf '%s' "$container_info" | jq -r '.Id // empty' 2>/dev/null || true)"
+              current_admin_health="$(printf '%s' "$container_info" | jq -r '.State.Health.Status // empty' 2>/dev/null || true)"
+              if [ -n "$current_admin_id" ] && [ "$current_admin_id" != "$previous_admin_id" ] && [ "$current_admin_health" = "healthy" ]; then
+                replacement_healthy=true
+                echo "Replacement admin container is healthy" >&2
+                break
+              fi
+              echo "Waiting for replacement admin container ($attempt/30)" >&2
+              sleep 10
+            done
+            if [ "$replacement_healthy" != "true" ]; then
+              echo "Portainer timed out and no healthy replacement container was observed" >&2
+              exit 1
+            fi
           else
             echo "Redeploy failed (HTTP $redeploy_http_code): $redeploy_body" >&2
             exit 1


### PR DESCRIPTION
## Root cause
The Portainer stack update is synchronous and is proxied through Cloudflare. The update took over 120 seconds, so Cloudflare returned HTTP 524 even though Portainer completed the replacement and all production containers became healthy. The workflow failed before its health checks.

## Fix
- record the current admin container ID before the update
- on HTTP 524 only, poll the Portainer Docker API
- accept the asynchronous result only after a different admin container is healthy
- keep all other non-200 responses failing closed

## Verification
- actionlint v1.7.7 passes (ignoring one pre-existing SC2129 style warning)
- production evidence from failed run: new admin and dash containers are healthy and public health endpoints return 200

## Summary by Sourcery

确保仅在确认替换的 admin 容器处于健康状态后，才接受因网关超时的 Portainer stack 更新。

Bug Fixes:
- 对于收到 Cloudflare HTTP 524 超时的部署，通过确认新的健康 admin 容器已替换先前的容器来进行验证。
- 除已明确处理的 HTTP 524 情况外，对所有非 200 响应继续保持“失败即关闭”（fail closed）策略。

Enhancements:
- 在将异步 stack 更新视为成功之前，增加在超时后的 Portainer Docker API 轮询。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure gateway-timed-out Portainer stack updates are accepted only after the replacement admin container is confirmed healthy.

Bug Fixes:
- Verify deployments that receive a Cloudflare HTTP 524 timeout by confirming a new healthy admin container replaces the previous one.
- Continue failing closed for all non-200 responses other than the explicitly handled HTTP 524 case.

Enhancements:
- Add post-timeout polling of the Portainer Docker API before accepting an asynchronous stack update as successful.

</details>

Bug Fixes（错误修复）:
- 在遇到 Cloudflare HTTP 524 网关超时时，通过要求出现一个新的且健康的 admin 容器，来验证异步 Stack 更新是否成功。
- 除了显式处理的 HTTP 524 情况外，对其他所有非 200 响应继续采用“默认失败”（fail closed）策略。

Enhancements（增强）:
- 在超时之后增加对 Portainer Docker API 的轮询，在允许部署被视为成功之前，确认 admin 容器已被替换并且处于健康状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

确保仅在确认替换的 admin 容器处于健康状态后，才接受因网关超时的 Portainer stack 更新。

Bug Fixes:
- 对于收到 Cloudflare HTTP 524 超时的部署，通过确认新的健康 admin 容器已替换先前的容器来进行验证。
- 除已明确处理的 HTTP 524 情况外，对所有非 200 响应继续保持“失败即关闭”（fail closed）策略。

Enhancements:
- 在将异步 stack 更新视为成功之前，增加在超时后的 Portainer Docker API 轮询。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure gateway-timed-out Portainer stack updates are accepted only after the replacement admin container is confirmed healthy.

Bug Fixes:
- Verify deployments that receive a Cloudflare HTTP 524 timeout by confirming a new healthy admin container replaces the previous one.
- Continue failing closed for all non-200 responses other than the explicitly handled HTTP 524 case.

Enhancements:
- Add post-timeout polling of the Portainer Docker API before accepting an asynchronous stack update as successful.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production deployment handling for temporary HTTP 524 responses.
  * Added connection and total timeouts to deployment verification requests.
  * Deployment now verifies that a replacement admin container becomes healthy before completing.
  * Deployments fail clearly when the current or replacement container cannot be identified or a healthy replacement is not available after repeated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->