### PR TITLE
fix(web): 修复展开底部空白与插件当前日志过滤

### DIFF
--- a/apps/web/src/features/admin/AdminPage.tsx
+++ b/apps/web/src/features/admin/AdminPage.tsx
@@ -1056,7 +1056,7 @@ export function AdminPage({
 
   return (
     <div className="flex h-full min-h-0 flex-col px-4 pt-4">
-      <Tabs value={activeTab} onValueChange={(value) => onTabChange(value as AdminTab)} className="min-h-0 flex-1">
+      <Tabs value={activeTab} onValueChange={(value) => onTabChange(value as AdminTab)} className="min-h-0 flex-1 overflow-hidden">
         <TabsList className={managementTabsListClassName}>
           <TabsTrigger value="users" className={managementTabsTriggerClassName}>
             用户

--- a/apps/web/src/features/admin/PluginConfigPage.tsx
+++ b/apps/web/src/features/admin/PluginConfigPage.tsx
@@ -6,6 +6,7 @@ import { FONT_OPTIONS } from "@campux/domain";
 import type { BotMessageTypeConfig, PluginColorPreset, TenantMetadata, TenantPluginConfig } from "@/types/app";
 import { api } from "@/lib/api";
 import { builtInSvgAvatarFilenames } from "@/lib/built-in-svg-avatars";
+import { filterPluginAuditLogs } from "./plugin-audit-log-filter";
 import { AggregateLoginIcon, AGGREGATE_LOGIN_TYPE_LABELS } from "../aggregate-oauth/icons";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -1187,7 +1188,9 @@ export function PluginConfigPage({ tenantId, metadata, onSaved }: { tenantId: st
                       <div className="grid place-items-center py-6 text-xs text-slate-400"><LoaderIcon className="size-4 animate-spin" /> 加载中…</div>
                     ) : (
                       (() => {
-                        const filtered = logScope === "current" ? auditLog.filter((entry) => entry.pluginName === activePlugin.name) : auditLog;
+                        const filtered = logScope === "current"
+                          ? filterPluginAuditLogs(auditLog, activePlugin.id, PRESET_NAME_BY_ID[activePlugin.id])
+                          : auditLog;
                         if (filtered.length === 0) {
                           return <p className="py-4 text-center text-xs text-slate-400">暂无日志</p>;
                         }

--- a/apps/web/src/features/admin/plugin-audit-log-filter.test.ts
+++ b/apps/web/src/features/admin/plugin-audit-log-filter.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { filterPluginAuditLogs } from "./plugin-audit-log-filter";
+
+const PRESET_NAME_BY_ID: Record<string, string> = {
+  markdownRender: "campux-plugin-markdown-render",
+  colorSelection: "campux-plugin-color-selection",
+  campaigns: "campux-plugin-campaigns",
+};
+
+describe("filterPluginAuditLogs", () => {
+  const auditLog = [
+    {
+      id: "1",
+      pluginName: "campux-plugin-markdown-render",
+      action: "tenant.plugin.markdownRender.enable",
+    },
+    {
+      id: "2",
+      pluginName: "campux-plugin-color-selection",
+      action: "tenant.plugin.colorSelection.config",
+    },
+  ];
+
+  test("matches registry pluginName, not Chinese display name", () => {
+    const filtered = filterPluginAuditLogs(auditLog, "markdownRender", PRESET_NAME_BY_ID.markdownRender!);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]?.pluginName).toBe("campux-plugin-markdown-render");
+  });
+
+  test("legacy display-name filter would incorrectly return empty", () => {
+    const wrong = auditLog.filter((entry) => entry.pluginName === "Markdown 渲染");
+    expect(wrong).toHaveLength(0);
+  });
+
+  test("falls back to action token when pluginName is missing", () => {
+    const withNullName = [{ id: "4", pluginName: null, action: "tenant.plugin.campaigns.enable" }];
+    const filtered = filterPluginAuditLogs(withNullName, "campaigns", PRESET_NAME_BY_ID.campaigns!);
+    expect(filtered).toHaveLength(1);
+  });
+
+  test("does not leak other plugins into current scope", () => {
+    const filtered = filterPluginAuditLogs(auditLog, "colorSelection", PRESET_NAME_BY_ID.colorSelection!);
+    expect(filtered.map((entry) => entry.id)).toEqual(["2"]);
+  });
+});

--- a/apps/web/src/features/admin/plugin-audit-log-filter.ts
+++ b/apps/web/src/features/admin/plugin-audit-log-filter.ts
@@ -1,0 +1,10 @@
+/** 审计日志「当前插件」过滤：pluginName 是 registry 名，不是界面展示名。 */
+export function filterPluginAuditLogs<T extends { pluginName: string | null; action: string }>(
+  auditLog: readonly T[],
+  pluginId: string,
+  registryName: string,
+): T[] {
+  return auditLog.filter(
+    (entry) => entry.pluginName === registryName || entry.action.includes(`.${pluginId}.`),
+  );
+}

--- a/apps/web/src/features/posts/PostRulesAction.tsx
+++ b/apps/web/src/features/posts/PostRulesAction.tsx
@@ -38,8 +38,9 @@ const RuleButton = forwardRef<HTMLButtonElement, ComponentPropsWithoutRef<"butto
 });
 
 function RuleList({ rules }: { rules: string[] }) {
+  // 不用 flex-1：在 Drawer/Dialog 的 flex 列里会把中间区域撑满，底部出现大片空白。
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto px-4 md:px-5">
+    <div className="max-h-[50dvh] overflow-y-auto px-4 md:px-5">
       <div className="flex flex-col gap-2 pb-1">
         {rules.map((rule, index) => (
           <Alert key={rule} className="rounded-md">
@@ -67,7 +68,7 @@ export function PostRulesAction({ rules }: { rules: string[] }) {
               <DrawerDescription>发布前请确认内容符合当前校园墙规范。</DrawerDescription>
             </DrawerHeader>
             <RuleList rules={rules} />
-            <DrawerFooter className="shrink-0">
+            <DrawerFooter className="mt-0 shrink-0">
               <DrawerClose asChild>
                 <Button>好的</Button>
               </DrawerClose>


### PR DESCRIPTION
## Summary
- 修复管理页插件「当前插件」日志永远为空：审计日志的 `pluginName` 是 registry 名（如 `campux-plugin-markdown-render`），前端却用界面展示名（如「Markdown 渲染」）过滤；改为按预设 id 对应的 registry 名过滤，并兼容 `action` 前缀。
- 修复投稿页「投稿规则」展开后底部空白：Drawer/Dialog 内容区 `flex-1` + Footer `mt-auto` 在 vaul 按 `max-h` 测量时会把中间撑满；改为内容自适应高度，Footer 取消 `mt-auto`。
- 修复墙面设置 LLM/OAuth 展开后可能整页溢出：管理页 `Tabs` 补上 `overflow-hidden`，滚动只发生在 `TabsContent` 内部。

## Verification
- `bun --cwd apps/web typecheck` 通过
- `bun test`（apps/web）49 pass / 0 fail
- 新增 `plugin-audit-log-filter.test.ts` 覆盖 registry 名过滤与 action 回退
- Playwright 布局复现：旧抽屉布局规则与按钮间距约 476px，修复后约 8px，且抽屉高度从撑满 85dvh 收为贴合内容（约 250px）

## Commits
- `fix(web): 修复插件「当前插件」日志按 registry 名过滤`
- `fix(web): 修复投稿规则展开后底部空白`
- `fix(web): 管理页 Tabs 增加 overflow-hidden`

## Sourcery 总结

修复管理页插件日志过滤和多处可展开面板的布局溢出问题。

错误修复：
- 修复管理页“当前插件”审计日志过滤，改为按插件 registry 名匹配并兼容 action 回退。
- 修复投稿规则抽屉展开后的底部空白，并限制规则列表高度以避免内容区域异常撑开。
- 修复管理页 LLM/OAuth 设置展开时可能发生的整页溢出。

测试：
- 新增插件审计日志过滤测试，覆盖 registry 名匹配、action 回退及插件隔离。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复管理页插件日志过滤和多处可展开面板的布局溢出问题。

Bug Fixes:
- 修复管理页“当前插件”审计日志过滤，改为按插件 registry 名匹配并兼容 action 回退。
- 修复投稿规则抽屉展开后的底部空白，并限制规则列表高度以避免内容区域异常撑开。
- 修复管理页 LLM/OAuth 设置展开时可能发生的整页溢出。

Tests:
- 新增插件审计日志过滤测试，覆盖 registry 名匹配、action 回退及插件隔离。

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin audit-log filtering to show entries for the selected plugin, including logs using registry names or legacy action identifiers.
  - Prevented audit logs from other plugins from appearing in the current plugin view.

- **UI Improvements**
  - Updated admin tab content to remain within its designated layout area.
  - Improved the post rules drawer by constraining the rules list height and correcting footer spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->