### PR TITLE
fix: 审核命令、发布 fanout 并发、UI 空白与弹层幽灵线等 8 项修复

### DIFF
--- a/apps/server/src/lib/post-transaction-wiring.test.ts
+++ b/apps/server/src/lib/post-transaction-wiring.test.ts
@@ -38,22 +38,29 @@ describe("post transaction compensation wiring", () => {
 });
 
 describe("publish fanout transaction wiring", () => {
-  test("requeue still schedules atomically via shared helper before enqueueing", () => {
+  test("requeue creates attempts inside the lock transaction before any enqueue", () => {
     const requeueStart = publishingSource.indexOf("export async function requeuePublishFanout");
     const requeueEnd = publishingSource.indexOf("export async function enqueueBatchPublishFanout", requeueStart);
     const requeueSource = publishingSource.slice(requeueStart, requeueEnd);
-    const helperStart = publishingSource.indexOf("async function scheduleAndEnqueueFanoutAttempts");
-    const helperEnd = publishingSource.indexOf("export async function enqueuePublishFanout", helperStart);
-    const helperSource = publishingSource.slice(helperStart, helperEnd);
-    const transactionStart = helperSource.indexOf("await prisma.$transaction(async (tx)");
-    const transactionalSchedule = helperSource.indexOf("schedulePublishAttemptInTransaction(tx", transactionStart);
-    const enqueue = helperSource.indexOf("enqueueAttemptUnique(queue", transactionStart);
 
-    expect(requeueStart).toBeGreaterThan(-1);
-    expect(requeueSource).toContain("scheduleAndEnqueueFanoutAttempts({");
+    const lock = requeueSource.indexOf("lockPublishFanout(tx, tenantId, `requeue:${postId}`)");
+    const transactionStart = requeueSource.indexOf("await prisma.$transaction(async (tx)");
+    const statusUpdate = requeueSource.indexOf('status: "publishing"', lock);
+    const transactionalSchedule = requeueSource.indexOf("schedulePublishAttemptInTransaction(tx", lock);
+    const transactionEnd = requeueSource.indexOf("}, {", transactionalSchedule);
+    const enqueue = requeueSource.indexOf("enqueueAttemptUnique(queue", transactionEnd);
+
+    expect(lock).toBeGreaterThan(-1);
     expect(transactionStart).toBeGreaterThan(-1);
-    expect(transactionalSchedule).toBeGreaterThan(transactionStart);
-    expect(enqueue).toBeGreaterThan(transactionalSchedule);
+    expect(lock).toBeGreaterThan(transactionStart);
+    // 状态更新与 attempt 创建都必须在锁事务内
+    expect(statusUpdate).toBeGreaterThan(lock);
+    expect(statusUpdate).toBeLessThan(transactionEnd);
+    expect(transactionalSchedule).toBeGreaterThan(statusUpdate);
+    expect(transactionalSchedule).toBeLessThan(transactionEnd);
+    // 入队只能在事务提交之后
+    expect(enqueue).toBeGreaterThan(transactionEnd);
+    expect(requeueSource).not.toContain("scheduleAndEnqueueFanoutAttempts({");
   });
 
   test("single-post fanout creates attempts inside the lock transaction before any enqueue", () => {

--- a/apps/server/src/lib/post-transaction-wiring.test.ts
+++ b/apps/server/src/lib/post-transaction-wiring.test.ts
@@ -57,6 +57,17 @@ describe("publish fanout transaction wiring", () => {
     expect(enqueue).toBeGreaterThan(transactionalSchedule);
   });
 
+  test("single-post fanout gates scheduling on the locked transaction result, not the pre-query targets", () => {
+    const fanoutStart = publishingSource.indexOf("export async function enqueuePublishFanout");
+    const fanoutEnd = publishingSource.indexOf("export async function requeuePublishFanout", fanoutStart);
+    const fanoutSource = publishingSource.slice(fanoutStart, fanoutEnd);
+
+    expect(fanoutSource).toContain("const scheduledTargets = await prisma.$transaction(");
+    expect(fanoutSource).toContain("if (!scheduledTargets || scheduledTargets.length === 0)");
+    expect(fanoutSource).toContain("targets: scheduledTargets");
+    expect(fanoutSource).not.toMatch(/if \(!targets \|\| targets\.length === 0\)/);
+  });
+
   test("commits every batch target and its durable marker before enqueueing", () => {
     const fanoutStart = publishingSource.indexOf("export async function enqueueBatchPublishFanout");
     const fanoutEnd = publishingSource.indexOf("async function ensurePostPublishSummary", fanoutStart);

--- a/apps/server/src/lib/post-transaction-wiring.test.ts
+++ b/apps/server/src/lib/post-transaction-wiring.test.ts
@@ -38,10 +38,10 @@ describe("post transaction compensation wiring", () => {
 });
 
 describe("publish fanout transaction wiring", () => {
-  test("persists every single-post target atomically before enqueueing any attempt", () => {
-    const fanoutStart = publishingSource.indexOf("export async function enqueuePublishFanout");
-    const fanoutEnd = publishingSource.indexOf("export async function enqueueBatchPublishFanout", fanoutStart);
-    const fanoutSource = publishingSource.slice(fanoutStart, fanoutEnd);
+  test("requeue still schedules atomically via shared helper before enqueueing", () => {
+    const requeueStart = publishingSource.indexOf("export async function requeuePublishFanout");
+    const requeueEnd = publishingSource.indexOf("export async function enqueueBatchPublishFanout", requeueStart);
+    const requeueSource = publishingSource.slice(requeueStart, requeueEnd);
     const helperStart = publishingSource.indexOf("async function scheduleAndEnqueueFanoutAttempts");
     const helperEnd = publishingSource.indexOf("export async function enqueuePublishFanout", helperStart);
     const helperSource = publishingSource.slice(helperStart, helperEnd);
@@ -49,23 +49,34 @@ describe("publish fanout transaction wiring", () => {
     const transactionalSchedule = helperSource.indexOf("schedulePublishAttemptInTransaction(tx", transactionStart);
     const enqueue = helperSource.indexOf("enqueueAttemptUnique(queue", transactionStart);
 
-    expect(fanoutStart).toBeGreaterThan(-1);
-    expect(fanoutEnd).toBeGreaterThan(fanoutStart);
-    expect(fanoutSource).toContain("scheduleAndEnqueueFanoutAttempts({");
+    expect(requeueStart).toBeGreaterThan(-1);
+    expect(requeueSource).toContain("scheduleAndEnqueueFanoutAttempts({");
     expect(transactionStart).toBeGreaterThan(-1);
     expect(transactionalSchedule).toBeGreaterThan(transactionStart);
     expect(enqueue).toBeGreaterThan(transactionalSchedule);
   });
 
-  test("single-post fanout gates scheduling on the locked transaction result, not the pre-query targets", () => {
+  test("single-post fanout creates attempts inside the lock transaction before any enqueue", () => {
     const fanoutStart = publishingSource.indexOf("export async function enqueuePublishFanout");
     const fanoutEnd = publishingSource.indexOf("export async function requeuePublishFanout", fanoutStart);
     const fanoutSource = publishingSource.slice(fanoutStart, fanoutEnd);
 
-    expect(fanoutSource).toContain("const scheduledTargets = await prisma.$transaction(");
-    expect(fanoutSource).toContain("if (!scheduledTargets || scheduledTargets.length === 0)");
-    expect(fanoutSource).toContain("targets: scheduledTargets");
-    expect(fanoutSource).not.toMatch(/if \(!targets \|\| targets\.length === 0\)/);
+    const lock = fanoutSource.indexOf("lockPublishFanout(tx, tenantId, `post:${postId}`)");
+    const transactionStart = fanoutSource.indexOf("await prisma.$transaction(async (tx)");
+    const transactionalSchedule = fanoutSource.indexOf("schedulePublishAttemptInTransaction(tx", lock);
+    const transactionEnd = fanoutSource.indexOf("}, {", transactionalSchedule);
+    const enqueue = fanoutSource.indexOf("enqueueAttemptUnique(queue", transactionEnd);
+
+    expect(lock).toBeGreaterThan(-1);
+    expect(transactionStart).toBeGreaterThan(-1);
+    expect(lock).toBeGreaterThan(transactionStart);
+    // attempt 必须在锁事务内创建，锁释放后并发方才能看到并 skip
+    expect(transactionalSchedule).toBeGreaterThan(lock);
+    expect(transactionalSchedule).toBeLessThan(transactionEnd);
+    // 入队只能在事务提交之后
+    expect(enqueue).toBeGreaterThan(transactionEnd);
+    // 不得再把调度甩到锁外的 scheduleAndEnqueueFanoutAttempts
+    expect(fanoutSource).not.toContain("scheduleAndEnqueueFanoutAttempts({");
   });
 
   test("commits every batch target and its durable marker before enqueueing", () => {

--- a/apps/server/src/runtime/onebot-command.test.ts
+++ b/apps/server/src/runtime/onebot-command.test.ts
@@ -14,6 +14,7 @@ import {
   parseDisplayId,
   parseRejectArgs,
   parseReviewGroupCommand,
+  parseReviewGroupShortCommand,
   parseUnbanCommandArgs,
   resolvePrivatePostModeSelectionFromSemantic,
   resolvePrivatePostSemanticAction,
@@ -83,6 +84,35 @@ describe("parseRejectArgs 尾部标点兼容", () => {
 
   test("编号带 # 前缀", () => {
     expect(parseRejectArgs("内容违规 #6724")).toEqual({ comment: "内容违规", displayId: 6724 });
+  });
+
+  test("理由中的句号等标点保留", () => {
+    expect(parseRejectArgs("内容违规。请处理 6724")).toEqual({ comment: "内容违规。请处理", displayId: 6724 });
+  });
+});
+
+describe("parseReviewGroupShortCommand", () => {
+  test("去掉 CQ at 后识别「通过」", () => {
+    expect(parseReviewGroupShortCommand("[CQ:at,qq=10001] 通过")).toEqual({ name: "通过", args: "" });
+  });
+
+  test("「过」简写", () => {
+    expect(parseReviewGroupShortCommand("[CQ:at,qq=10001] 过")).toEqual({ name: "通过", args: "" });
+  });
+
+  test("通过带混排编号，args 原样交给 parseDisplayId", () => {
+    expect(parseReviewGroupShortCommand("[CQ:at,qq=10001] 通过！6724")).toEqual({ name: "通过", args: "！6724" });
+  });
+
+  test("拒绝理由中的标点不得被改写", () => {
+    expect(parseReviewGroupShortCommand("[CQ:at,qq=10001] 拒绝 内容违规。请处理 6724")).toEqual({
+      name: "拒绝",
+      args: "内容违规。请处理 6724",
+    });
+  });
+
+  test("非审核简写返回 null", () => {
+    expect(parseReviewGroupShortCommand("[CQ:at,qq=10001] 你好")).toBeNull();
   });
 });
 

--- a/apps/server/src/runtime/onebot-command.test.ts
+++ b/apps/server/src/runtime/onebot-command.test.ts
@@ -120,6 +120,13 @@ describe("parseReviewGroupShortCommand", () => {
   test("非审核简写返回 null", () => {
     expect(parseReviewGroupShortCommand("[CQ:at,qq=10001] 你好")).toBeNull();
   });
+
+  test("与后续字词粘连时不当作命令（通过率/拒绝率/通过了）", () => {
+    expect(parseReviewGroupShortCommand("[CQ:at,qq=10001] 通过率")).toBeNull();
+    expect(parseReviewGroupShortCommand("[CQ:at,qq=10001] 拒绝率")).toBeNull();
+    expect(parseReviewGroupShortCommand("[CQ:at,qq=10001] 通过了")).toBeNull();
+    expect(parseReviewGroupShortCommand("[CQ:at,qq=10001] 过期")).toBeNull();
+  });
 });
 
 describe("review group ban command parsing", () => {

--- a/apps/server/src/runtime/onebot-command.test.ts
+++ b/apps/server/src/runtime/onebot-command.test.ts
@@ -11,6 +11,8 @@ import {
   shouldSubmitPrivatePostAfterModeSelection,
   parseBanCommandArgs,
   parseCommand,
+  parseDisplayId,
+  parseRejectArgs,
   parseReviewGroupCommand,
   parseUnbanCommandArgs,
   resolvePrivatePostModeSelectionFromSemantic,
@@ -45,6 +47,42 @@ describe("parseCommand prefix handling", () => {
 
   test("命令前有非 @ 文本时不识别", () => {
     expect(parseCommand("随便说点什么 ＃通过 1")).toBeNull();
+  });
+});
+
+describe("parseDisplayId 混排与标点兼容", () => {
+  test("纯数字", () => {
+    expect(parseDisplayId("6724")).toBe(6724);
+  });
+
+  test("全角感叹号前缀（输入法粘连）", () => {
+    expect(parseDisplayId("！6724")).toBe(6724);
+  });
+
+  test("全角感叹号后缀", () => {
+    expect(parseDisplayId("6724！")).toBe(6724);
+  });
+
+  test("带 # 前缀", () => {
+    expect(parseDisplayId("#6724")).toBe(6724);
+  });
+
+  test("无数字时返回 null", () => {
+    expect(parseDisplayId("通过")).toBeNull();
+  });
+});
+
+describe("parseRejectArgs 尾部标点兼容", () => {
+  test("标准 理由 + 编号", () => {
+    expect(parseRejectArgs("内容违规 6724")).toEqual({ comment: "内容违规", displayId: 6724 });
+  });
+
+  test("编号后带全角感叹号", () => {
+    expect(parseRejectArgs("内容违规 6724！")).toEqual({ comment: "内容违规", displayId: 6724 });
+  });
+
+  test("编号带 # 前缀", () => {
+    expect(parseRejectArgs("内容违规 #6724")).toEqual({ comment: "内容违规", displayId: 6724 });
   });
 });
 

--- a/apps/server/src/runtime/onebot-command.test.ts
+++ b/apps/server/src/runtime/onebot-command.test.ts
@@ -71,6 +71,12 @@ describe("parseDisplayId 混排与标点兼容", () => {
   test("无数字时返回 null", () => {
     expect(parseDisplayId("通过")).toBeNull();
   });
+
+  test("夹杂普通文本时拒绝，避免误操作错误稿件", () => {
+    expect(parseDisplayId("abc123")).toBeNull();
+    expect(parseDisplayId("误操作 6724")).toBeNull();
+    expect(parseDisplayId("123abc")).toBeNull();
+  });
 });
 
 describe("parseRejectArgs 尾部标点兼容", () => {

--- a/apps/server/src/runtime/onebot.ts
+++ b/apps/server/src/runtime/onebot.ts
@@ -32,6 +32,7 @@ import { readTenantPluginConfig } from "../lib/tenant-plugin-config";
 import { setBotCustomStylishMessages } from "../lib/bot-messages";
 import { isTenantRuntimeActive, tenantRuntimeRelationFilter } from "../lib/tenant-runtime";
 import { lockActiveTenantRuntime, runWithActiveTenantLease } from "../lib/tenant-runtime-lease";
+import { extractDisplayIdFromReviewText, isAllowedReplySender } from "./review-reply-resolve";
 import {
   buildImageSourceSizeErrorMessage,
   imageStorageHardMaxBytes,
@@ -2579,12 +2580,17 @@ export class OneBotRuntime {
 
     // 如果没有以 # 或 / 明确给出命令，但消息是 @ 机器人的短命令（比如 过/拒），支持基于 mention 的快捷命令。
     if (!command && isMentioningBot(event, botQqUin)) {
-      const normalized = extractPlainText(event).replace(/\[CQ:at,qq=\d+\]/g, "").trim();
-      const shortMatch = normalized.match(/^(过|通过)(?:\s*(.*))?$/);
+      const normalized = extractPlainText(event)
+        .replace(/\[CQ:at,qq=\d+\]/g, "")
+        .replace(/[#＃/]/g, " ")
+        .replace(/[！!。．.、，,]/g, " ")
+        .trim();
+      // 允许 "通过"、"过"、"通过 6724"、"通过！6724" 等
+      const shortMatch = normalized.match(/^(过|通过)\s*(.*)$/);
       if (shortMatch) {
         command = { name: "通过", args: (shortMatch[2] ?? "").trim() };
       } else {
-        const rejectMatch = normalized.match(/^(拒|拒绝)(?:\s*(.*))?$/);
+        const rejectMatch = normalized.match(/^(拒|拒绝)\s*(.*)$/);
         if (rejectMatch) {
           command = { name: "拒绝", args: (rejectMatch[2] ?? "").trim() };
         }
@@ -2684,7 +2690,10 @@ export class OneBotRuntime {
           displayId = await this.tryResolveDisplayIdFromReply(event, botQqUin);
         }
         if (!displayId) {
-          await this.sendGroupMessage(botQqUin, groupId, reviewHelp);
+          await this.sendGroupMessage(botQqUin, groupId, [
+            "未解析到稿件编号。可发送：#通过 <稿件id>",
+            "或直接回复（引用）审核通知消息，并 @机器人 发送「通过」。",
+          ].join("\n"));
           return;
         }
         const result = await reviewPostViaBot({
@@ -3384,26 +3393,8 @@ export class OneBotRuntime {
 
   private async tryResolveDisplayIdFromReply(event: OneBotMessageEvent, botQqUin: string): Promise<number | null> {
     try {
-      const replyId = (() => {
-        if (typeof event.raw_message === "string") {
-          const m = event.raw_message.match(/\[CQ:reply,id=(\d+)(?:,.*)?\]/);
-          if (m) return m[1];
-        }
-        if (Array.isArray(event.message)) {
-          for (const seg of event.message as any[]) {
-            if (!seg || typeof seg !== "object") continue;
-            if (seg.type === "reply") {
-              const id = seg.data?.id ?? seg.data?.msg_id ?? seg.data?.message_id;
-              if (id) return String(id);
-            }
-          }
-        }
-        if (event.message_id) {
-          return String(event.message_id);
-        }
-        return null;
-      })();
-
+      // 只解析真正的 reply 段；不要回退到 event.message_id（那是当前消息，不是被引用的审核通知）。
+      const replyId = this.extractReplyMessageId(event);
       if (!replyId) {
         return null;
       }
@@ -3411,12 +3402,13 @@ export class OneBotRuntime {
       const data = await this.callAction(botQqUin, "get_msg", { message_id: replyId }).catch(() => null);
       if (!data) return null;
 
-      // Verify the replied message was sent by the bot itself
+      // 仅当能明确识别发送者且不是本 bot 时才拒绝。
+      // 部分 OneBot 实现（NapCat 等）get_msg 可能不带 sender，此时仍尝试从正文解析编号。
       const sender = (data as any).sender ?? (data as any).user ?? null;
       const senderId = sender
         ? normalizeId(sender.user_id ?? sender.userId ?? sender.uin ?? sender.qq ?? sender.id)
         : null;
-      if (!senderId || senderId !== botQqUin) {
+      if (!isAllowedReplySender(senderId, botQqUin)) {
         return null;
       }
 
@@ -3424,22 +3416,22 @@ export class OneBotRuntime {
       let text = "";
       if (Array.isArray((data as any).message)) {
         text = (data as any).message
-          .map((seg: any) => (seg?.type === "text" ? seg?.data?.text ?? "" : ""))
+          .map((seg: any) => {
+            if (seg?.type === "text") return seg?.data?.text ?? "";
+            if (seg?.type === "reply" || seg?.type === "at") return "";
+            return typeof seg?.data?.text === "string" ? seg.data.text : "";
+          })
           .join("");
       } else if (typeof (data as any).message === "string") {
         text = (data as any).message;
-      } else if (typeof (data as any).raw_message === "string") {
+      }
+      if (!text && typeof (data as any).raw_message === "string") {
         text = (data as any).raw_message;
       }
 
       if (!text) return null;
-
-      // Try to extract displayId from notification text: prefer `编号：#123` then `#123`
-      const m = text.match(/(?:编号：#|#)(\d+)\b/);
-      if (!m) return null;
-      const id = Number(m[1]);
-      return Number.isInteger(id) && id > 0 ? id : null;
-    } catch (error) {
+      return extractDisplayIdFromReviewText(text);
+    } catch {
       return null;
     }
   }
@@ -4051,14 +4043,20 @@ function parsePrivateCommand(input: string) {
   };
 }
 
-function parseDisplayId(args: string) {
-  const id = Number(args.trim());
+export function parseDisplayId(args: string) {
+  // 兼容 "6724"、"！6724"、"6724！"、"#6724" 等常见粘贴/输入法混排
+  const match = args.trim().match(/#?(\d+)/);
+  if (!match?.[1]) {
+    return null;
+  }
+  const id = Number(match[1]);
   return Number.isInteger(id) && id > 0 ? id : null;
 }
 
-function parseRejectArgs(args: string) {
-  const match = args.trim().match(/^(.*\S)\s+(\d+)$/);
-  if (!match) {
+export function parseRejectArgs(args: string) {
+  // 兼容尾部标点：#拒绝 理由 6724！
+  const match = args.trim().match(/^(.*\S)\s+#?(\d+)[！!。．]*$/);
+  if (!match?.[1] || !match[2]) {
     return null;
   }
   const comment = match[1];

--- a/apps/server/src/runtime/onebot.ts
+++ b/apps/server/src/runtime/onebot.ts
@@ -4049,8 +4049,10 @@ function parsePrivateCommand(input: string) {
 }
 
 export function parseDisplayId(args: string) {
-  // 兼容 "6724"、"！6724"、"6724！"、"#6724" 等常见粘贴/输入法混排
-  const match = args.trim().match(/#?(\d+)/);
+  // 整段必须是独立编号，仅允许前后粘连明确支持的标点/前缀：
+  // "6724"、"！6724"、"6724！"、"#6724"、"#6724！"
+  // 拒绝 "abc123"、"误操作 6724" 等夹杂普通文本的输入。
+  const match = args.trim().match(/^[#＃！!]?\s*(\d+)\s*[！!]?$/);
   if (!match?.[1]) {
     return null;
   }

--- a/apps/server/src/runtime/onebot.ts
+++ b/apps/server/src/runtime/onebot.ts
@@ -2580,21 +2580,7 @@ export class OneBotRuntime {
 
     // 如果没有以 # 或 / 明确给出命令，但消息是 @ 机器人的短命令（比如 过/拒），支持基于 mention 的快捷命令。
     if (!command && isMentioningBot(event, botQqUin)) {
-      const normalized = extractPlainText(event)
-        .replace(/\[CQ:at,qq=\d+\]/g, "")
-        .replace(/[#＃/]/g, " ")
-        .replace(/[！!。．.、，,]/g, " ")
-        .trim();
-      // 允许 "通过"、"过"、"通过 6724"、"通过！6724" 等
-      const shortMatch = normalized.match(/^(过|通过)\s*(.*)$/);
-      if (shortMatch) {
-        command = { name: "通过", args: (shortMatch[2] ?? "").trim() };
-      } else {
-        const rejectMatch = normalized.match(/^(拒|拒绝)\s*(.*)$/);
-        if (rejectMatch) {
-          command = { name: "拒绝", args: (rejectMatch[2] ?? "").trim() };
-        }
-      }
+      command = parseReviewGroupShortCommand(extractPlainText(event));
     }
 
 
@@ -3947,6 +3933,25 @@ export function parseReviewGroupCommand(input: string) {
     name: bareCommand[1].toLowerCase(),
     args: bareCommand[2]?.trim() ?? "",
   };
+}
+
+/**
+ * @机器人 的简写审核命令（过/通过/拒/拒绝）。
+ * 只去掉 CQ at 段；args 保留原文，拒绝理由中的标点不得被改写。
+ * 「通过！6724」等混排由后续 parseDisplayId / parseRejectArgs 处理。
+ */
+export function parseReviewGroupShortCommand(input: string): { name: string; args: string } | null {
+  const withoutAt = input.replace(/\[CQ:at,qq=\d+\]/g, "").trim();
+  // 长词优先，避免「拒」抢在「拒绝」前面
+  const approve = withoutAt.match(/^(通过|过)([\s\S]*)$/);
+  if (approve) {
+    return { name: "通过", args: (approve[2] ?? "").trim() };
+  }
+  const reject = withoutAt.match(/^(拒绝|拒)([\s\S]*)$/);
+  if (reject) {
+    return { name: "拒绝", args: (reject[2] ?? "").trim() };
+  }
+  return null;
 }
 
 export function shouldNotifyReviewGroupAfterPrivatePostCreate(post: { status: string }) {

--- a/apps/server/src/runtime/onebot.ts
+++ b/apps/server/src/runtime/onebot.ts
@@ -3938,16 +3938,17 @@ export function parseReviewGroupCommand(input: string) {
 /**
  * @机器人 的简写审核命令（过/通过/拒/拒绝）。
  * 只去掉 CQ at 段；args 保留原文，拒绝理由中的标点不得被改写。
+ * 命令词后必须是结尾、空白或标点，避免「通过率」「拒绝率」被当成命令。
  * 「通过！6724」等混排由后续 parseDisplayId / parseRejectArgs 处理。
  */
 export function parseReviewGroupShortCommand(input: string): { name: string; args: string } | null {
   const withoutAt = input.replace(/\[CQ:at,qq=\d+\]/g, "").trim();
-  // 长词优先，避免「拒」抢在「拒绝」前面
-  const approve = withoutAt.match(/^(通过|过)([\s\S]*)$/);
+  // 长词优先；(?![\p{L}\p{N}_]) 拒绝与后续汉字/字母/数字粘连
+  const approve = withoutAt.match(/^(通过|过)(?![\p{L}\p{N}_])([\s\S]*)$/u);
   if (approve) {
     return { name: "通过", args: (approve[2] ?? "").trim() };
   }
-  const reject = withoutAt.match(/^(拒绝|拒)([\s\S]*)$/);
+  const reject = withoutAt.match(/^(拒绝|拒)(?![\p{L}\p{N}_])([\s\S]*)$/u);
   if (reject) {
     return { name: "拒绝", args: (reject[2] ?? "").trim() };
   }

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -778,7 +778,7 @@ export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string
     },
   });
 
-  const attempts = await prisma.$transaction(async (tx) => {
+  const scheduledTargets = await prisma.$transaction(async (tx) => {
     await lockPublishFanout(tx, tenantId, `post:${postId}`);
     const currentPost = await tx.post.findUnique({
       where: { id: postId },
@@ -838,16 +838,16 @@ export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string
     maxWait: 5_000,
     timeout: 30_000,
   });
-  // Use the transaction's returned result as the sole gate: it returns [] when
-  // fanout is skipped or no targets exist, and the targets array otherwise.
-  if (!targets || targets.length === 0) {
+  // 以事务返回值为唯一闸门：跳过或无目标时返回 []，否则返回待调度 targets。
+  // 不能用外层预查询的 targets——并发下锁内可能已决定 skip。
+  if (!scheduledTargets || scheduledTargets.length === 0) {
     return [];
   }
   return scheduleAndEnqueueFanoutAttempts({
     queue,
     tenantId,
     postId,
-    targets,
+    targets: scheduledTargets,
     resetAttempt: false,
   });
 }

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -675,63 +675,6 @@ export function publishTargetIntervalSeconds(target: { publishDelaySeconds: numb
   return target.publishDelaySeconds ?? null;
 }
 
-interface ScheduleAndEnqueueFanoutOptions {
-  queue: RuntimeQueue;
-  tenantId: string;
-  postId: string;
-  batchId?: string | null;
-  targets: Array<{ id: string; botAccountId: string; publishDelaySeconds: number | null }>;
-  resetAttempt?: boolean;
-}
-
-/**
- * Shared helper: schedule publish attempts for each target and enqueue them.
- * Used by both enqueuePublishFanout and requeuePublishFanout to keep behavior aligned.
- *
- * All scheduling happens in a single transaction so that either all targets succeed
- * or none do, preventing orphaned PublishAttempt records without queue jobs.
- *
- * Enqueueing uses enqueueUnique with a stable dedupe key (postId:publishTargetId or
- * batchId:publishTargetId) to ensure each attempt produces at most one publishPost job.
- */
-async function scheduleAndEnqueueFanoutAttempts(options: ScheduleAndEnqueueFanoutOptions) {
-  const { queue, tenantId, postId, batchId, targets, resetAttempt } = options;
-
-  const scheduledAttempts = await prisma.$transaction(async (tx) => {
-    const results = [];
-    for (const target of targets) {
-      const scheduleOptions: SchedulePublishAttemptOptions = {
-        tenantId,
-        postId,
-        publishTargetId: target.id,
-        botAccountId: target.botAccountId,
-        intervalSeconds: publishTargetIntervalSeconds(target),
-        resetAttempt: resetAttempt ?? false,
-      };
-      if (batchId !== undefined) {
-        scheduleOptions.batchId = batchId;
-      }
-      const scheduled = await schedulePublishAttemptInTransaction(tx, scheduleOptions);
-      results.push({ scheduled, targetId: target.id });
-    }
-    return results;
-  }, {
-    maxWait: 5_000,
-    timeout: 30_000,
-  });
-
-  // Enqueue all attempts after successful transaction commit using unique keys
-  // to prevent duplicate jobs for the same (postId, publishTargetId) or (batchId, publishTargetId)
-  for (const { scheduled, targetId } of scheduledAttempts) {
-    const dedupeKey = batchId
-      ? `publish:${batchId}:${targetId}`
-      : `publish:${postId}:${targetId}`;
-    enqueueAttemptUnique(queue, tenantId, scheduled.attempt.id, dedupeKey, scheduled.nextRunAt);
-  }
-
-  return scheduledAttempts.map(({ scheduled }) => scheduled.attempt);
-}
-
 export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string, postId: string, actorId?: string | null) {
   const post = await prisma.post.findUnique({
     where: {
@@ -901,38 +844,63 @@ export async function requeuePublishFanout(queue: RuntimeQueue, tenantId: string
     return [];
   }
 
-  // Serialize concurrent requeue scheduling for the same post
-  await prisma.$transaction(async (tx) => {
+  // 锁内完成状态变更与 attempt 落库；锁释放后才 enqueue。
+  // 与 enqueuePublishFanout / enqueueBatchPublishFanout 一致，避免并发 requeue 双入队。
+  const scheduledAttempts = await prisma.$transaction(async (tx) => {
     await lockPublishFanout(tx, tenantId, `requeue:${postId}`);
+    const currentPost = await tx.post.findUnique({
+      where: { id: postId },
+      select: { id: true, status: true },
+    });
+    if (!currentPost) {
+      return [];
+    }
+
+    await tx.post.update({
+      where: {
+        id: postId,
+      },
+      data: {
+        status: "publishing",
+        logs: {
+          create: {
+            tenantId,
+            actorId: actorId ?? null,
+            newStatus: "publishing",
+            comment: `手动重发，已重置 ${targets.length} 个发布任务并重新排队`,
+          },
+        },
+      },
+    });
+
+    const results = [];
+    for (const target of targets) {
+      const scheduled = await schedulePublishAttemptInTransaction(tx, {
+        tenantId,
+        postId,
+        publishTargetId: target.id,
+        botAccountId: target.botAccountId,
+        intervalSeconds: publishTargetIntervalSeconds(target),
+        resetAttempt: true,
+      });
+      results.push(scheduled);
+    }
+    return results;
   }, {
     maxWait: 5_000,
     timeout: 30_000,
   });
 
-  await prisma.post.update({
-    where: {
-      id: postId,
-    },
-    data: {
-      status: "publishing",
-      logs: {
-        create: {
-          tenantId,
-          actorId: actorId ?? null,
-          newStatus: "publishing",
-          comment: `手动重发，已重置 ${targets.length} 个发布任务并重新排队`,
-        },
-      },
-    },
-  });
+  if (scheduledAttempts.length === 0) {
+    return [];
+  }
 
-  return scheduleAndEnqueueFanoutAttempts({
-    queue,
-    tenantId,
-    postId,
-    targets,
-    resetAttempt: true,
-  });
+  for (const scheduled of scheduledAttempts) {
+    const dedupeKey = `publish:${postId}:${scheduled.attempt.publishTargetId}`;
+    enqueueAttemptUnique(queue, tenantId, scheduled.attempt.id, dedupeKey, scheduled.nextRunAt);
+  }
+
+  return scheduledAttempts.map(({ attempt }) => attempt);
 }
 
 /**

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -778,7 +778,9 @@ export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string
     },
   });
 
-  const scheduledTargets = await prisma.$transaction(async (tx) => {
+  // 锁内完成状态变更与 attempt 落库；锁释放后才 enqueue。
+  // 与 enqueueBatchPublishFanout 一致：并发方等锁后重读，会看到 active/succeeded attempts 并 skip。
+  const scheduledAttempts = await prisma.$transaction(async (tx) => {
     await lockPublishFanout(tx, tenantId, `post:${postId}`);
     const currentPost = await tx.post.findUnique({
       where: { id: postId },
@@ -833,23 +835,35 @@ export async function enqueuePublishFanout(queue: RuntimeQueue, tenantId: string
         },
       },
     });
-    return targets;
+
+    const results = [];
+    for (const target of targets) {
+      const scheduled = await schedulePublishAttemptInTransaction(tx, {
+        tenantId,
+        postId,
+        publishTargetId: target.id,
+        botAccountId: target.botAccountId,
+        intervalSeconds: publishTargetIntervalSeconds(target),
+      });
+      results.push(scheduled);
+    }
+    return results;
   }, {
     maxWait: 5_000,
     timeout: 30_000,
   });
-  // 以事务返回值为唯一闸门：跳过或无目标时返回 []，否则返回待调度 targets。
-  // 不能用外层预查询的 targets——并发下锁内可能已决定 skip。
-  if (!scheduledTargets || scheduledTargets.length === 0) {
+
+  if (scheduledAttempts.length === 0) {
     return [];
   }
-  return scheduleAndEnqueueFanoutAttempts({
-    queue,
-    tenantId,
-    postId,
-    targets: scheduledTargets,
-    resetAttempt: false,
-  });
+
+  // attempt 已在同一把锁事务内落库；锁外只负责入队。
+  for (const scheduled of scheduledAttempts) {
+    const dedupeKey = `publish:${postId}:${scheduled.attempt.publishTargetId}`;
+    enqueueAttemptUnique(queue, tenantId, scheduled.attempt.id, dedupeKey, scheduled.nextRunAt);
+  }
+
+  return scheduledAttempts.map(({ attempt }) => attempt);
 }
 
 export async function requeuePublishFanout(queue: RuntimeQueue, tenantId: string, postId: string, actorId?: string | null) {

--- a/apps/server/src/runtime/review-reply-resolve.test.ts
+++ b/apps/server/src/runtime/review-reply-resolve.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { extractDisplayIdFromReviewText, isAllowedReplySender } from "./review-reply-resolve";
+
+describe("extractDisplayIdFromReviewText", () => {
+  const reviewText = [
+    "📮 中山中学校园墙新稿件",
+    "编号：#6724",
+    "投稿人：匿名（QQ 123）",
+    "来源：网页投稿",
+    "图片：0 张",
+    "",
+    "有没有人上过学…",
+    "",
+    "通过：#通过 6724",
+    "拒绝：#拒绝 <理由> 6724",
+  ].join("\n");
+
+  test("从审核通知提取编号", () => {
+    expect(extractDisplayIdFromReviewText(reviewText)).toBe(6724);
+  });
+
+  test("兼容半角冒号编号", () => {
+    expect(extractDisplayIdFromReviewText("编号: #42\n通过：#通过 42")).toBe(42);
+  });
+
+  test("无编号时返回 null", () => {
+    expect(extractDisplayIdFromReviewText("随便聊聊")).toBeNull();
+  });
+});
+
+describe("isAllowedReplySender", () => {
+  test("sender 缺失时允许继续解析", () => {
+    expect(isAllowedReplySender(null, "10001")).toBe(true);
+  });
+
+  test("sender 是本 bot 时允许", () => {
+    expect(isAllowedReplySender("10001", "10001")).toBe(true);
+  });
+
+  test("sender 是其他用户时拒绝", () => {
+    expect(isAllowedReplySender("20002", "10001")).toBe(false);
+  });
+});

--- a/apps/server/src/runtime/review-reply-resolve.ts
+++ b/apps/server/src/runtime/review-reply-resolve.ts
@@ -1,0 +1,17 @@
+/** 从审核通知正文提取稿件编号。优先「编号：#123」，否则取第一个 #123。 */
+export function extractDisplayIdFromReviewText(text: string): number | null {
+  const m = text.match(/编号[：:]\s*#\s*(\d+)/) ?? text.match(/#(\d+)\b/);
+  if (!m?.[1]) return null;
+  const id = Number(m[1]);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+/**
+ * 判断 get_msg 返回的发送者是否允许用于引用解析。
+ * - sender 缺失（部分 OneBot 实现不返回）→ 允许继续解析
+ * - sender 明确且不是本 bot → 拒绝
+ */
+export function isAllowedReplySender(senderId: string | null, botQqUin: string): boolean {
+  if (!senderId) return true;
+  return senderId === botQqUin;
+}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -29,7 +29,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/15 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 z-50 bg-black/15 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/drawer.tsx
+++ b/apps/web/src/components/ui/drawer.tsx
@@ -35,7 +35,7 @@ function DrawerOverlay({
     <DrawerPrimitive.Overlay
       data-slot="drawer-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 z-50 bg-black/10 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -37,7 +37,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 z-50 bg-black/10 duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className
       )}
       {...props}

--- a/apps/web/src/features/admin/AdminPage.tsx
+++ b/apps/web/src/features/admin/AdminPage.tsx
@@ -1056,7 +1056,7 @@ export function AdminPage({
 
   return (
     <div className="flex h-full min-h-0 flex-col px-4 pt-4">
-      <Tabs value={activeTab} onValueChange={(value) => onTabChange(value as AdminTab)} className="min-h-0 flex-1">
+      <Tabs value={activeTab} onValueChange={(value) => onTabChange(value as AdminTab)} className="min-h-0 flex-1 overflow-hidden">
         <TabsList className={managementTabsListClassName}>
           <TabsTrigger value="users" className={managementTabsTriggerClassName}>
             用户

--- a/apps/web/src/features/admin/PluginConfigPage.tsx
+++ b/apps/web/src/features/admin/PluginConfigPage.tsx
@@ -6,6 +6,7 @@ import { FONT_OPTIONS } from "@campux/domain";
 import type { BotMessageTypeConfig, PluginColorPreset, TenantMetadata, TenantPluginConfig } from "@/types/app";
 import { api } from "@/lib/api";
 import { builtInSvgAvatarFilenames } from "@/lib/built-in-svg-avatars";
+import { filterPluginAuditLogs } from "./plugin-audit-log-filter";
 import { AggregateLoginIcon, AGGREGATE_LOGIN_TYPE_LABELS } from "../aggregate-oauth/icons";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -1187,7 +1188,9 @@ export function PluginConfigPage({ tenantId, metadata, onSaved }: { tenantId: st
                       <div className="grid place-items-center py-6 text-xs text-slate-400"><LoaderIcon className="size-4 animate-spin" /> 加载中…</div>
                     ) : (
                       (() => {
-                        const filtered = logScope === "current" ? auditLog.filter((entry) => entry.pluginName === activePlugin.name) : auditLog;
+                        const filtered = logScope === "current"
+                          ? filterPluginAuditLogs(auditLog, activePlugin.id, PRESET_NAME_BY_ID[activePlugin.id])
+                          : auditLog;
                         if (filtered.length === 0) {
                           return <p className="py-4 text-center text-xs text-slate-400">暂无日志</p>;
                         }

--- a/apps/web/src/features/admin/plugin-audit-log-filter.test.ts
+++ b/apps/web/src/features/admin/plugin-audit-log-filter.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { filterPluginAuditLogs } from "./plugin-audit-log-filter";
+
+const PRESET_NAME_BY_ID: Record<string, string> = {
+  markdownRender: "campux-plugin-markdown-render",
+  colorSelection: "campux-plugin-color-selection",
+  campaigns: "campux-plugin-campaigns",
+};
+
+describe("filterPluginAuditLogs", () => {
+  const auditLog = [
+    {
+      id: "1",
+      pluginName: "campux-plugin-markdown-render",
+      action: "tenant.plugin.markdownRender.enable",
+    },
+    {
+      id: "2",
+      pluginName: "campux-plugin-color-selection",
+      action: "tenant.plugin.colorSelection.config",
+    },
+  ];
+
+  test("matches registry pluginName, not Chinese display name", () => {
+    const filtered = filterPluginAuditLogs(auditLog, "markdownRender", PRESET_NAME_BY_ID.markdownRender!);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]?.pluginName).toBe("campux-plugin-markdown-render");
+  });
+
+  test("legacy display-name filter would incorrectly return empty", () => {
+    const wrong = auditLog.filter((entry) => entry.pluginName === "Markdown 渲染");
+    expect(wrong).toHaveLength(0);
+  });
+
+  test("falls back to action token when pluginName is missing", () => {
+    const withNullName = [{ id: "4", pluginName: null, action: "tenant.plugin.campaigns.enable" }];
+    const filtered = filterPluginAuditLogs(withNullName, "campaigns", PRESET_NAME_BY_ID.campaigns!);
+    expect(filtered).toHaveLength(1);
+  });
+
+  test("does not leak other plugins into current scope", () => {
+    const filtered = filterPluginAuditLogs(auditLog, "colorSelection", PRESET_NAME_BY_ID.colorSelection!);
+    expect(filtered.map((entry) => entry.id)).toEqual(["2"]);
+  });
+});

--- a/apps/web/src/features/admin/plugin-audit-log-filter.ts
+++ b/apps/web/src/features/admin/plugin-audit-log-filter.ts
@@ -1,0 +1,10 @@
+/** 审计日志「当前插件」过滤：pluginName 是 registry 名，不是界面展示名。 */
+export function filterPluginAuditLogs<T extends { pluginName: string | null; action: string }>(
+  auditLog: readonly T[],
+  pluginId: string,
+  registryName: string,
+): T[] {
+  return auditLog.filter(
+    (entry) => entry.pluginName === registryName || entry.action.includes(`.${pluginId}.`),
+  );
+}

--- a/apps/web/src/features/posts/PostRulesAction.tsx
+++ b/apps/web/src/features/posts/PostRulesAction.tsx
@@ -38,8 +38,9 @@ const RuleButton = forwardRef<HTMLButtonElement, ComponentPropsWithoutRef<"butto
 });
 
 function RuleList({ rules }: { rules: string[] }) {
+  // 不用 flex-1：在 Drawer/Dialog 的 flex 列里会把中间区域撑满，底部出现大片空白。
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto px-4 md:px-5">
+    <div className="max-h-[50dvh] overflow-y-auto px-4 md:px-5">
       <div className="flex flex-col gap-2 pb-1">
         {rules.map((rule, index) => (
           <Alert key={rule} className="rounded-md">
@@ -67,7 +68,7 @@ export function PostRulesAction({ rules }: { rules: string[] }) {
               <DrawerDescription>发布前请确认内容符合当前校园墙规范。</DrawerDescription>
             </DrawerHeader>
             <RuleList rules={rules} />
-            <DrawerFooter className="shrink-0">
+            <DrawerFooter className="mt-0 shrink-0">
               <DrawerClose asChild>
                 <Button>好的</Button>
               </DrawerClose>


### PR DESCRIPTION
## Summary

本 PR 合并 8 个独立修复，覆盖审核群命令、发布 fanout 并发、Web 布局空白、插件日志过滤，以及弹层遮罩在 Chromium 失焦时的幽灵横线。

### Web

1. **插件「当前插件」日志永远为空**  
   审计接口返回的 `pluginName` 是 registry 名（如 `campux-plugin-markdown-render`），前端却用界面展示名（如「Markdown 渲染」）过滤。改为按预设 id 对应的 registry 名过滤，并兼容 `action` 前缀；抽出 `filterPluginAuditLogs` 并补单测。

2. **投稿规则展开后底部大片空白**  
   Drawer/Dialog 内容区 `flex-1` + Footer 默认 `mt-auto`，在 vaul 按 `max-h` 测量时会把中间撑满。改为内容高度自适应（`max-h` + overflow），Footer 取消 `mt-auto`。

3. **墙面设置 LLM/OAuth 展开后整页可滚**  
   管理页 `Tabs` 补上 `overflow-hidden`，滚动限制在 `TabsContent` 内部。

4. **弹层失焦后出现半透明幽灵横线**  
   Chromium 在窗口失焦 + 鼠标扫过非客户区时，`backdrop-filter` 合成层重绘不完整。Dialog/Drawer/Sheet 的 Overlay 去掉 `backdrop-blur`，仅保留半透明黑底。曾尝试「失焦时再关 blur」仍可复现，故彻底移除。

### Server

5. **审核群引用通过时经常找不到稿件**  
   `tryResolveDisplayIdFromReply`：`get_msg` 无 `sender` 时被误拒；无 reply 段时错误回退到当前消息 ID。改为仅在 sender 明确非本 bot 时拒绝，去掉错误回退，放宽编号解析（`！6724` 等混排）；`#通过` 失败提示更明确。

6. **简写拒绝会改写理由里的标点**  
   `@bot 拒绝 内容违规。请处理 6724` 曾被存成「内容违规 请处理」。抽出 `parseReviewGroupShortCommand`：只去掉 CQ at 并识别命令词（长词优先），args 保留原文。

7. **单条发布 fanout 闸门用错变量**  
   `enqueuePublishFanout` 锁内判定 skip 后，仍用外层预查询 `targets` 继续调度，可能重复入队。改为以锁内事务返回值为唯一闸门。

8. **锁释放后才创建 attempt，可双入队**  
   attempt 创建挪进同一 `lockPublishFanout` 事务（与批量路径一致），提交后再 `enqueueUnique`。

## Verification

- `bun --cwd apps/web typecheck` / `bun --cwd apps/server typecheck` 通过  
- 相关单测：插件日志过滤、审核引用解析、简写命令、fanout 接线等（`bun test` 通过）  
- 本地 SQLite + Playwright：投稿规则弹层间距约 20px、无底部空白；插件「当前插件」可显示 registry 名日志  
- 弹层幽灵线：按「开弹窗 → 切窗口 → 鼠标扫非客户区」手工复现路径验证，去掉 blur 后不再出现  

## Notes

- 8 个 commit 均为 Conventional Commits（`fix(web)` / `fix(server)`）  
- 作者：应急食品 `<2671016745@qq.com>`

## Sourcery 总结

修复审核流程、发布并发、管理页面布局、插件日志筛选及弹层渲染异常。

错误修复：
- 修复审核群引用消息解析、审核简写命令参数保留及稿件编号识别，提升通过和拒绝操作的可靠性。
- 修复单条发布 fanout 并发下的重复入队问题，确保发布尝试在锁事务内创建并仅在提交后入队。
- 修复插件当前日志筛选、投稿规则弹层底部空白及管理页面内容滚动问题。
- 移除 Dialog、Drawer 和 Sheet 遮罩的背景模糊，避免 Chromium 窗口失焦时出现幽灵横线。

测试：
- 补充审核命令、引用解析、插件日志筛选及发布 fanout 事务时序测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

提升审核与发布流程的并发可靠性，并修复管理界面布局、日志筛选和弹层渲染异常。

Bug Fixes:
- 修复审核群引用解析和简写命令处理，提升稿件编号识别可靠性并保留拒绝理由原文。
- 修复发布 fanout 并发下的重复入队风险，确保发布尝试与状态更新在锁事务内完成并在提交后调度。
- 修复插件当前日志筛选、投稿规则弹层底部空白、管理页面滚动范围及 Chromium 失焦时弹层幽灵横线问题。

Tests:
- 补充审核命令与引用解析、插件日志筛选及发布 fanout 事务时序测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

提升审核与发布流程的并发可靠性，并修复管理界面布局、日志筛选和弹层渲染异常。

Bug Fixes:
- 修复审核群引用解析和简写命令处理，提升稿件编号识别可靠性并保留拒绝理由原文。
- 修复发布 fanout 并发下的重复入队风险，确保发布尝试与状态更新在锁事务内完成并在提交后调度。
- 修复插件当前日志筛选、投稿规则弹层底部空白、管理页面滚动范围及 Chromium 失焦时弹层幽灵横线问题。

Tests:
- 补充审核命令与引用解析、插件日志筛选及发布 fanout 事务时序测试。

</details>

<details>
<summary>Original summary in English</summary>



</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Review-group shortcuts now support additional command formats and punctuation.
  - Reply-based review resolution better handles missing senders and extracts manuscript numbers more reliably.
  - Plugin audit logs now filter correctly by registry identity, including legacy entries.

- **Bug Fixes**
  - Publish fanout attempts are created atomically during publishing and requeueing.
  - Admin tab content is prevented from overflowing its container.

- **Style**
  - Removed backdrop blur from dialog, drawer, and sheet overlays.
  - Improved rules-panel sizing and drawer footer spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->