### PR TITLE
fix(server): 审核群引用通过时正确解析稿件编号

### DIFF
--- a/apps/server/src/runtime/onebot-command.test.ts
+++ b/apps/server/src/runtime/onebot-command.test.ts
@@ -14,6 +14,7 @@ import {
   parseDisplayId,
   parseRejectArgs,
   parseReviewGroupCommand,
+  parseReviewGroupShortCommand,
   parseUnbanCommandArgs,
   resolvePrivatePostModeSelectionFromSemantic,
   resolvePrivatePostSemanticAction,
@@ -83,6 +84,35 @@ describe("parseRejectArgs 尾部标点兼容", () => {
 
   test("编号带 # 前缀", () => {
     expect(parseRejectArgs("内容违规 #6724")).toEqual({ comment: "内容违规", displayId: 6724 });
+  });
+
+  test("理由中的句号等标点保留", () => {
+    expect(parseRejectArgs("内容违规。请处理 6724")).toEqual({ comment: "内容违规。请处理", displayId: 6724 });
+  });
+});
+
+describe("parseReviewGroupShortCommand", () => {
+  test("去掉 CQ at 后识别「通过」", () => {
+    expect(parseReviewGroupShortCommand("[CQ:at,qq=10001] 通过")).toEqual({ name: "通过", args: "" });
+  });
+
+  test("「过」简写", () => {
+    expect(parseReviewGroupShortCommand("[CQ:at,qq=10001] 过")).toEqual({ name: "通过", args: "" });
+  });
+
+  test("通过带混排编号，args 原样交给 parseDisplayId", () => {
+    expect(parseReviewGroupShortCommand("[CQ:at,qq=10001] 通过！6724")).toEqual({ name: "通过", args: "！6724" });
+  });
+
+  test("拒绝理由中的标点不得被改写", () => {
+    expect(parseReviewGroupShortCommand("[CQ:at,qq=10001] 拒绝 内容违规。请处理 6724")).toEqual({
+      name: "拒绝",
+      args: "内容违规。请处理 6724",
+    });
+  });
+
+  test("非审核简写返回 null", () => {
+    expect(parseReviewGroupShortCommand("[CQ:at,qq=10001] 你好")).toBeNull();
   });
 });
 

--- a/apps/server/src/runtime/onebot-command.test.ts
+++ b/apps/server/src/runtime/onebot-command.test.ts
@@ -11,6 +11,8 @@ import {
   shouldSubmitPrivatePostAfterModeSelection,
   parseBanCommandArgs,
   parseCommand,
+  parseDisplayId,
+  parseRejectArgs,
   parseReviewGroupCommand,
   parseUnbanCommandArgs,
   resolvePrivatePostModeSelectionFromSemantic,
@@ -45,6 +47,42 @@ describe("parseCommand prefix handling", () => {
 
   test("命令前有非 @ 文本时不识别", () => {
     expect(parseCommand("随便说点什么 ＃通过 1")).toBeNull();
+  });
+});
+
+describe("parseDisplayId 混排与标点兼容", () => {
+  test("纯数字", () => {
+    expect(parseDisplayId("6724")).toBe(6724);
+  });
+
+  test("全角感叹号前缀（输入法粘连）", () => {
+    expect(parseDisplayId("！6724")).toBe(6724);
+  });
+
+  test("全角感叹号后缀", () => {
+    expect(parseDisplayId("6724！")).toBe(6724);
+  });
+
+  test("带 # 前缀", () => {
+    expect(parseDisplayId("#6724")).toBe(6724);
+  });
+
+  test("无数字时返回 null", () => {
+    expect(parseDisplayId("通过")).toBeNull();
+  });
+});
+
+describe("parseRejectArgs 尾部标点兼容", () => {
+  test("标准 理由 + 编号", () => {
+    expect(parseRejectArgs("内容违规 6724")).toEqual({ comment: "内容违规", displayId: 6724 });
+  });
+
+  test("编号后带全角感叹号", () => {
+    expect(parseRejectArgs("内容违规 6724！")).toEqual({ comment: "内容违规", displayId: 6724 });
+  });
+
+  test("编号带 # 前缀", () => {
+    expect(parseRejectArgs("内容违规 #6724")).toEqual({ comment: "内容违规", displayId: 6724 });
   });
 });
 

--- a/apps/server/src/runtime/onebot.ts
+++ b/apps/server/src/runtime/onebot.ts
@@ -32,6 +32,7 @@ import { readTenantPluginConfig } from "../lib/tenant-plugin-config";
 import { setBotCustomStylishMessages } from "../lib/bot-messages";
 import { isTenantRuntimeActive, tenantRuntimeRelationFilter } from "../lib/tenant-runtime";
 import { lockActiveTenantRuntime, runWithActiveTenantLease } from "../lib/tenant-runtime-lease";
+import { extractDisplayIdFromReviewText, isAllowedReplySender } from "./review-reply-resolve";
 import {
   buildImageSourceSizeErrorMessage,
   imageStorageHardMaxBytes,
@@ -2579,12 +2580,17 @@ export class OneBotRuntime {
 
     // 如果没有以 # 或 / 明确给出命令，但消息是 @ 机器人的短命令（比如 过/拒），支持基于 mention 的快捷命令。
     if (!command && isMentioningBot(event, botQqUin)) {
-      const normalized = extractPlainText(event).replace(/\[CQ:at,qq=\d+\]/g, "").trim();
-      const shortMatch = normalized.match(/^(过|通过)(?:\s*(.*))?$/);
+      const normalized = extractPlainText(event)
+        .replace(/\[CQ:at,qq=\d+\]/g, "")
+        .replace(/[#＃/]/g, " ")
+        .replace(/[！!。．.、，,]/g, " ")
+        .trim();
+      // 允许 "通过"、"过"、"通过 6724"、"通过！6724" 等
+      const shortMatch = normalized.match(/^(过|通过)\s*(.*)$/);
       if (shortMatch) {
         command = { name: "通过", args: (shortMatch[2] ?? "").trim() };
       } else {
-        const rejectMatch = normalized.match(/^(拒|拒绝)(?:\s*(.*))?$/);
+        const rejectMatch = normalized.match(/^(拒|拒绝)\s*(.*)$/);
         if (rejectMatch) {
           command = { name: "拒绝", args: (rejectMatch[2] ?? "").trim() };
         }
@@ -2684,7 +2690,10 @@ export class OneBotRuntime {
           displayId = await this.tryResolveDisplayIdFromReply(event, botQqUin);
         }
         if (!displayId) {
-          await this.sendGroupMessage(botQqUin, groupId, reviewHelp);
+          await this.sendGroupMessage(botQqUin, groupId, [
+            "未解析到稿件编号。可发送：#通过 <稿件id>",
+            "或直接回复（引用）审核通知消息，并 @机器人 发送「通过」。",
+          ].join("\n"));
           return;
         }
         const result = await reviewPostViaBot({
@@ -3384,26 +3393,8 @@ export class OneBotRuntime {
 
   private async tryResolveDisplayIdFromReply(event: OneBotMessageEvent, botQqUin: string): Promise<number | null> {
     try {
-      const replyId = (() => {
-        if (typeof event.raw_message === "string") {
-          const m = event.raw_message.match(/\[CQ:reply,id=(\d+)(?:,.*)?\]/);
-          if (m) return m[1];
-        }
-        if (Array.isArray(event.message)) {
-          for (const seg of event.message as any[]) {
-            if (!seg || typeof seg !== "object") continue;
-            if (seg.type === "reply") {
-              const id = seg.data?.id ?? seg.data?.msg_id ?? seg.data?.message_id;
-              if (id) return String(id);
-            }
-          }
-        }
-        if (event.message_id) {
-          return String(event.message_id);
-        }
-        return null;
-      })();
-
+      // 只解析真正的 reply 段；不要回退到 event.message_id（那是当前消息，不是被引用的审核通知）。
+      const replyId = this.extractReplyMessageId(event);
       if (!replyId) {
         return null;
       }
@@ -3411,12 +3402,13 @@ export class OneBotRuntime {
       const data = await this.callAction(botQqUin, "get_msg", { message_id: replyId }).catch(() => null);
       if (!data) return null;
 
-      // Verify the replied message was sent by the bot itself
+      // 仅当能明确识别发送者且不是本 bot 时才拒绝。
+      // 部分 OneBot 实现（NapCat 等）get_msg 可能不带 sender，此时仍尝试从正文解析编号。
       const sender = (data as any).sender ?? (data as any).user ?? null;
       const senderId = sender
         ? normalizeId(sender.user_id ?? sender.userId ?? sender.uin ?? sender.qq ?? sender.id)
         : null;
-      if (!senderId || senderId !== botQqUin) {
+      if (!isAllowedReplySender(senderId, botQqUin)) {
         return null;
       }
 
@@ -3424,22 +3416,22 @@ export class OneBotRuntime {
       let text = "";
       if (Array.isArray((data as any).message)) {
         text = (data as any).message
-          .map((seg: any) => (seg?.type === "text" ? seg?.data?.text ?? "" : ""))
+          .map((seg: any) => {
+            if (seg?.type === "text") return seg?.data?.text ?? "";
+            if (seg?.type === "reply" || seg?.type === "at") return "";
+            return typeof seg?.data?.text === "string" ? seg.data.text : "";
+          })
           .join("");
       } else if (typeof (data as any).message === "string") {
         text = (data as any).message;
-      } else if (typeof (data as any).raw_message === "string") {
+      }
+      if (!text && typeof (data as any).raw_message === "string") {
         text = (data as any).raw_message;
       }
 
       if (!text) return null;
-
-      // Try to extract displayId from notification text: prefer `编号：#123` then `#123`
-      const m = text.match(/(?:编号：#|#)(\d+)\b/);
-      if (!m) return null;
-      const id = Number(m[1]);
-      return Number.isInteger(id) && id > 0 ? id : null;
-    } catch (error) {
+      return extractDisplayIdFromReviewText(text);
+    } catch {
       return null;
     }
   }
@@ -4051,14 +4043,20 @@ function parsePrivateCommand(input: string) {
   };
 }
 
-function parseDisplayId(args: string) {
-  const id = Number(args.trim());
+export function parseDisplayId(args: string) {
+  // 兼容 "6724"、"！6724"、"6724！"、"#6724" 等常见粘贴/输入法混排
+  const match = args.trim().match(/#?(\d+)/);
+  if (!match?.[1]) {
+    return null;
+  }
+  const id = Number(match[1]);
   return Number.isInteger(id) && id > 0 ? id : null;
 }
 
-function parseRejectArgs(args: string) {
-  const match = args.trim().match(/^(.*\S)\s+(\d+)$/);
-  if (!match) {
+export function parseRejectArgs(args: string) {
+  // 兼容尾部标点：#拒绝 理由 6724！
+  const match = args.trim().match(/^(.*\S)\s+#?(\d+)[！!。．]*$/);
+  if (!match?.[1] || !match[2]) {
     return null;
   }
   const comment = match[1];

--- a/apps/server/src/runtime/onebot.ts
+++ b/apps/server/src/runtime/onebot.ts
@@ -2580,21 +2580,7 @@ export class OneBotRuntime {
 
     // 如果没有以 # 或 / 明确给出命令，但消息是 @ 机器人的短命令（比如 过/拒），支持基于 mention 的快捷命令。
     if (!command && isMentioningBot(event, botQqUin)) {
-      const normalized = extractPlainText(event)
-        .replace(/\[CQ:at,qq=\d+\]/g, "")
-        .replace(/[#＃/]/g, " ")
-        .replace(/[！!。．.、，,]/g, " ")
-        .trim();
-      // 允许 "通过"、"过"、"通过 6724"、"通过！6724" 等
-      const shortMatch = normalized.match(/^(过|通过)\s*(.*)$/);
-      if (shortMatch) {
-        command = { name: "通过", args: (shortMatch[2] ?? "").trim() };
-      } else {
-        const rejectMatch = normalized.match(/^(拒|拒绝)\s*(.*)$/);
-        if (rejectMatch) {
-          command = { name: "拒绝", args: (rejectMatch[2] ?? "").trim() };
-        }
-      }
+      command = parseReviewGroupShortCommand(extractPlainText(event));
     }
 
 
@@ -3947,6 +3933,25 @@ export function parseReviewGroupCommand(input: string) {
     name: bareCommand[1].toLowerCase(),
     args: bareCommand[2]?.trim() ?? "",
   };
+}
+
+/**
+ * @机器人 的简写审核命令（过/通过/拒/拒绝）。
+ * 只去掉 CQ at 段；args 保留原文，拒绝理由中的标点不得被改写。
+ * 「通过！6724」等混排由后续 parseDisplayId / parseRejectArgs 处理。
+ */
+export function parseReviewGroupShortCommand(input: string): { name: string; args: string } | null {
+  const withoutAt = input.replace(/\[CQ:at,qq=\d+\]/g, "").trim();
+  // 长词优先，避免「拒」抢在「拒绝」前面
+  const approve = withoutAt.match(/^(通过|过)([\s\S]*)$/);
+  if (approve) {
+    return { name: "通过", args: (approve[2] ?? "").trim() };
+  }
+  const reject = withoutAt.match(/^(拒绝|拒)([\s\S]*)$/);
+  if (reject) {
+    return { name: "拒绝", args: (reject[2] ?? "").trim() };
+  }
+  return null;
 }
 
 export function shouldNotifyReviewGroupAfterPrivatePostCreate(post: { status: string }) {

--- a/apps/server/src/runtime/review-reply-resolve.test.ts
+++ b/apps/server/src/runtime/review-reply-resolve.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { extractDisplayIdFromReviewText, isAllowedReplySender } from "./review-reply-resolve";
+
+describe("extractDisplayIdFromReviewText", () => {
+  const reviewText = [
+    "📮 中山中学校园墙新稿件",
+    "编号：#6724",
+    "投稿人：匿名（QQ 123）",
+    "来源：网页投稿",
+    "图片：0 张",
+    "",
+    "有没有人上过学…",
+    "",
+    "通过：#通过 6724",
+    "拒绝：#拒绝 <理由> 6724",
+  ].join("\n");
+
+  test("从审核通知提取编号", () => {
+    expect(extractDisplayIdFromReviewText(reviewText)).toBe(6724);
+  });
+
+  test("兼容半角冒号编号", () => {
+    expect(extractDisplayIdFromReviewText("编号: #42\n通过：#通过 42")).toBe(42);
+  });
+
+  test("无编号时返回 null", () => {
+    expect(extractDisplayIdFromReviewText("随便聊聊")).toBeNull();
+  });
+});
+
+describe("isAllowedReplySender", () => {
+  test("sender 缺失时允许继续解析", () => {
+    expect(isAllowedReplySender(null, "10001")).toBe(true);
+  });
+
+  test("sender 是本 bot 时允许", () => {
+    expect(isAllowedReplySender("10001", "10001")).toBe(true);
+  });
+
+  test("sender 是其他用户时拒绝", () => {
+    expect(isAllowedReplySender("20002", "10001")).toBe(false);
+  });
+});

--- a/apps/server/src/runtime/review-reply-resolve.ts
+++ b/apps/server/src/runtime/review-reply-resolve.ts
@@ -1,0 +1,17 @@
+/** 从审核通知正文提取稿件编号。优先「编号：#123」，否则取第一个 #123。 */
+export function extractDisplayIdFromReviewText(text: string): number | null {
+  const m = text.match(/编号[：:]\s*#\s*(\d+)/) ?? text.match(/#(\d+)\b/);
+  if (!m?.[1]) return null;
+  const id = Number(m[1]);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+/**
+ * 判断 get_msg 返回的发送者是否允许用于引用解析。
+ * - sender 缺失（部分 OneBot 实现不返回）→ 允许继续解析
+ * - sender 明确且不是本 bot → 拒绝
+ */
+export function isAllowedReplySender(senderId: string | null, botQqUin: string): boolean {
+  if (!senderId) return true;
+  return senderId === botQqUin;
+}


### PR DESCRIPTION
## Summary
审核群里「回复/引用审核通知 + @机器人 通过」经常失败，机器人提示找不到审核消息，只能退回手写 `#通过 6724`。

根因与修复：

1. **`tryResolveDisplayIdFromReply` 对 sender 校验过严**  
   NapCat 等实现的 `get_msg` 可能不返回 `sender`，原先 `!senderId` 直接放弃解析。改为仅当 sender **明确存在且不是本 bot** 时才拒绝。

2. **无 reply 段时错误回退到 `event.message_id`**  
   那是当前用户消息的 ID，不是被引用的审核通知。已去掉该回退，只解析真正的 reply 段（复用 `extractReplyMessageId`）。

3. **`parseDisplayId` / `parseRejectArgs` 吃不进输入法混排**  
   例如 `通过！6724`、`6724！`、`#拒绝 理由 6724！`。改为从参数中提取数字编号，并容忍尾部标点。

4. **`#通过` 解析失败提示更明确**  
   直接给出 `#通过 <稿件id>` 与「引用审核通知后 @机器人 发通过」两种用法。

## Verification
- `bun --cwd apps/server typecheck` 通过
- `bun test`（onebot-command + review-reply-resolve）**52 pass / 0 fail**
- 新增用例覆盖：编号提取、sender 缺失/匹配/不匹配、`！6724` 等混排解析

## Commit
- `fix(server): 审核群引用通过时正确解析稿件编号`

## Summary by Sourcery

确保审核群引用审核通知并 @机器人执行通过或拒绝时能够可靠解析并处理对应稿件。

Bug Fixes:
- 修复审核群通过或拒绝命令无法从引用的审核通知中解析稿件编号的问题。
- 允许缺少发送者信息的引用消息继续解析，同时拒绝明确来自其他用户的消息，并避免错误使用当前消息编号。
- 增强通过和拒绝命令对输入法混排、编号前后标点及 # 前缀的兼容性。
- 改进未解析到稿件编号时的使用提示。

Enhancements:
- 提取并复用审核群短命令、引用消息及稿件编号解析逻辑。

Tests:
- 新增审核命令、编号格式、引用发送者校验和审核通知编号提取的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

确保审核群引用审核通知并 @机器人执行通过或拒绝时能够可靠解析并处理对应稿件。

Bug Fixes:
- 修复审核群通过或拒绝命令无法从引用的审核通知中解析稿件编号的问题。
- 允许缺少发送者信息的引用消息继续解析，同时拒绝明确来自其他用户的消息，并避免错误使用当前消息编号。
- 增强通过和拒绝命令对输入法混排、编号前后标点及 # 前缀的兼容性。
- 改进未解析到稿件编号时的使用提示。

Enhancements:
- 提取并复用审核群短命令、引用消息及稿件编号解析逻辑。

Tests:
- 新增审核命令、编号格式、引用发送者校验和审核通知编号提取的测试覆盖。

</details>

<details>
<summary>Original summary in English</summary>



</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Review-group commands now correctly recognize IDs with `#` or `/` prefixes and common punctuation, including full-width punctuation.
  - Reply-based review actions now resolve IDs more reliably from notification text and accept valid bot replies while rejecting unrelated senders.
  - Missing IDs in approval commands now show a focused usage hint instead of the full help message.

- **Tests**
  - Added coverage for command parsing and reply-based ID resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->